### PR TITLE
Fix MTU settings so fragmented packets can be received

### DIFF
--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -113,6 +113,10 @@ pub use self::raw_socket::RawSocket;
 #[cfg(all(feature = "phy-tap_interface", target_os = "linux"))]
 pub use self::tap_interface::TapInterface;
 
+/// Ethernet header length to be added to the MTU, since the header is not counted into MTU
+/// 6 bytes src addr, 6 bytes dst addr, 2 bytes EthType, (optional) 4 bytes IEEE 802.1Q Header
+pub const ETHERNET_HAEDER_MAX_LEN: usize = 18;
+
 /// A tracer device for Ethernet frames.
 pub type EthernetTracer<T> = Tracer<T, super::wire::EthernetFrame<&'static [u8]>>;
 

--- a/src/phy/raw_socket.rs
+++ b/src/phy/raw_socket.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::os::unix::io::{RawFd, AsRawFd};
 
 use Result;
-use phy::{self, sys, DeviceCapabilities, Device};
+use phy::{self, sys, DeviceCapabilities, Device, ETHERNET_HAEDER_MAX_LEN};
 use time::Instant;
 
 /// A socket that captures or transmits the complete frame.
@@ -32,7 +32,7 @@ impl RawSocket {
         let mtu = lower.interface_mtu()?;
         Ok(RawSocket {
             lower: Rc::new(RefCell::new(lower)),
-            mtu:   mtu
+            mtu:   mtu + ETHERNET_HAEDER_MAX_LEN
         })
     }
 }

--- a/src/phy/tap_interface.rs
+++ b/src/phy/tap_interface.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::os::unix::io::{RawFd, AsRawFd};
 
 use Result;
-use phy::{self, sys, DeviceCapabilities, Device};
+use phy::{self, sys, DeviceCapabilities, Device, ETHERNET_HAEDER_MAX_LEN};
 use time::Instant;
 
 /// A virtual Ethernet interface.
@@ -33,7 +33,7 @@ impl TapInterface {
         let mtu = lower.interface_mtu()?;
         Ok(TapInterface {
             lower: Rc::new(RefCell::new(lower)),
-            mtu:   mtu
+            mtu:   mtu + ETHERNET_HAEDER_MAX_LEN
         })
     }
 }


### PR DESCRIPTION
This is needed to get the fragmentation to work. In Linux MTU refers to the max length of the ethernet payload. But smoltcp counts MTU as max length of the ethernet frame. Hence without this added ethernet length, all fragmented packets are truncated. I am happy to fix is more meaningfully later, but without this fix the fragmentation reassembly doesn't work.