### PR TITLE
Add process_ipv6 to EthernetInterface

### DIFF
--- a/src/iface/neighbor.rs
+++ b/src/iface/neighbor.rs
@@ -168,7 +168,6 @@ mod test {
     const HADDR_D: EthernetAddress = EthernetAddress([0, 0, 0, 0, 0, 4]);
 
     #[test]
-    #[cfg(feature = "proto-ipv4")]
     fn test_fill() {
         let mut cache_storage = [Default::default(); 3];
         let mut cache = Cache::new(&mut cache_storage[..]);
@@ -186,7 +185,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "proto-ipv4")]
     fn test_expire() {
         let mut cache_storage = [Default::default(); 3];
         let mut cache = Cache::new(&mut cache_storage[..]);
@@ -197,7 +195,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "proto-ipv4")]
     fn test_replace() {
         let mut cache_storage = [Default::default(); 3];
         let mut cache = Cache::new(&mut cache_storage[..]);
@@ -209,7 +206,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "proto-ipv4")]
     fn test_evict() {
         let mut cache_storage = [Default::default(); 3];
         let mut cache = Cache::new(&mut cache_storage[..]);
@@ -226,7 +222,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "proto-ipv4")]
     fn test_hush() {
         let mut cache_storage = [Default::default(); 3];
         let mut cache = Cache::new(&mut cache_storage[..]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,7 @@
 #![cfg_attr(feature = "alloc", feature(alloc))]
 #![no_std]
 #![deny(unsafe_code)]
-// TODO: Change this to enable deny(unused) if IPv6 or IPv4 are enabled
-#![cfg_attr(feature = "proto-ipv4", deny(unused))]
+#![cfg_attr(any(feature = "proto-ipv4", feature = "proto-ipv6"), deny(unused))]
 
 //! The _smoltcp_ library is built in a layered structure, with the layers corresponding
 //! to the levels of API abstraction. Only the highest layers would be used by a typical

--- a/src/wire/ip.rs
+++ b/src/wire/ip.rs
@@ -605,13 +605,13 @@ impl Repr {
     ///
     /// # Panics
     /// This function panics if invoked on an unspecified representation.
-    pub fn emit<T: AsRef<[u8]> + AsMut<[u8]>>(&self, buffer: T, checksum_caps: &ChecksumCapabilities) {
+    pub fn emit<T: AsRef<[u8]> + AsMut<[u8]>>(&self, buffer: T, _checksum_caps: &ChecksumCapabilities) {
         match self {
             &Repr::Unspecified { .. } =>
                 panic!("unspecified IP representation"),
             #[cfg(feature = "proto-ipv4")]
             &Repr::Ipv4(repr) =>
-                repr.emit(&mut Ipv4Packet::new(buffer), &checksum_caps),
+                repr.emit(&mut Ipv4Packet::new(buffer), &_checksum_caps),
             #[cfg(feature = "proto-ipv6")]
             &Repr::Ipv6(repr) =>
                 repr.emit(&mut Ipv6Packet::new(buffer)),
@@ -727,12 +727,14 @@ pub mod checksum {
     }
 }
 
-use super::pretty_print::{PrettyPrint, PrettyIndent};
+use super::pretty_print::PrettyIndent;
 
 pub fn pretty_print_ip_payload<T: Into<Repr>>(f: &mut fmt::Formatter, indent: &mut PrettyIndent,
                                               ip_repr: T, payload: &[u8]) -> fmt::Result {
     #[cfg(feature = "proto-ipv4")]
     use wire::Icmpv4Packet;
+    #[cfg(feature = "proto-ipv4")]
+    use super::pretty_print::PrettyPrint;
     use wire::{TcpPacket, TcpRepr, UdpPacket, UdpRepr};
     use wire::ip::checksum::format_checksum;
 


### PR DESCRIPTION
 - Add `process_ipv6` to `EthernetInterface`
 - Add basic test for `process_ipv6`
 - Add `deny(unused)` if either proto-ipv4 or proto-ipv6 is enabled
 - Add `cfg`s where needed to avoid compile time errors due to the above