### PR TITLE
Add support for IPv6 gateway, and use it to make examples IPv6-capable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ required-features = ["std", "phy-raw_socket", "proto-ipv4"]
 
 [[example]]
 name = "httpclient"
-required-features = ["std", "phy-tap_interface", "proto-ipv4", "socket-tcp"]
+required-features = ["std", "phy-tap_interface", "proto-ipv4", "proto-ipv6", "socket-tcp"]
 
 [[example]]
 name = "ping"

--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ a specific user:
 sudo ip tuntap add name tap0 mode tap user $USER
 sudo ip link set tap0 up
 sudo ip addr add 192.168.69.100/24 dev tap0
+sudo ip -6 addr add fe80::100/64 dev tap0
+sudo ip -6 addr add fdaa::100/64 dev tap0
+sudo ip -6 route add fe80::/64 dev tap0
+sudo ip -6 route add fdaa::/64 dev tap0
 ```
 
 It's possible to let _smoltcp_ access Internet by enabling routing for the tap interface:
@@ -197,6 +201,8 @@ It's possible to let _smoltcp_ access Internet by enabling routing for the tap i
 ```sh
 sudo iptables -t nat -A POSTROUTING -s 192.168.69.0/24 -j MASQUERADE
 sudo sysctl net.ipv4.ip_forward=1
+sudo ip6tables -t nat -A POSTROUTING -s fdaa::/64 -j MASQUERADE
+sudo sysctl -w net.ipv6.conf.all.forwarding=1
 ```
 
 ### Fault injection
@@ -245,7 +251,7 @@ sudo ./target/debug/examples/tcpdump eth0
 
 _examples/httpclient.rs_ emulates a network host that can initiate HTTP requests.
 
-The host is assigned the hardware address `02-00-00-00-00-02` and IPv4 address `192.168.69.1`.
+The host is assigned the hardware address `02-00-00-00-00-02`, IPv4 address `192.168.69.1`, and IPv6 address `fdaa::1`.
 
 Read its [source code](/examples/httpclient.rs), then run it as:
 
@@ -257,6 +263,12 @@ For example:
 
 ```sh
 cargo run --example httpclient -- tap0 93.184.216.34 http://example.org/
+```
+
+or:
+
+```sh
+cargo run --example httpclient -- tap0 2606:2800:220:1:248:1893:25c8:1946 http://example.org/
 ```
 
 It connects to the given address (not a hostname) and URL, and prints any returned response data.

--- a/examples/httpclient.rs
+++ b/examples/httpclient.rs
@@ -13,7 +13,7 @@ use std::collections::BTreeMap;
 use std::os::unix::io::AsRawFd;
 use url::Url;
 use smoltcp::phy::wait as phy_wait;
-use smoltcp::wire::{EthernetAddress, Ipv4Address, IpAddress, IpCidr};
+use smoltcp::wire::{EthernetAddress, Ipv4Address, Ipv6Address, IpAddress, IpCidr};
 use smoltcp::iface::{NeighborCache, EthernetInterfaceBuilder};
 use smoltcp::socket::{SocketSet, TcpSocket, TcpSocketBuffer};
 use smoltcp::time::Instant;
@@ -42,13 +42,17 @@ fn main() {
     let tcp_socket = TcpSocket::new(tcp_rx_buffer, tcp_tx_buffer);
 
     let ethernet_addr = EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x02]);
-    let ip_addrs = [IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24)];
+    let ip_addrs = [IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24),
+                    IpCidr::new(IpAddress::v6(0xfdaa, 0, 0, 0, 0, 0, 0, 1), 64),
+                    IpCidr::new(IpAddress::v6(0xfe80, 0, 0, 0, 0, 0, 0, 1), 64)];
     let default_v4_gw = Ipv4Address::new(192, 168, 69, 100);
+    let default_v6_gw = Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 0x100);
     let mut iface = EthernetInterfaceBuilder::new(device)
             .ethernet_addr(ethernet_addr)
             .neighbor_cache(neighbor_cache)
             .ip_addrs(ip_addrs)
             .ipv4_gateway(default_v4_gw)
+            .ipv6_gateway(default_v6_gw)
             .finalize();
 
     let mut sockets = SocketSet::new(vec![]);

--- a/src/socket/icmp.rs
+++ b/src/socket/icmp.rs
@@ -341,7 +341,7 @@ impl<'a, 'b> IcmpSocket<'a, 'b> {
                     let ip_repr = IpRepr::Ipv6(Ipv6Repr {
                         src_addr:    src_addr,
                         dst_addr:    ipv6_addr,
-                        next_header: IpProtocol::Icmp,
+                        next_header: IpProtocol::Icmpv6,
                         payload_len: repr.buffer_len(),
                         hop_limit:   hop_limit,
                     });
@@ -609,7 +609,7 @@ mod test_ipv6 {
     static LOCAL_IPV6_REPR: IpRepr = IpRepr::Ipv6(Ipv6Repr {
         src_addr: Ipv6Address::UNSPECIFIED,
         dst_addr: REMOTE_IPV6,
-        next_header: IpProtocol::Icmp,
+        next_header: IpProtocol::Icmpv6,
         payload_len: 24,
         hop_limit: 0x40
     });
@@ -617,7 +617,7 @@ mod test_ipv6 {
     static REMOTE_IPV6_REPR: IpRepr = IpRepr::Ipv6(Ipv6Repr {
         src_addr: REMOTE_IPV6,
         dst_addr: LOCAL_IPV6,
-        next_header: IpProtocol::Icmp,
+        next_header: IpProtocol::Icmpv6,
         payload_len: 24,
         hop_limit: 0x40
     });
@@ -683,7 +683,7 @@ mod test_ipv6 {
             assert_eq!(ip_repr, IpRepr::Ipv6(Ipv6Repr {
                 src_addr: Ipv6Address::UNSPECIFIED,
                 dst_addr: REMOTE_IPV6,
-                next_header: IpProtocol::Icmp,
+                next_header: IpProtocol::Icmpv6,
                 payload_len: ECHOV6_REPR.buffer_len(),
                 hop_limit: 0x2a,
             }));
@@ -757,7 +757,7 @@ mod test_ipv6 {
             header: Ipv6Repr {
                 src_addr: LOCAL_IPV6,
                 dst_addr: REMOTE_IPV6,
-                next_header: IpProtocol::Icmp,
+                next_header: IpProtocol::Icmpv6,
                 payload_len: 12,
                 hop_limit: 0x40
             },
@@ -766,7 +766,7 @@ mod test_ipv6 {
         let ip_repr = IpRepr::Unspecified {
             src_addr: REMOTE_IPV6.into(),
             dst_addr: LOCAL_IPV6.into(),
-            protocol: IpProtocol::Icmp,
+            protocol: IpProtocol::Icmpv6,
             payload_len: icmp_repr.buffer_len(),
             hop_limit: 0x40
         };


### PR DESCRIPTION
Also contains a fix to #205 (`Protocol::Icmp` -> `Protocol::Icmpv6`).

Both examples were tested on my computer with both IP versions.

Instructions in the README should work, but they are a summary of a lot of trial-and-error to configure my computer so some command(s) might be missing.