### PR TITLE
Relax type constraints on payload_mut methods

### DIFF
--- a/src/wire/ethernet.rs
+++ b/src/wire/ethernet.rs
@@ -187,9 +187,7 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Frame<T> {
         let data = self.buffer.as_mut();
         NetworkEndian::write_u16(&mut data[field::ETHERTYPE], value.into())
     }
-}
 
-impl<'a, T: AsRef<[u8]> + AsMut<[u8]> + ?Sized> Frame<&'a mut T> {
     /// Return a mutable pointer to the payload.
     #[inline]
     pub fn payload_mut(&mut self) -> &mut [u8] {

--- a/src/wire/icmpv6.rs
+++ b/src/wire/icmpv6.rs
@@ -357,9 +357,7 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Packet<T> {
         };
         self.set_checksum(checksum)
     }
-}
 
-impl<'a, T: AsRef<[u8]> + AsMut<[u8]> + ?Sized> Packet<&'a mut T> {
     /// Return a mutable pointer to the type-specific data.
     #[inline]
     pub fn payload_mut(&mut self) -> &mut [u8] {

--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -524,9 +524,7 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Packet<T> {
         };
         self.set_checksum(checksum)
     }
-}
 
-impl<'a, T: AsRef<[u8]> + AsMut<[u8]> + ?Sized> Packet<&'a mut T> {
     /// Return a mutable pointer to the payload.
     #[inline]
     pub fn payload_mut(&mut self) -> &mut [u8] {

--- a/src/wire/ipv6.rs
+++ b/src/wire/ipv6.rs
@@ -538,9 +538,7 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Packet<T> {
         let data = self.buffer.as_mut();
         data[field::DST_ADDR].copy_from_slice(value.as_bytes());
     }
-}
 
-impl<'a, T: AsRef<[u8]> + AsMut<[u8]> + ?Sized> Packet<&'a mut T> {
     /// Return a mutable pointer to the payload.
     #[inline]
     pub fn payload_mut(&mut self) -> &mut [u8] {

--- a/src/wire/tcp.rs
+++ b/src/wire/tcp.rs
@@ -492,9 +492,7 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Packet<T> {
         };
         self.set_checksum(checksum)
     }
-}
 
-impl<'a, T: AsRef<[u8]> + AsMut<[u8]> + ?Sized> Packet<&'a mut T> {
     /// Return a pointer to the options.
     #[inline]
     pub fn options_mut(&mut self) -> &mut [u8] {

--- a/src/wire/udp.rs
+++ b/src/wire/udp.rs
@@ -180,9 +180,7 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Packet<T> {
         // so no action is necessary on the remote end.
         self.set_checksum(if checksum == 0 { 0xffff } else { checksum })
     }
-}
 
-impl<'a, T: AsRef<[u8]> + AsMut<[u8]> + ?Sized> Packet<&'a mut T> {
     /// Return a mutable pointer to the payload.
     #[inline]
     pub fn payload_mut(&mut self) -> &mut [u8] {


### PR DESCRIPTION
Currently, `payload_mut` methods on packet types require the underlying buffer to be a mutable reference `&mut T` where `T: AsMut<u8>`. This makes the methods unusable for types like `Ipv4Packet<Vec<u8>>` or `Ipv4Packet<BytesMut>`. We can simplify this to just work over packets with buffer type `T` for `T: AsMut<u8>`.

Note that removing the `?Sized` bound doesn't make these impls any less general since `&mut T` is still `Sized` even if `T` isn't.  eg. you can still use this with `Ipv4Packet<&mut [u8]>` and friends.