### PR TITLE
Fix server example

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -55,8 +55,8 @@ fn main() {
     let ethernet_addr = EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]);
     let ip_addrs = [
         IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24),
-        IpCidr::new(IpAddress::v6(0xfdbe, 0x0000, 0x0000, 0x0000,
-                                  0x0000, 0x0000, 0x0000, 0x002a), 64)
+        IpCidr::new(IpAddress::v6(0xfdaa, 0, 0, 0, 0, 0, 0, 1), 64),
+        IpCidr::new(IpAddress::v6(0xfe80, 0, 0, 0, 0, 0, 0, 1), 64)
     ];
     let mut iface = EthernetInterfaceBuilder::new(device)
             .ethernet_addr(ethernet_addr)


### PR DESCRIPTION
Make the IPv6 address used in the server example the same as the IPv6
address used in the others.