### PR TITLE
Use core::time::Duration. Closes #182.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ include complicated compile-time computations, such as macro or type tricks, eve
 at cost of performance degradation.
 
 _smoltcp_ does not need heap allocation *at all*, is [extensively documented][docs],
-and compiles on stable Rust 1.20 and later.
+and compiles on stable Rust 1.25 and later.
 
 _smoltcp_ achieves [~Gbps of throughput](#examplesbenchmarkrs) when tested against
 the Linux TCP stack in loopback mode.

--- a/src/time.rs
+++ b/src/time.rs
@@ -230,19 +230,17 @@ impl ops::DivAssign<u32> for Duration {
     }
 }
 
-#[cfg(feature = "std")]
-impl From<::std::time::Duration> for Duration {
-    fn from(other: ::std::time::Duration) -> Duration {
+impl From<::core::time::Duration> for Duration {
+    fn from(other: ::core::time::Duration) -> Duration {
         Duration::from_millis(
             other.as_secs() * 1000 + (other.subsec_nanos() / 1_000_000) as u64
         )
     }
 }
 
-#[cfg(feature = "std")]
-impl Into<::std::time::Duration> for Duration {
-    fn into(self) -> ::std::time::Duration {
-        ::std::time::Duration::from_millis(
+impl Into<::core::time::Duration> for Duration {
+    fn into(self) -> ::core::time::Duration {
+        ::core::time::Duration::from_millis(
             self.total_millis()
         )
     }
@@ -331,14 +329,13 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "std")]
     fn test_duration_conversions() {
-        let mut std_duration = ::std::time::Duration::from_millis(4934);
+        let mut std_duration = ::core::time::Duration::from_millis(4934);
         let duration: Duration = std_duration.into();
         assert_eq!(duration, Duration::from_millis(4934));
         assert_eq!(Duration::from(std_duration), Duration::from_millis(4934));
 
         std_duration = duration.into();
-        assert_eq!(std_duration, ::std::time::Duration::from_millis(4934));
+        assert_eq!(std_duration, ::core::time::Duration::from_millis(4934));
     }
 }


### PR DESCRIPTION
Duration is now in core, so we can now include the conversions to/from that without requiring std. (#182).