### PR TITLE
Remove v4 from udp/tcp of ChecksumCapabilities

### DIFF
--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -157,8 +157,8 @@ impl Checksum {
 #[derive(Debug, Clone, Default)]
 pub struct ChecksumCapabilities {
     pub ipv4: Checksum,
-    pub udpv4: Checksum,
-    pub tcpv4: Checksum,
+    pub udp: Checksum,
+    pub tcp: Checksum,
     #[cfg(feature = "proto-ipv4")]
     pub icmpv4: Checksum,
     #[cfg(feature = "proto-ipv6")]
@@ -172,8 +172,8 @@ impl ChecksumCapabilities {
     pub fn ignored() -> Self {
         ChecksumCapabilities {
             ipv4: Checksum::None,
-            udpv4: Checksum::None,
-            tcpv4: Checksum::None,
+            udp: Checksum::None,
+            tcp: Checksum::None,
             #[cfg(feature = "proto-ipv4")]
             icmpv4: Checksum::None,
             #[cfg(feature = "proto-ipv6")]

--- a/src/wire/tcp.rs
+++ b/src/wire/tcp.rs
@@ -658,7 +658,7 @@ impl<'a> Repr<'a> {
         if packet.src_port() == 0 { return Err(Error::Malformed) }
         if packet.dst_port() == 0 { return Err(Error::Malformed) }
         // Valid checksum is expected.
-        if checksum_caps.tcpv4.rx() && !packet.verify_checksum(src_addr, dst_addr) {
+        if checksum_caps.tcp.rx() && !packet.verify_checksum(src_addr, dst_addr) {
             return Err(Error::Checksum)
         }
 
@@ -752,7 +752,7 @@ impl<'a> Repr<'a> {
         packet.set_urgent_at(0);
         packet.payload_mut().copy_from_slice(self.payload);
 
-        if checksum_caps.tcpv4.tx() {
+        if checksum_caps.tcp.tx() {
             packet.fill_checksum(src_addr, dst_addr)
         } else {
             // make sure we get a consistently zeroed checksum,

--- a/src/wire/udp.rs
+++ b/src/wire/udp.rs
@@ -212,7 +212,7 @@ impl<'a> Repr<'a> {
         // Destination port cannot be omitted (but source port can be).
         if packet.dst_port() == 0 { return Err(Error::Malformed) }
         // Valid checksum is expected...
-        if checksum_caps.udpv4.rx() && !packet.verify_checksum(src_addr, dst_addr) {
+        if checksum_caps.udp.rx() && !packet.verify_checksum(src_addr, dst_addr) {
             match (src_addr, dst_addr) {
                 #[cfg(feature = "proto-ipv4")]
                 (&IpAddress::Ipv4(_), &IpAddress::Ipv4(_))
@@ -249,7 +249,7 @@ impl<'a> Repr<'a> {
         packet.set_len((field::CHECKSUM.end + self.payload.len()) as u16);
         packet.payload_mut().copy_from_slice(self.payload);
 
-        if checksum_caps.udpv4.tx() {
+        if checksum_caps.udp.tx() {
             packet.fill_checksum(src_addr, dst_addr)
         } else {
             // make sure we get a consistently zeroed checksum,


### PR DESCRIPTION
The `tcpv4` and `udpv4` members are used for IPv6 and IPv4. Remove the `v4`.

Fixes: #213 