### PR TITLE
Uncomment associated constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ include complicated compile-time computations, such as macro or type tricks, eve
 at cost of performance degradation.
 
 _smoltcp_ does not need heap allocation *at all*, is [extensively documented][docs],
-and compiles on stable Rust 1.19 and later.
+and compiles on stable Rust 1.20 and later.
 
 [docs]: https://docs.rs/smoltcp/
 

--- a/src/iface/ethernet.rs
+++ b/src/iface/ethernet.rs
@@ -517,7 +517,7 @@ impl<'a, 'b, 'c, DeviceT: Device + 'a> Interface<'a, 'b, 'c, DeviceT> {
         }
 
         if dst_addr.is_broadcast() {
-            return Ok(EthernetAddress([0xff; 6]))
+            return Ok(EthernetAddress::BROADCAST)
         }
 
         match (src_addr, dst_addr) {
@@ -529,12 +529,12 @@ impl<'a, 'b, 'c, DeviceT: Device + 'a> Interface<'a, 'b, 'c, DeviceT> {
                     operation: ArpOperation::Request,
                     source_hardware_addr: self.hardware_addr,
                     source_protocol_addr: src_addr,
-                    target_hardware_addr: EthernetAddress([0xff; 6]),
+                    target_hardware_addr: EthernetAddress::BROADCAST,
                     target_protocol_addr: dst_addr,
                 };
 
                 self.dispatch_ethernet(timestamp, arp_repr.buffer_len(), |mut frame| {
-                    frame.set_dst_addr(EthernetAddress([0xff; 6]));
+                    frame.set_dst_addr(EthernetAddress::BROADCAST);
                     frame.set_ethertype(EthernetProtocol::Arp);
 
                     arp_repr.emit(&mut ArpPacket::new(frame.payload_mut()))

--- a/src/wire/ethernet.rs
+++ b/src/wire/ethernet.rs
@@ -28,7 +28,7 @@ impl fmt::Display for EtherType {
 pub struct Address(pub [u8; 6]);
 
 impl Address {
-    // pub const BROADCAST: Address = Address([0xff; 6]);
+    pub const BROADCAST: Address = Address([0xff; 6]);
 
     /// Construct an Ethernet address from a sequence of octets, in big-endian.
     ///
@@ -53,7 +53,7 @@ impl Address {
 
     /// Query whether this address is the broadcast address.
     pub fn is_broadcast(&self) -> bool {
-        self.0 == [0xff; 6]
+        *self == Self::BROADCAST
     }
 
     /// Query whether the "multicast" bit in the OUI is set.
@@ -269,5 +269,13 @@ mod test {
         frame.set_ethertype(EtherType::Ipv4);
         frame.payload_mut().copy_from_slice(&PAYLOAD_BYTES[..]);
         assert_eq!(&frame.into_inner()[..], &FRAME_BYTES[..]);
+    }
+
+    #[test]
+    fn test_broadcast() {
+        assert!(Address::BROADCAST.is_broadcast());
+        assert!(!Address::BROADCAST.is_unicast());
+        assert!(Address::BROADCAST.is_multicast());
+        assert!(Address::BROADCAST.is_local());
     }
 }

--- a/src/wire/ip.rs
+++ b/src/wire/ip.rs
@@ -99,8 +99,7 @@ impl Address {
     pub fn to_unspecified(&self) -> Address {
         match self {
             &Address::Unspecified => Address::Unspecified,
-            // &Address::Ipv4 => Address::Ipv4(Ipv4Address::UNSPECIFIED),
-            &Address::Ipv4(_) => Address::Ipv4(Ipv4Address(/*FIXME*/[0x00; 4])),
+            &Address::Ipv4(_) => Address::Ipv4(Ipv4Address::UNSPECIFIED),
         }
     }
 }
@@ -136,7 +135,7 @@ pub struct Endpoint {
 }
 
 impl Endpoint {
-    // pub const UNSPECIFIED: Endpoint = Endpoint { addr: Address::Unspecified, port: 0 };
+    pub const UNSPECIFIED: Endpoint = Endpoint { addr: Address::Unspecified, port: 0 };
 
     /// Create an endpoint address from given address and port.
     pub fn new(addr: Address, port: u16) -> Endpoint {
@@ -476,7 +475,7 @@ mod test {
 
         assert_eq!(
             IpRepr::Ipv4(Ipv4Repr{
-                src_addr: Ipv4Address::new(0, 0, 0, 0),
+                src_addr: Ipv4Address::UNSPECIFIED,
                 dst_addr: ip_addr_b,
                 protocol: proto,
                 payload_len
@@ -486,7 +485,7 @@ mod test {
 
         assert_eq!(
             IpRepr::Ipv4(Ipv4Repr{
-                src_addr: Ipv4Address::new(0, 0, 0, 0),
+                src_addr: Ipv4Address::UNSPECIFIED,
                 dst_addr: ip_addr_b,
                 protocol: proto,
                 payload_len
@@ -498,5 +497,10 @@ mod test {
                 payload_len
             }))
         );
+    }
+
+    #[test]
+    fn endpoint_unspecified() {
+        assert!(!Endpoint::UNSPECIFIED.is_specified());
     }
 }

--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -12,8 +12,8 @@ pub use super::IpProtocol as Protocol;
 pub struct Address(pub [u8; 4]);
 
 impl Address {
-    // pub const UNSPECIFIED: Address = Address([0x00; 4]);
-    // pub const BROADCAST:   Address = Address([0xff; 4]);
+    pub const UNSPECIFIED: Address = Address([0x00; 4]);
+    pub const BROADCAST:   Address = Address([0xff; 4]);
 
     /// Construct an IPv4 address from parts.
     pub fn new(a0: u8, a1: u8, a2: u8, a3: u8) -> Address {
@@ -667,5 +667,23 @@ mod test {
         repr.emit(&mut packet);
         packet.payload_mut().copy_from_slice(&REPR_PAYLOAD_BYTES);
         assert_eq!(&packet.into_inner()[..], &REPR_PACKET_BYTES[..]);
+    }
+
+    #[test]
+    fn test_unspecified() {
+        assert!(Address::UNSPECIFIED.is_unspecified());
+        assert!(!Address::UNSPECIFIED.is_broadcast());
+        assert!(!Address::UNSPECIFIED.is_multicast());
+        assert!(!Address::UNSPECIFIED.is_link_local());
+        assert!(!Address::UNSPECIFIED.is_loopback());
+    }
+
+    #[test]
+    fn test_broadcast() {
+        assert!(!Address::BROADCAST.is_unspecified());
+        assert!(Address::BROADCAST.is_broadcast());
+        assert!(!Address::BROADCAST.is_multicast());
+        assert!(!Address::BROADCAST.is_link_local());
+        assert!(!Address::BROADCAST.is_loopback());
     }
 }


### PR DESCRIPTION
Associated constants were stabilized in 1.20: https://blog.rust-lang.org/2017/08/31/Rust-1.20.html .