### PR TITLE
Remove debug println in test_evict

### DIFF
--- a/src/iface/neighbor.rs
+++ b/src/iface/neighbor.rs
@@ -219,9 +219,7 @@ mod test {
         assert_eq!(cache.lookup_pure(&PADDR_B, 1000), Some(HADDR_B));
         assert_eq!(cache.lookup_pure(&PADDR_D, 1000), None);
 
-        println!("{:?}", cache);
         cache.fill(PADDR_D, HADDR_D, 300);
-        println!("{:?}", cache);
         assert_eq!(cache.lookup_pure(&PADDR_B, 1000), None);
         assert_eq!(cache.lookup_pure(&PADDR_D, 1000), Some(HADDR_D));
     }


### PR DESCRIPTION
The println's surrounding the final cache fill in test_evict that causes
PADDR_B to be evicted do not appear to be needed.