### PR TITLE
Implement set_ttl for Tcp and Udp sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ The only supported medium is Ethernet.
 The only supported internetworking protocol is IPv4.
 
   * IPv4 header checksum is generated and validated.
-  * IPv4 time-to-live value is fixed at 64.
   * IPv4 fragmentation is **not** supported.
   * IPv4 options are **not** supported and are silently ignored.
   * IPv4 routes or default gateways are **not** supported.

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -94,6 +94,7 @@ fn main() {
                     dst_addr: remote_addr,
                     protocol: IpProtocol::Icmp,
                     payload_len: icmp_repr.buffer_len(),
+                    ttl: 64
                 };
 
                 let raw_payload = socket

--- a/src/iface/ethernet.rs
+++ b/src/iface/ethernet.rs
@@ -367,7 +367,8 @@ impl<'a, 'b, 'c, DeviceT: Device + 'a> Interface<'a, 'b, 'c, DeviceT> {
                     src_addr:    ipv4_repr.dst_addr,
                     dst_addr:    ipv4_repr.src_addr,
                     protocol:    IpProtocol::Icmp,
-                    payload_len: icmp_reply_repr.buffer_len()
+                    payload_len: icmp_reply_repr.buffer_len(),
+                    ttl:         64,
                 };
                 Ok(Packet::Icmpv4(ipv4_reply_repr, icmp_reply_repr))
             }
@@ -392,7 +393,8 @@ impl<'a, 'b, 'c, DeviceT: Device + 'a> Interface<'a, 'b, 'c, DeviceT> {
                     src_addr:    ipv4_repr.dst_addr,
                     dst_addr:    ipv4_repr.src_addr,
                     protocol:    IpProtocol::Icmp,
-                    payload_len: icmp_reply_repr.buffer_len()
+                    payload_len: icmp_reply_repr.buffer_len(),
+                    ttl:         64
                 };
                 Ok(Packet::Icmpv4(ipv4_reply_repr, icmp_reply_repr))
             }
@@ -437,7 +439,8 @@ impl<'a, 'b, 'c, DeviceT: Device + 'a> Interface<'a, 'b, 'c, DeviceT> {
                     src_addr:    ipv4_repr.dst_addr,
                     dst_addr:    ipv4_repr.src_addr,
                     protocol:    IpProtocol::Icmp,
-                    payload_len: icmpv4_reply_repr.buffer_len()
+                    payload_len: icmpv4_reply_repr.buffer_len(),
+                    ttl:         64,
                 };
                 Ok(Packet::Icmpv4(ipv4_reply_repr, icmpv4_reply_repr))
             },

--- a/src/socket/raw.rs
+++ b/src/socket/raw.rs
@@ -270,7 +270,8 @@ mod test {
         src_addr: Ipv4Address([10, 0, 0, 1]),
         dst_addr: Ipv4Address([10, 0, 0, 2]),
         protocol: IpProtocol::Unknown(IP_PROTO),
-        payload_len: 4
+        payload_len: 4,
+        ttl: 64
     });
     const PACKET_BYTES: [u8; 24] = [
         0x45, 0x00, 0x00, 0x18,

--- a/src/wire/icmpv4.rs
+++ b/src/wire/icmpv4.rs
@@ -423,6 +423,7 @@ impl<'a> Repr<'a> {
                         dst_addr: ip_packet.dst_addr(),
                         protocol: ip_packet.protocol(),
                         payload_len: payload.len(),
+                        ttl:      ip_packet.ttl()
                     },
                     data: payload
                 })

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -52,7 +52,8 @@ let repr = Ipv4Repr {
     src_addr:    Ipv4Address::new(10, 0, 0, 1),
     dst_addr:    Ipv4Address::new(10, 0, 0, 2),
     protocol:    IpProtocol::Tcp,
-    payload_len: 10
+    payload_len: 10,
+    ttl:         64
 };
 let mut buffer = vec![0; repr.buffer_len() + repr.payload_len];
 { // emission


### PR DESCRIPTION
 - Add the `ttl` member to the `IpRepr`
 - Add the `ttl` member along with setters and getters to the tcp and udp
   socket types
 - Add unit tests for the new `set_ttl` parameter
 - Update usage of `IpRepr` to include the `ttl` value

Resolves: #58 