### PR TITLE
Use smart pointers in SocketSet's API

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -12,8 +12,7 @@ use std::os::unix::io::AsRawFd;
 use smoltcp::phy::wait as phy_wait;
 use smoltcp::wire::{EthernetAddress, Ipv4Address, IpAddress, IpCidr};
 use smoltcp::iface::{ArpCache, SliceArpCache, EthernetInterface};
-use smoltcp::socket::{AsSocket, SocketSet};
-use smoltcp::socket::{TcpSocket, TcpSocketBuffer};
+use smoltcp::socket::{SocketSet, TcpSocket, TcpSocketBuffer};
 
 fn main() {
     utils::setup_logging("");
@@ -50,14 +49,14 @@ fn main() {
     let tcp_handle = sockets.add(tcp_socket);
 
     {
-        let socket: &mut TcpSocket = sockets.get_mut(tcp_handle).as_socket();
+        let mut socket = sockets.get::<TcpSocket>(tcp_handle);
         socket.connect((address, port), 49500).unwrap();
     }
 
     let mut tcp_active = false;
     loop {
         {
-            let socket: &mut TcpSocket = sockets.get_mut(tcp_handle).as_socket();
+            let mut socket = sockets.get::<TcpSocket>(tcp_handle);
             if socket.is_active() && !tcp_active {
                 debug!("connected");
             } else if !socket.is_active() && tcp_active {

--- a/examples/loopback.rs
+++ b/examples/loopback.rs
@@ -19,8 +19,7 @@ use core::str;
 use smoltcp::phy::Loopback;
 use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr};
 use smoltcp::iface::{ArpCache, SliceArpCache, EthernetInterface};
-use smoltcp::socket::{AsSocket, SocketSet};
-use smoltcp::socket::{TcpSocket, TcpSocketBuffer};
+use smoltcp::socket::{SocketSet, TcpSocket, TcpSocketBuffer};
 
 #[cfg(not(feature = "std"))]
 mod mock {
@@ -124,7 +123,7 @@ fn main() {
     let mut done = false;
     while !done && clock.elapsed() < 10_000 {
         {
-            let socket: &mut TcpSocket = socket_set.get_mut(server_handle).as_socket();
+            let mut socket = socket_set.get::<TcpSocket>(server_handle);
             if !socket.is_active() && !socket.is_listening() {
                 if !did_listen {
                     debug!("listening");
@@ -141,7 +140,7 @@ fn main() {
         }
 
         {
-            let socket: &mut TcpSocket = socket_set.get_mut(client_handle).as_socket();
+            let mut socket = socket_set.get::<TcpSocket>(client_handle);
             if !socket.is_open() {
                 if !did_connect {
                     debug!("connecting");

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -16,8 +16,7 @@ use smoltcp::wire::{EthernetAddress, IpVersion, IpProtocol, IpAddress, IpCidr,
                     Ipv4Address, Ipv4Packet, Ipv4Repr,
                     Icmpv4Repr, Icmpv4Packet};
 use smoltcp::iface::{ArpCache, SliceArpCache, EthernetInterface};
-use smoltcp::socket::{AsSocket, SocketSet};
-use smoltcp::socket::{RawSocket, RawSocketBuffer, RawPacketBuffer};
+use smoltcp::socket::{SocketSet, RawSocket, RawSocketBuffer, RawPacketBuffer};
 use std::collections::HashMap;
 use byteorder::{ByteOrder, NetworkEndian};
 
@@ -75,7 +74,7 @@ fn main() {
 
     loop {
         {
-            let socket: &mut RawSocket = sockets.get_mut(raw_handle).as_socket();
+            let mut socket = sockets.get::<RawSocket>(raw_handle);
 
             let timestamp = Instant::now().duration_since(startup_time);
             let timestamp_us = (timestamp.as_secs() * 1000000) +

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -13,7 +13,7 @@ use std::os::unix::io::AsRawFd;
 use smoltcp::phy::wait as phy_wait;
 use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr};
 use smoltcp::iface::{ArpCache, SliceArpCache, EthernetInterface};
-use smoltcp::socket::{AsSocket, SocketSet};
+use smoltcp::socket::SocketSet;
 use smoltcp::socket::{UdpSocket, UdpSocketBuffer, UdpPacketBuffer};
 use smoltcp::socket::{TcpSocket, TcpSocketBuffer};
 
@@ -70,7 +70,7 @@ fn main() {
     loop {
         // udp:6969: respond "hello"
         {
-            let socket: &mut UdpSocket = sockets.get_mut(udp_handle).as_socket();
+            let mut socket = sockets.get::<UdpSocket>(udp_handle);
             if !socket.is_open() {
                 socket.bind(6969).unwrap()
             }
@@ -93,7 +93,7 @@ fn main() {
 
         // tcp:6969: respond "hello"
         {
-            let socket: &mut TcpSocket = sockets.get_mut(tcp1_handle).as_socket();
+            let mut socket = sockets.get::<TcpSocket>(tcp1_handle);
             if !socket.is_open() {
                 socket.listen(6969).unwrap();
             }
@@ -108,7 +108,7 @@ fn main() {
 
         // tcp:6970: echo with reverse
         {
-            let socket: &mut TcpSocket = sockets.get_mut(tcp2_handle).as_socket();
+            let mut socket = sockets.get::<TcpSocket>(tcp2_handle);
             if !socket.is_open() {
                 socket.listen(6970).unwrap()
             }
@@ -145,7 +145,7 @@ fn main() {
 
         // tcp:6971: sinkhole
         {
-            let socket: &mut TcpSocket = sockets.get_mut(tcp3_handle).as_socket();
+            let mut socket = sockets.get::<TcpSocket>(tcp3_handle);
             if !socket.is_open() {
                 socket.listen(6971).unwrap();
                 socket.set_keep_alive(Some(1000));
@@ -165,7 +165,7 @@ fn main() {
 
         // tcp:6972: fountain
         {
-            let socket: &mut TcpSocket = sockets.get_mut(tcp4_handle).as_socket();
+            let mut socket = sockets.get::<TcpSocket>(tcp4_handle);
             if !socket.is_open() {
                 socket.listen(6972).unwrap()
             }

--- a/src/iface/ethernet.rs
+++ b/src/iface/ethernet.rs
@@ -13,7 +13,7 @@ use wire::{Ipv4Packet, Ipv4Repr};
 use wire::{Icmpv4Packet, Icmpv4Repr, Icmpv4DstUnreachable};
 #[cfg(feature = "socket-udp")] use wire::{UdpPacket, UdpRepr};
 #[cfg(feature = "socket-tcp")] use wire::{TcpPacket, TcpRepr, TcpControl};
-use socket::{Socket, SocketSet, AsSocket};
+use socket::{Socket, SocketSet, FromSocket};
 #[cfg(feature = "socket-raw")] use socket::RawSocket;
 #[cfg(feature = "socket-udp")] use socket::UdpSocket;
 #[cfg(feature = "socket-tcp")] use socket::TcpSocket;
@@ -184,29 +184,29 @@ impl<'a, 'b, 'c, DeviceT: Device + 'a> Interface<'a, 'b, 'c, DeviceT> {
         let mut caps = self.device.capabilities();
         caps.max_transmission_unit -= EthernetFrame::<&[u8]>::header_len();
 
-        for socket in sockets.iter_mut() {
+        for mut socket in sockets.iter_mut() {
             let mut device_result = Ok(());
             let socket_result =
-                match socket {
+                match *socket {
                     #[cfg(feature = "socket-raw")]
-                    &mut Socket::Raw(ref mut socket) =>
+                    Socket::Raw(ref mut socket) =>
                         socket.dispatch(|response| {
                             device_result = self.dispatch(timestamp, Packet::Raw(response));
                             device_result
                         }, &caps.checksum),
                     #[cfg(feature = "socket-udp")]
-                    &mut Socket::Udp(ref mut socket) =>
+                    Socket::Udp(ref mut socket) =>
                         socket.dispatch(|response| {
                             device_result = self.dispatch(timestamp, Packet::Udp(response));
                             device_result
                         }),
                     #[cfg(feature = "socket-tcp")]
-                    &mut Socket::Tcp(ref mut socket) =>
+                    Socket::Tcp(ref mut socket) =>
                         socket.dispatch(timestamp, &caps, |response| {
                             device_result = self.dispatch(timestamp, Packet::Tcp(response));
                             device_result
                         }),
-                    &mut Socket::__Nonexhaustive(_) => unreachable!()
+                    Socket::__Nonexhaustive(_) => unreachable!()
                 };
             match (device_result, socket_result) {
                 (Err(Error::Unaddressable), _) => break, // no one to transmit to
@@ -312,8 +312,7 @@ impl<'a, 'b, 'c, DeviceT: Device + 'a> Interface<'a, 'b, 'c, DeviceT> {
 
         // Pass every IP packet to all raw sockets we have registered.
         #[cfg(feature = "socket-raw")]
-        for raw_socket in sockets.iter_mut().filter_map(
-                <Socket as AsSocket<RawSocket>>::try_as_socket) {
+        for mut raw_socket in sockets.iter_mut().filter_map(RawSocket::from_socket_ref) {
             if !raw_socket.accepts(&ip_repr) { continue }
 
             match raw_socket.process(&ip_repr, ip_payload, &checksum_caps) {
@@ -404,8 +403,7 @@ impl<'a, 'b, 'c, DeviceT: Device + 'a> Interface<'a, 'b, 'c, DeviceT> {
         let checksum_caps = self.device.capabilities().checksum;
         let udp_repr = UdpRepr::parse(&udp_packet, &src_addr, &dst_addr, &checksum_caps)?;
 
-        for udp_socket in sockets.iter_mut().filter_map(
-                <Socket as AsSocket<UdpSocket>>::try_as_socket) {
+        for mut udp_socket in sockets.iter_mut().filter_map(UdpSocket::from_socket_ref) {
             if !udp_socket.accepts(&ip_repr, &udp_repr) { continue }
 
             match udp_socket.process(&ip_repr, &udp_repr) {
@@ -447,8 +445,7 @@ impl<'a, 'b, 'c, DeviceT: Device + 'a> Interface<'a, 'b, 'c, DeviceT> {
         let checksum_caps = self.device.capabilities().checksum;
         let tcp_repr = TcpRepr::parse(&tcp_packet, &src_addr, &dst_addr, &checksum_caps)?;
 
-        for tcp_socket in sockets.iter_mut().filter_map(
-                <Socket as AsSocket<TcpSocket>>::try_as_socket) {
+        for mut tcp_socket in sockets.iter_mut().filter_map(TcpSocket::from_socket_ref) {
             if !tcp_socket.accepts(&ip_repr, &tcp_repr) { continue }
 
             match tcp_socket.process(timestamp, &ip_repr, &tcp_repr) {

--- a/src/socket/socket_ref.rs
+++ b/src/socket/socket_ref.rs
@@ -1,0 +1,95 @@
+use core::ops::{Deref, DerefMut};
+use socket::{FromSocket, Socket, SocketHandle};
+#[cfg(feature = "socket-raw")]
+use socket::RawSocket;
+#[cfg(feature = "socket-udp")]
+use socket::UdpSocket;
+#[cfg(feature = "socket-tcp")]
+use socket::TcpSocket;
+
+/// A trait for tracking a socket usage sessions.
+///
+/// Allows implementation of custom on-drop logic.
+pub trait Session {
+    fn finish(&mut self) {}
+}
+
+#[cfg(feature = "socket-raw")]
+impl<'a, 'b> Session for RawSocket<'a, 'b> {}
+#[cfg(feature = "socket-udp")]
+impl<'a, 'b> Session for UdpSocket<'a, 'b> {}
+#[cfg(feature = "socket-tcp")]
+impl<'a> Session for TcpSocket<'a> {}
+
+impl<'a, 'b> Session for Socket<'a, 'b> {
+    fn finish(&mut self) {
+        match *self {
+            #[cfg(feature = "socket-raw")]
+            Socket::Raw(ref mut raw_socket) => {
+                raw_socket.finish();
+            }
+            #[cfg(feature = "socket-udp")]
+            Socket::Udp(ref mut udp_socket) => {
+                udp_socket.finish();
+            }
+            #[cfg(feature = "socket-tcp")]
+            Socket::Tcp(ref mut tcp_socket) => {
+                tcp_socket.finish();
+            }
+            Socket::__Nonexhaustive(_) => unreachable!(),
+        }
+    }
+}
+
+/// A tracking smart-pointer to a socket.
+///
+/// Implements `Deref` and `DerefMut` to the socket it contains.
+pub struct Ref<'a, T: Session + 'a> {
+    socket: &'a mut T,
+    handle: SocketHandle,
+    fused: bool,
+}
+
+impl<'a, T: Session> Ref<'a, T> {
+    pub(crate) fn new(socket: &'a mut T, handle: SocketHandle) -> Self {
+        Ref {
+            socket,
+            handle,
+            fused: true,
+        }
+    }
+}
+
+impl<'a, 'b, 'c, T: FromSocket<'b, 'c>> Ref<'a, T> {
+    pub(crate) fn from_socket_ref(mut socket_ref: Ref<'a, Socket<'b, 'c>>)
+                                  -> Option<Ref<'a, T>> {
+        if let Some(socket) = T::downcast_socket(socket_ref.socket) {
+            socket_ref.fused = false;
+            Some(Ref::new(socket, socket_ref.handle))
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a, T: Session> Deref for Ref<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.socket
+    }
+}
+
+impl<'a, T: Session> DerefMut for Ref<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.socket
+    }
+}
+
+impl<'a, T: Session> Drop for Ref<'a, T> {
+    fn drop(&mut self) {
+        if self.fused {
+            Session::finish(self.socket);
+        }
+    }
+}


### PR DESCRIPTION
**Problem**: Currently `SocketSet` return sockets as `&mut Socket` which makes impossible to automatically track state changes, which, in turn, makes implementing packet dispatch problematic.

**Solution**: Implement `SocketRef` smart reference, which automatically calls bookkeeping code at the end of a usage session. Change `SocketSet` to return `SocketRef` instead of `&mut Socket`.

**Changes introduced by this pull request**:
- the `SocketRef` struct has been added;
- the `SocketSession` trait for socket type-specific usage session cleanup has been added;
- `SocketSet` returns `SocketRef` instead of `&mut Socket`;
- the `AsSocket`trait has been refactored into `FromSocket`;

**Other**: Currently `SocketRef` holds only socket's handle and `&mut *Socket`, and all `SocketSession::finish` implementations are empty. 

This PR is a part of #19 effort.