### PR TITLE
Remove trailing whitespace

### DIFF
--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -892,7 +892,7 @@ mod test {
         let cidr_without_prefix = Cidr::new(cidr.address(), 0);
         assert!(cidr_without_prefix.contains_addr(&Address::new(127, 0, 0, 1)));
     }
-    
+
     #[test]
     fn test_cidr_from_netmask() {
         assert_eq!(Cidr::from_netmask(Address([0, 0, 0, 0]), Address([1, 0, 2, 0])).is_err(),
@@ -910,7 +910,7 @@ mod test {
         assert_eq!(Cidr::from_netmask(Address([255, 255, 255, 255]), Address([255, 255, 255, 255])).unwrap(),
                    Cidr::new(Address([255, 255, 255, 255]), 32));
     }
-    
+
     #[test]
     fn test_cidr_netmask() {
         assert_eq!(Cidr::new(Address([0, 0, 0, 0]), 0).netmask(),

--- a/src/wire/ipv6.rs
+++ b/src/wire/ipv6.rs
@@ -190,7 +190,7 @@ impl fmt::Display for Address {
         if self.is_ipv4_mapped() {
             return write!(f, "::ffff:{}.{}.{}.{}", self.0[12], self.0[13], self.0[14], self.0[15])
         }
-        
+
         // The string representation of an IPv6 address should
         // collapse a series of 16 bit sections that evaluate
         // to 0 to "::"


### PR DESCRIPTION
nit: remove some trailing whitespace.