### PR TITLE
Fix ICMP Destination Unreachable packet causing panic

### DIFF
--- a/src/iface/ethernet.rs
+++ b/src/iface/ethernet.rs
@@ -377,9 +377,8 @@ impl<'a, 'b, 'c, DeviceT: Device + 'a> Interface<'a, 'b, 'c, DeviceT> {
             // Ignore any echo replies.
             Icmpv4Repr::EchoReply { .. } => Ok(Packet::None),
 			
-			// if dst unreachable just print a message
-			// TODO: maybe we should do something smarter?
-			Icmpv4Repr::DstUnreachable { .. } => Ok(Packet::None),
+	    // Ignore the destination unreachable reply
+	    Icmpv4Repr::DstUnreachable { .. } => Ok(Packet::None),
 			
             // FIXME: do something correct here?
             _ => Err(Error::Unrecognized),


### PR DESCRIPTION
If an `Icmpv4Repr::DstUnreachable` was received it resulted into `panic!`. This PR fixes that.