### PR TITLE
Add bench tests

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,107 @@
+#![feature(test)]
+
+extern crate test;
+extern crate smoltcp;
+
+mod wire {
+    use test;
+    #[cfg(feature = "proto-ipv6")]
+    use smoltcp::wire::{Ipv6Address, Ipv6Repr, Ipv6Packet};
+    #[cfg(feature = "proto-ipv4")]
+    use smoltcp::wire::{Ipv4Address, Ipv4Repr, Ipv4Packet};
+    use smoltcp::phy::{ChecksumCapabilities};
+    use smoltcp::wire::{IpAddress, IpProtocol};
+    use smoltcp::wire::{TcpRepr, TcpPacket, TcpSeqNumber, TcpControl};
+    use smoltcp::wire::{UdpRepr, UdpPacket};
+
+    #[cfg(feature = "proto-ipv6")]
+    const SRC_ADDR: IpAddress = IpAddress::Ipv6(Ipv6Address([0xfe, 0x80, 0, 0, 0, 0, 0, 0,
+                                                             0, 0, 0, 0, 0, 0, 0, 1]));
+    #[cfg(feature = "proto-ipv6")]
+    const DST_ADDR: IpAddress = IpAddress::Ipv6(Ipv6Address([0xfe, 0x80, 0, 0, 0, 0, 0, 0,
+                                                             0, 0, 0, 0, 0, 0, 0, 2]));
+
+    #[cfg(all(not(feature = "proto-ipv6"), feature = "proto-ipv4"))]
+    const SRC_ADDR: IpAddress = IpAddress::Ipv4(Ipv4Address([192, 168, 1, 1]));
+    #[cfg(all(not(feature = "proto-ipv6"), feature = "proto-ipv4"))]
+    const DST_ADDR: IpAddress = IpAddress::Ipv4(Ipv4Address([192, 168, 1, 2]));
+
+    #[bench]
+    #[cfg(any(feature = "proto-ipv6", feature = "proto-ipv4"))]
+    fn bench_emit_tcp(b: &mut test::Bencher) {
+        static PAYLOAD_BYTES: [u8; 400] =
+            [0x2a; 400];
+        let repr = TcpRepr {
+            src_port:     48896,
+            dst_port:     80,
+            seq_number:   TcpSeqNumber(0x01234567),
+            ack_number:   None,
+            window_len:   0x0123,
+            control:      TcpControl::Syn,
+            max_seg_size: None,
+            payload:      &PAYLOAD_BYTES
+        };
+        let mut bytes = vec![0xa5; repr.buffer_len()];
+
+        b.iter(|| {
+            let mut packet = TcpPacket::new(&mut bytes);
+            repr.emit(&mut packet, &SRC_ADDR, &DST_ADDR, &ChecksumCapabilities::default());
+        });
+    }
+
+    #[bench]
+    #[cfg(any(feature = "proto-ipv6", feature = "proto-ipv4"))]
+    fn bench_emit_udp(b: &mut test::Bencher) {
+        static PAYLOAD_BYTES: [u8; 400] =
+            [0x2a; 400];
+        let repr = UdpRepr {
+            src_port: 48896,
+            dst_port: 80,
+            payload:  &PAYLOAD_BYTES
+        };
+        let mut bytes = vec![0xa5; repr.buffer_len()];
+
+        b.iter(|| {
+            let mut packet = UdpPacket::new(&mut bytes);
+            repr.emit(&mut packet, &SRC_ADDR, &DST_ADDR, &ChecksumCapabilities::default());
+        });
+    }
+
+    #[bench]
+    #[cfg(feature = "proto-ipv4")]
+    fn bench_emit_ipv4(b: &mut test::Bencher) {
+        let repr = Ipv4Repr {
+            src_addr:    Ipv4Address([192, 168, 1, 1]),
+            dst_addr:    Ipv4Address([192, 168, 1, 2]),
+            protocol:    IpProtocol::Tcp,
+            payload_len: 100,
+            hop_limit:   64
+        };
+        let mut bytes = vec![0xa5; repr.buffer_len()];
+
+        b.iter(|| {
+            let mut packet = Ipv4Packet::new(&mut bytes);
+            repr.emit(&mut packet, &ChecksumCapabilities::default());
+        });
+    }
+
+    #[bench]
+    #[cfg(feature = "proto-ipv6")]
+    fn bench_emit_ipv6(b: &mut test::Bencher) {
+        let repr = Ipv6Repr {
+            src_addr:    Ipv6Address([0xfe, 0x80, 0, 0, 0, 0, 0, 0,
+                                      0, 0, 0, 0, 0, 0, 0, 1]),
+            dst_addr:    Ipv6Address([0xfe, 0x80, 0, 0, 0, 0, 0, 0,
+                                      0, 0, 0, 0, 0, 0, 0, 2]),
+            next_header: IpProtocol::Tcp,
+            payload_len: 100,
+            hop_limit:   64
+        };
+        let mut bytes = vec![0xa5; repr.buffer_len()];
+
+        b.iter(|| {
+            let mut packet = Ipv6Packet::new(&mut bytes);
+            repr.emit(&mut packet);
+        });
+    }
+}


### PR DESCRIPTION
 - Add basic infrastructure for `cargo bench` tests
 - Add bench tests for
   - `TcpRepr::emit`
   - `UdpRepr::emit`
   - `Ipv4Repr::emit`
   - `Ipv6Repr::emit`

I got excited about 56ddb0c206bff68dbbd1e7e97bfadee7988f79b1 and 275eb90785a26ed1bd942f087c2d81647dc58f84 and I realized we should probably have `cargo bench` tests for stuff like `emit`.

56ddb0c206bff68dbbd1e7e97bfadee7988f79b1

``` 
running 4 tests
test wire::bench_emit_ipv4 ... bench:          40 ns/iter (+/- 0)
test wire::bench_emit_ipv6 ... bench:          27 ns/iter (+/- 0)
test wire::bench_emit_tcp  ... bench:         142 ns/iter (+/- 0)
test wire::bench_emit_udp  ... bench:         134 ns/iter (+/- 0)
```

ba1d5ed576caaf7e99e066d38771ff27882678e6

```
running 4 tests
test wire::bench_emit_ipv4 ... bench:          46 ns/iter (+/- 0)
test wire::bench_emit_ipv6 ... bench:          27 ns/iter (+/- 0)
test wire::bench_emit_tcp  ... bench:         263 ns/iter (+/- 1)
test wire::bench_emit_udp  ... bench:         252 ns/iter (+/- 0)
```