### PR TITLE
Add `PrettyPrinter::print` convenience method

### DIFF
--- a/src/wire/pretty_print.rs
+++ b/src/wire/pretty_print.rs
@@ -93,6 +93,17 @@ impl<'a, T: PrettyPrint> PrettyPrinter<'a, T> {
     }
 }
 
+impl<'a, T: PrettyPrint + AsRef<[u8]>> PrettyPrinter<'a, T> {
+    /// Create a `PrettyPrinter` which prints the given object.
+    pub fn print(printable: &'a T) -> PrettyPrinter<'a, T> {
+        PrettyPrinter {
+            prefix: "",
+            buffer: printable,
+            phantom: PhantomData,
+        }
+    }
+}
+
 impl<'a, T: PrettyPrint> fmt::Display for PrettyPrinter<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         T::pretty_print(&self.buffer, f, &mut PrettyIndent::new(self.prefix))


### PR DESCRIPTION
This is a much more convenient way of printing data during debugging because it saves me from having to reiterate the type of the packet. eg.

```rust
let frame = EthernetFrame::new(buffer);
trace!("{}", PrettyPrinter::print(&frame));
```

vs

```rust
let frame = EthernetFrame::new(buffer);
trace!("{}", PrettyPrinter::<EthernetFrame<&[u8]>>::new("", buffer));
```

The time saved quickly adds up when I'm trying to spray `trace` statements all over a piece of broken code.

Alternatively, or in addition, it might be a good idea to make the `Debug` impls pretty print like this. That way I could simply write `trace!("{:?}", frame)`. Thoughts?
