### PR TITLE
Tests: Add basic interface tests

### DIFF
--- a/src/wire/arp.rs
+++ b/src/wire/arp.rs
@@ -21,7 +21,7 @@ enum_with_unknown! {
 }
 
 /// A read/write wrapper around an Address Resolution Protocol packet buffer.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Packet<T: AsRef<[u8]>> {
     buffer: T
 }

--- a/src/wire/icmpv4.rs
+++ b/src/wire/icmpv4.rs
@@ -166,7 +166,7 @@ enum_with_unknown! {
 }
 
 /// A read/write wrapper around an Internet Control Message Protocol version 4 packet buffer.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Packet<T: AsRef<[u8]>> {
     buffer: T
 }

--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -129,7 +129,7 @@ impl fmt::Display for Cidr {
 }
 
 /// A read/write wrapper around an Internet Protocol version 4 packet buffer.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Packet<T: AsRef<[u8]>> {
     buffer: T
 }

--- a/src/wire/tcp.rs
+++ b/src/wire/tcp.rs
@@ -62,7 +62,7 @@ impl cmp::PartialOrd for SeqNumber {
 }
 
 /// A read/write wrapper around a Transmission Control Protocol packet buffer.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Packet<T: AsRef<[u8]>> {
     buffer: T
 }

--- a/src/wire/udp.rs
+++ b/src/wire/udp.rs
@@ -7,7 +7,7 @@ use super::{IpProtocol, IpAddress};
 use super::ip::checksum;
 
 /// A read/write wrapper around an User Datagram Protocol packet buffer.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Packet<T: AsRef<[u8]>> {
     buffer: T
 }


### PR DESCRIPTION
Was looking at how the `EthernetInterface` worked and wrote some basic unit tests. Feel free to close this if you feel these tests aren't that useful.

 - Add tests for the following
   - ICMP error responses are not sent in response to broadcast requests (this
     isn't super relevant now, but this ensures we don't cause broadcast storms
     once we consume broadcast packets).
   - ARP requests are responded to and inserted into the cache
   - ARP requests for someone else are not responded to, but the sender
     is still inserted in the cache