### PR TITLE
Don't end ICMP packet processing with ICMP sockets. Ignore `Error::Unaddressable` for ICMP sockets.

### DIFF
--- a/src/iface/ethernet.rs
+++ b/src/iface/ethernet.rs
@@ -227,11 +227,13 @@ impl<'b, 'c, DeviceT> Interface<'b, 'c, DeviceT>
                     Socket::Icmp(ref mut socket) =>
                         socket.dispatch(&caps, |response| {
                             let tx_token = device.transmit().ok_or(Error::Exhausted)?;
-                            match response {
-                                (IpRepr::Ipv4(repr), icmp_repr) =>
-                                    inner.dispatch(tx_token, timestamp, Packet::Icmpv4((repr, icmp_repr))),
+                            device_result = match response {
+                                (IpRepr::Ipv4(ipv4_repr), icmpv4_repr) =>
+                                    inner.dispatch(tx_token, timestamp,
+                                                   Packet::Icmpv4((ipv4_repr, icmpv4_repr))),
                                 _ => Err(Error::Unaddressable),
-                            }
+                            };
+                            device_result
                         }),
                     #[cfg(feature = "socket-udp")]
                     Socket::Udp(ref mut socket) =>


### PR DESCRIPTION
**Context:** I'm using ICMP sockets to implement `ping` in Redox.

**Problem:** Echo Requests to localhost fail because they are processed by the same ICMP socket which sent them in the first place, and `smoltcp` doesn't get a chance to respond to them with Echo Replies. The same problem could arise if another host sends Echo Request with an `ident` value we have an ICMP socket bound to.

**Solution:** Copy the raw sockets approach, whereby we dispatch a packet to all ICMP sockets and then let `smoltcp` handle it as well. Keep a flag to indicate whether a packet of unknown type has been processed by at least one ICMP socket, return `Error::Unrecognized` otherwise.