### PR TITLE
NDISC: Improve the representation layer for NDISC

### DIFF
--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -186,6 +186,8 @@ pub use self::ndisc::Repr as NdiscRepr;
 pub use self::ndiscoption::{NdiscOption,
                             Repr as NdiscOptionRepr,
                             Type as NdiscOptionType,
+                            PrefixInformation as NdiscPrefixInformation,
+                            RedirectedHeader as NdiscRedirectedHeader,
                             PrefixInfoFlags as NdiscPrefixInfoFlags};
 
 pub use self::udp::{Packet as UdpPacket,

--- a/src/wire/ndiscoption.rs
+++ b/src/wire/ndiscoption.rs
@@ -391,23 +391,28 @@ impl<'a, T: AsRef<[u8]> + ?Sized> fmt::Display for NdiscOption<&'a T> {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct PrefixInformation {
+    pub prefix_len: u8,
+    pub flags: PrefixInfoFlags,
+    pub valid_lifetime: Duration,
+    pub preferred_lifetime: Duration,
+    pub prefix: Ipv6Address
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct RedirectedHeader<'a> {
+    pub header: Ipv6Repr,
+    pub data: &'a [u8]
+}
 
 /// A high-level representation of an NDISC Option.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Repr<'a> {
     SourceLinkLayerAddr(EthernetAddress),
     TargetLinkLayerAddr(EthernetAddress),
-    PrefixInformation {
-        prefix_len: u8,
-        flags: PrefixInfoFlags,
-        valid_lifetime: Duration,
-        preferred_lifetime: Duration,
-        prefix: Ipv6Address
-    },
-    RedirectedHeader {
-        header: Ipv6Repr,
-        data: &'a [u8]
-    },
+    PrefixInformation(PrefixInformation),
+    RedirectedHeader(RedirectedHeader<'a>),
     Mtu(u32),
     Unknown {
         type_:  u8,
@@ -437,13 +442,13 @@ impl<'a> Repr<'a> {
             },
             Type::PrefixInformation => {
                 if opt.data_len() == 4 {
-                    Ok(Repr::PrefixInformation {
+                    Ok(Repr::PrefixInformation(PrefixInformation {
                         prefix_len: opt.prefix_len(),
                         flags: opt.prefix_flags(),
                         valid_lifetime: opt.valid_lifetime(),
                         preferred_lifetime: opt.preferred_lifetime(),
                         prefix: opt.prefix()
-                    })
+                    }))
                 } else {
                     Err(Error::Malformed)
                 }
@@ -457,10 +462,10 @@ impl<'a> Repr<'a> {
                 } else {
                     let ip_packet = Ipv6Packet::new(&opt.data()[field::IP_DATA..]);
                     let ip_repr = Ipv6Repr::parse(&ip_packet)?;
-                    Ok(Repr::RedirectedHeader {
+                    Ok(Repr::RedirectedHeader(RedirectedHeader {
                         header: ip_repr,
                         data: &opt.data()[field::IP_DATA + ip_repr.buffer_len()..]
-                    })
+                    }))
                 }
             },
             Type::Mtu => {
@@ -485,9 +490,9 @@ impl<'a> Repr<'a> {
         match self {
             &Repr::SourceLinkLayerAddr(_) | &Repr::TargetLinkLayerAddr(_) =>
                 field::LL_ADDR.end,
-            &Repr::PrefixInformation { .. } =>
+            &Repr::PrefixInformation(_) =>
                 field::PREFIX.end,
-            &Repr::RedirectedHeader { header, data } =>
+            &Repr::RedirectedHeader(RedirectedHeader { header, data }) =>
                 field::IP_DATA + header.buffer_len() + data.len(),
             &Repr::Mtu(_) =>
                 field::MTU.end,
@@ -510,10 +515,10 @@ impl<'a> Repr<'a> {
                 opt.set_data_len(1);
                 opt.set_link_layer_addr(addr);
             },
-            &Repr::PrefixInformation {
+            &Repr::PrefixInformation(PrefixInformation {
                 prefix_len, flags, valid_lifetime,
                 preferred_lifetime, prefix
-            } => {
+            }) => {
                 opt.clear_prefix_reserved();
                 opt.set_option_type(Type::PrefixInformation);
                 opt.set_data_len(4);
@@ -523,9 +528,9 @@ impl<'a> Repr<'a> {
                 opt.set_preferred_lifetime(preferred_lifetime);
                 opt.set_prefix(prefix);
             },
-            &Repr::RedirectedHeader {
+            &Repr::RedirectedHeader(RedirectedHeader {
                 header, data
-            } => {
+            }) => {
                 let data_len = data.len() / 8;
                 opt.clear_redirected_reserved();
                 opt.set_option_type(Type::RedirectedHeader);
@@ -559,16 +564,16 @@ impl<'a> fmt::Display for Repr<'a> {
             &Repr::TargetLinkLayerAddr(addr) => {
                 write!(f, "TargetLinkLayer addr={}", addr)
             },
-            &Repr::PrefixInformation {
+            &Repr::PrefixInformation(PrefixInformation {
                 prefix, prefix_len,
                 ..
-            } => {
+            }) => {
                 write!(f, "PrefixInformation prefix={}/{}", prefix, prefix_len)
             },
-            &Repr::RedirectedHeader {
+            &Repr::RedirectedHeader(RedirectedHeader {
                 header,
                 ..
-            } => {
+            }) => {
                 write!(f, "RedirectedHeader header={}", header)
             },
             &Repr::Mtu(mtu) => {
@@ -605,7 +610,7 @@ mod test {
     use Error;
     use time::Duration;
     use wire::{EthernetAddress, Ipv6Address};
-    use super::{NdiscOption, Type, PrefixInfoFlags, Repr};
+    use super::{NdiscOption, Type, PrefixInfoFlags, PrefixInformation, Repr};
 
     static PREFIX_OPT_BYTES: [u8; 32] = [
         0x03, 0x04, 0x40, 0xc0,
@@ -671,26 +676,26 @@ mod test {
 
     #[test]
     fn test_repr_parse_prefix_info() {
-        let repr = Repr::PrefixInformation {
+        let repr = Repr::PrefixInformation(PrefixInformation {
             prefix_len: 64,
             flags: PrefixInfoFlags::ON_LINK | PrefixInfoFlags::ADDRCONF,
             valid_lifetime: Duration::from_secs(900),
             preferred_lifetime: Duration::from_secs(1000),
             prefix: Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)
-        };
+        });
         assert_eq!(Repr::parse(&NdiscOption::new(&PREFIX_OPT_BYTES)), Ok(repr));
     }
 
     #[test]
     fn test_repr_emit_prefix_info() {
         let mut bytes = [0x2a; 32];
-        let repr = Repr::PrefixInformation {
+        let repr = Repr::PrefixInformation(PrefixInformation {
             prefix_len: 64,
             flags: PrefixInfoFlags::ON_LINK | PrefixInfoFlags::ADDRCONF,
             valid_lifetime: Duration::from_secs(900),
             preferred_lifetime: Duration::from_secs(1000),
             prefix: Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)
-        };
+        });
         let mut opt = NdiscOption::new(&mut bytes);
         repr.emit(&mut opt);
         assert_eq!(&opt.into_inner()[..], &PREFIX_OPT_BYTES[..]);


### PR DESCRIPTION
Each given NDISC packet type may only include one of a few options.
Instead of including the options in the NDISC representation layer as a
simple `&[u8]` include the associated packet types available options as
`Option<T>` members, making the representation layer much more
usable.