### PR TITLE
implement IntoIterator for SliceCache

### DIFF
--- a/src/iface/arp_cache.rs
+++ b/src/iface/arp_cache.rs
@@ -59,7 +59,6 @@ impl<'b, 'a: 'b> Iterator for SliceCacheIterator<'b, 'a> {
     type Item = &'b (IpAddress, EthernetAddress, usize);
 
     fn next(&mut self) -> Option<Self::Item> {
-        println!("{:?}", self.storage);
 
         while self.index < self.storage.len() {
             let cur_index = self.index;


### PR DESCRIPTION
I'd like to have the ability to dump the arp cache. One way to do this is to iterate over the cache, which is what this PR implement. If you are ok with this change, I'd like to add an `iter_arp_cache` method on `EthernetInterface`.

While implementing this, I noticed that the ARP cache could have entries with non unicast ip addresses (like `0.0.0.0`, `0.0.0.1` or `255.255.255.255`). Is this intentional? Shouldn't the insert fail when trying to insert such entries? If that's intentional, I'll  remove 26b78ae and make `SliceCacheIterator` work for these entries. Otherwise, I can work on a fix.

I also noticed that the `lru` counter was not incremented on insert. I took the liberty to add this but I can revert if that was intentional.