### PR TITLE
Do not export phy::wait on non-Unix platforms

### DIFF
--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -87,7 +87,7 @@ impl<'a> phy::TxToken for StmPhyTxToken<'a> {
 use Result;
 use time::Instant;
 
-#[cfg(any(feature = "phy-raw_socket", feature = "phy-tap_interface"))]
+#[cfg(all(any(feature = "phy-raw_socket", feature = "phy-tap_interface"), unix))]
 mod sys;
 
 mod tracer;
@@ -100,7 +100,7 @@ mod raw_socket;
 #[cfg(all(feature = "phy-tap_interface", target_os = "linux"))]
 mod tap_interface;
 
-#[cfg(any(feature = "phy-raw_socket", feature = "phy-tap_interface"))]
+#[cfg(all(any(feature = "phy-raw_socket", feature = "phy-tap_interface"), unix))]
 pub use self::sys::wait;
 
 pub use self::tracer::Tracer;


### PR DESCRIPTION
Necessary to use smoltcp on seL4 (and perhaps other platforms).

By @aisamanra