### PR TITLE
Store plain DeviceT instead of Managed<_> in EthernetInterface

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -42,7 +42,7 @@ fn main() {
     let ip_addrs = [IpCidr::new(IpAddress::v4(192, 168, 69, 2), 24)];
     let default_v4_gw = Ipv4Address::new(192, 168, 69, 100);
     let mut iface = EthernetInterface::new(
-        Box::new(device), Box::new(arp_cache) as Box<ArpCache>,
+        device, Box::new(arp_cache) as Box<ArpCache>,
         ethernet_addr, ip_addrs, Some(default_v4_gw));
 
     let mut sockets = SocketSet::new(vec![]);

--- a/examples/loopback.rs
+++ b/examples/loopback.rs
@@ -69,10 +69,10 @@ mod mock {
 
 fn main() {
     let clock = mock::Clock::new();
-    let mut device = Loopback::new();
+    let device = Loopback::new();
 
     #[cfg(feature = "std")]
-    let mut device = {
+    let device = {
         let clock = clock.clone();
         utils::setup_logging_with_clock("", move || clock.elapsed());
 
@@ -90,7 +90,7 @@ fn main() {
 
     let mut ip_addrs = [IpCidr::new(IpAddress::v4(127, 0, 0, 1), 8)];
     let mut iface = EthernetInterface::new(
-        &mut device, &mut arp_cache as &mut ArpCache,
+        device, &mut arp_cache as &mut ArpCache,
         EthernetAddress::default(), &mut ip_addrs[..], None);
 
     let server_socket = {

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -60,7 +60,7 @@ fn main() {
     let ip_addr = IpCidr::new(IpAddress::from(local_addr), 24);
     let default_v4_gw = Ipv4Address::new(192, 168, 69, 100);
     let mut iface = EthernetInterface::new(
-        Box::new(device), Box::new(arp_cache) as Box<ArpCache>,
+        device, Box::new(arp_cache) as Box<ArpCache>,
         ethernet_addr, [ip_addr], Some(default_v4_gw));
 
     let mut sockets = SocketSet::new(vec![]);

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -56,7 +56,7 @@ fn main() {
     let ethernet_addr = EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]);
     let ip_addrs = [IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24)];
     let mut iface = EthernetInterface::new(
-        Box::new(device), Box::new(arp_cache) as Box<ArpCache>,
+        device, Box::new(arp_cache) as Box<ArpCache>,
         ethernet_addr, ip_addrs, None);
 
     let mut sockets = SocketSet::new(vec![]);


### PR DESCRIPTION
This avoids unnecessary boxing of the device and simplifies the code. However, it does no longer allow EthernetInterfaces with a borrowed device.