### PR TITLE
Move device-specific parts of `EthernetInterface` to new `EthernetDevice` type

### DIFF
--- a/src/iface/mod.rs
+++ b/src/iface/mod.rs
@@ -8,4 +8,4 @@ mod ethernet;
 
 pub use self::arp_cache::Cache as ArpCache;
 pub use self::arp_cache::SliceCache as SliceArpCache;
-pub use self::ethernet::Interface as EthernetInterface;
+pub use self::ethernet::{EthernetDevice, Interface as EthernetInterface, Packet as EthernetPacket};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,11 +106,11 @@ pub enum Error {
     Exhausted,
     /// An operation is not permitted in the current state.
     Illegal,
+    /// There was no an Ethernet address corresponding to an IPv4 address in the ARP cache.
+    UnknownEthernetAddress(wire::IpAddress),
     /// An endpoint or address of a remote host could not be translated to a lower level address.
-    /// E.g. there was no an Ethernet address corresponding to an IPv4 address in the ARP cache,
-    /// or a TCP connection attempt was made to an unspecified endpoint.
+    /// E.g. a TCP connection attempt was made to an unspecified endpoint.
     Unaddressable,
-
     /// An incoming packet could not be parsed because some of its fields were out of bounds
     /// of the received data.
     Truncated,
@@ -141,6 +141,7 @@ impl fmt::Display for Error {
         match self {
             &Error::Exhausted     => write!(f, "buffer space exhausted"),
             &Error::Illegal       => write!(f, "illegal operation"),
+            &Error::UnknownEthernetAddress(ip) => write!(f, "unknown ethernet address for ip {}", ip),
             &Error::Unaddressable => write!(f, "unaddressable destination"),
             &Error::Truncated     => write!(f, "truncated packet"),
             &Error::Checksum      => write!(f, "checksum error"),

--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -173,7 +173,7 @@ impl Checksum {
 }
 
 /// A description of checksum behavior for every supported protocol.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct ChecksumCapabilities {
     pub ipv4: Checksum,
     pub udpv4: Checksum,


### PR DESCRIPTION
Also:
- add a `write_into_buffer` and a `Packet::required_buffer_size` method
- the device specific buffer allocation is moved to a `EthernetDevice::dispatch` method
- instead of allocating the buffer on demand, it is passed when calling the `write_into_buffer` method
- `lookup_hardware_addr` no longer sends ARP request packets. Instead it returns a new `UnknownEthernetAddress` error, which is caught by the `EthernetDevice::dispatch` method, which in turn sends an ARP request.
- make `Packet` and `process_frame` (named `process_ethernet` before) public
- make `ChecksumCapabilities` Copy (I see no reason why it shouldn't be Copy)
- some renamings and documentation updates to adapt to the changes

The goal is to make `EthernetInterface` independent from the underlying device and allow one to use it without implementing the `phy::Device` trait. Feedback appreciated!

TODO:

- [ ] Add getters/setters for device capabilities on `EthernetInterface`

cc @oli-obk