### PR TITLE
Allow broadcast/multicast traffic to UDP sockets

### DIFF
--- a/src/iface/ethernet.rs
+++ b/src/iface/ethernet.rs
@@ -503,6 +503,7 @@ impl<'b, 'c> InterfaceInner<'b, 'c> {
 
         // Ignore any packets not directed to our hardware address.
         if !eth_frame.dst_addr().is_broadcast() &&
+           !eth_frame.dst_addr().is_multicast() &&
                 eth_frame.dst_addr() != self.ethernet_addr {
             return Ok(Packet::None)
         }
@@ -677,7 +678,9 @@ impl<'b, 'c> InterfaceInner<'b, 'c> {
         #[cfg(feature = "socket-raw")]
         let handled_by_raw_socket = self.raw_socket_filter(sockets, &ip_repr, ip_payload);
 
-        if !ipv4_repr.dst_addr.is_broadcast() && !self.has_ip_addr(ipv4_repr.dst_addr) {
+        if !ipv4_repr.dst_addr.is_broadcast() &&
+           !ipv4_repr.dst_addr.is_multicast() &&
+           !self.has_ip_addr(ipv4_repr.dst_addr) {
             // Ignore IP packets not directed at us.
             return Ok(Packet::None)
         }

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -164,7 +164,9 @@ impl<'a, 'b> UdpSocket<'a, 'b> {
     pub(crate) fn accepts(&self, ip_repr: &IpRepr, repr: &UdpRepr) -> bool {
         if self.endpoint.port != repr.dst_port { return false }
         if !self.endpoint.addr.is_unspecified() &&
-           self.endpoint.addr != ip_repr.dst_addr() { return false }
+            self.endpoint.addr != ip_repr.dst_addr() &&
+            !ip_repr.dst_addr().is_broadcast() &&
+            !ip_repr.dst_addr().is_multicast() { return false }
 
         true
     }


### PR DESCRIPTION
The path for broadcast seemed prepared, therefore adding multicast into it seemed logical.