### PR TITLE
Add `Hash` trait on `IpAddress/IpCidr`

### DIFF
--- a/src/wire/ip.rs
+++ b/src/wire/ip.rs
@@ -9,7 +9,7 @@ use super::{Ipv4Address, Ipv4Packet, Ipv4Repr, Ipv4Cidr};
 use super::{Ipv6Address, Ipv6Cidr, Ipv6Packet, Ipv6Repr};
 
 /// Internet protocol version.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub enum Version {
     Unspecified,
     #[cfg(feature = "proto-ipv4")]
@@ -82,7 +82,7 @@ impl fmt::Display for Protocol {
 }
 
 /// An internetworking address.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub enum Address {
     /// An unspecified address.
     /// May be used as a placeholder for storage where the address is not assigned yet.
@@ -195,7 +195,7 @@ impl fmt::Display for Address {
 
 /// A specification of a CIDR block, containing an address and a variable-length
 /// subnet masking prefix length.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub enum Cidr {
     #[cfg(feature = "proto-ipv4")]
     Ipv4(Ipv4Cidr),
@@ -304,7 +304,7 @@ impl fmt::Display for Cidr {
 /// An internet endpoint address.
 ///
 /// An endpoint can be constructed from a port, in which case the address is unspecified.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default)]
+#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default)]
 pub struct Endpoint {
     pub addr: Address,
     pub port: u16

--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -22,7 +22,7 @@ pub use super::IpProtocol as Protocol;
 pub const MIN_MTU: usize = 576;
 
 /// A four-octet IPv4 address.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default)]
+#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default)]
 pub struct Address(pub [u8; 4]);
 
 impl Address {
@@ -94,7 +94,7 @@ impl fmt::Display for Address {
 
 /// A specification of an IPv4 CIDR block, containing an address and a variable-length
 /// subnet masking prefix length.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default)]
 pub struct Cidr {
     address:    Address,
     prefix_len: u8,

--- a/src/wire/ipv6.rs
+++ b/src/wire/ipv6.rs
@@ -13,7 +13,7 @@ use super::ip::pretty_print_ip_payload;
 pub const MIN_MTU: usize = 1280;
 
 /// A sixteen-octet IPv6 address.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default)]
+#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default)]
 pub struct Address(pub [u8; 16]);
 
 impl Address {
@@ -237,7 +237,7 @@ impl From<::wire::ipv4::Address> for Address {
 
 /// A specification of an IPv6 CIDR block, containing an address and a variable-length
 /// subnet masking prefix length.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default)]
 pub struct Cidr {
     address:    Address,
     prefix_len: u8,


### PR DESCRIPTION
Add `Hash` trait on:

*    `wire::IpVersion` 
*    `wire::IpEndpoint`
*    `wire::IpAddress`
*    `wire::IpCidr` 
*    `wire::Ipv4Address` 
*    `wire::Ipv6Address` 
*    `wire::Ipv4Cidr` 
*    `wire::Ipv6Cidr`