### PR TITLE
Make socket errors in `socket_egress` non-critical.

### DIFF
--- a/src/iface/ethernet.rs
+++ b/src/iface/ethernet.rs
@@ -252,10 +252,13 @@ impl<'b, 'c, DeviceT> Interface<'b, 'c, DeviceT>
             match (device_result, socket_result) {
                 (Err(Error::Unaddressable), _) => break, // no one to transmit to
                 (Err(Error::Exhausted), _) => break,     // nowhere to transmit
-                (Ok(()), Err(Error::Exhausted)) => (),   // nothing to transmit
-                (Err(err), _) | (_, Err(err)) => {
-                    net_debug!("cannot dispatch egress packet: {}", err);
+                (Err(err), _) => {
+                    net_debug!("cannot dispatch egress packet, device error: {}", err);
                     return Err(err)
+                }
+                (Ok(()), Err(Error::Exhausted)) => (),   // nothing to transmit
+                (Ok(()), Err(err)) => {
+                    net_debug!("cannot dispatch egress packet, socket error: {}", err);
                 }
                 (Ok(()), Ok(())) => ()
             }


### PR DESCRIPTION
**Problem:** Right now a socket error in `EthernetInterface::socket_egress` results in both `socket_egress` and `poll` returning early, which prevents `socket_egress` from processing other sockets and `poll` from processing ingress packets. For example, if a socket tries to send a packet to an unresolved host, `inner.dispatch` returns `Error::Unaddressable`, which shortcuts `socket_egress` and `poll`, which prevents ingress sockets from being processed, and host's MAC from being resolved, while the socket exists.

**Solution**: Make socket errors non-critical, a socket error shouldn't affect other sockets or ingress packet processing. 

**Other:** I'm not sure if this is the best solution, but the problem is real, specifically the situation described above.