### PR TITLE
Ignore unrecognized NDISC options (as per RFC 4861).

### DIFF
--- a/src/wire/ndisc.rs
+++ b/src/wire/ndisc.rs
@@ -228,7 +228,7 @@ impl<'a> Repr<'a> {
                     let opt = NdiscOption::new_checked(packet.payload())?;
                     match opt.option_type() {
                         NdiscOptionType::SourceLinkLayerAddr => Some(opt.link_layer_addr()),
-                        _ => { return Err(Error::Unrecognized); }
+                        _ => None,
                     }
                 } else {
                     None
@@ -245,7 +245,7 @@ impl<'a> Repr<'a> {
                         NdiscOptionRepr::SourceLinkLayerAddr(addr) => lladdr = Some(addr),
                         NdiscOptionRepr::Mtu(val) => mtu = Some(val),
                         NdiscOptionRepr::PrefixInformation(info) => prefix_info = Some(info),
-                        _ => { return Err(Error::Unrecognized); }
+                        _ => ()
                     }
                     offset += opt.buffer_len();
                 }
@@ -263,7 +263,7 @@ impl<'a> Repr<'a> {
                     let opt = NdiscOption::new_checked(packet.payload())?;
                     match opt.option_type() {
                         NdiscOptionType::SourceLinkLayerAddr => Some(opt.link_layer_addr()),
-                        _ => { return Err(Error::Unrecognized); }
+                        _ => None,
                     }
                 } else {
                     None
@@ -277,7 +277,7 @@ impl<'a> Repr<'a> {
                     let opt = NdiscOption::new_checked(packet.payload())?;
                     match opt.option_type() {
                         NdiscOptionType::TargetLinkLayerAddr => Some(opt.link_layer_addr()),
-                        _ => { return Err(Error::Unrecognized); }
+                        _ => None,
                     }
                 } else {
                     None
@@ -311,7 +311,7 @@ impl<'a> Repr<'a> {
                                 offset += 8 + ip_repr.buffer_len() + data.len();
                             }
                         }
-                        _ => { return Err(Error::Unrecognized); }
+                        _ => ()
                     }
                 }
                 Ok(Repr::Redirect {


### PR DESCRIPTION
https://tools.ietf.org/html/rfc4861#section-4

> Future versions of this protocol may define new option types.
> Receivers MUST silently ignore any options they do not recognize
> and continue processing the message.