### PR TITLE
Rename `new` method on Packet types to `new_checked`

### DIFF
--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -35,7 +35,7 @@ macro_rules! send_icmp_ping {
             .send(icmp_repr.buffer_len(), $remote_addr)
             .unwrap();
 
-        let mut icmp_packet = $packet_type::new(icmp_payload);
+        let mut icmp_packet = $packet_type::new_unchecked(icmp_payload);
         (icmp_repr, icmp_packet)
     }}
 }
@@ -168,13 +168,14 @@ fn main() {
 
                 match remote_addr {
                     IpAddress::Ipv4(_) => {
-                        let icmp_packet = Icmpv4Packet::new(&payload);
-                        let icmp_repr = Icmpv4Repr::parse(&icmp_packet, &device_caps.checksum).unwrap();
+                        let icmp_packet = Icmpv4Packet::new_checked(&payload).unwrap();
+                        let icmp_repr =
+                            Icmpv4Repr::parse(&icmp_packet, &device_caps.checksum).unwrap();
                         get_icmp_pong!(Icmpv4Repr, icmp_repr, payload,
                                 waiting_queue, remote_addr, timestamp, received);
                     }
                     IpAddress::Ipv6(_) => {
-                        let icmp_packet = Icmpv6Packet::new(&payload);
+                        let icmp_packet = Icmpv6Packet::new_checked(&payload).unwrap();
                         let icmp_repr = Icmpv6Repr::parse(&remote_addr, &src_ipv6,
                                 &icmp_packet, &device_caps.checksum).unwrap();
                         get_icmp_pong!(Icmpv6Repr, icmp_repr, payload,

--- a/src/socket/icmp.rs
+++ b/src/socket/icmp.rs
@@ -256,7 +256,7 @@ impl<'a, 'b> IcmpSocket<'a, 'b> {
             #[cfg(feature = "proto-ipv4")]
             (&Endpoint::Udp(endpoint), &IcmpRepr::Ipv4(Icmpv4Repr::DstUnreachable { data, .. }))
                     if endpoint.addr.is_unspecified() || endpoint.addr == ip_repr.dst_addr() => {
-                let packet = UdpPacket::new(data);
+                let packet = UdpPacket::new_unchecked(data);
                 match UdpRepr::parse(&packet, &ip_repr.src_addr(), &ip_repr.dst_addr(), cksum) {
                     Ok(repr) => endpoint.port == repr.src_port,
                     Err(_) => false,
@@ -265,7 +265,7 @@ impl<'a, 'b> IcmpSocket<'a, 'b> {
             #[cfg(feature = "proto-ipv6")]
             (&Endpoint::Udp(endpoint), &IcmpRepr::Ipv6(Icmpv6Repr::DstUnreachable { data, .. }))
                     if endpoint.addr.is_unspecified() || endpoint.addr == ip_repr.dst_addr() => {
-                let packet = UdpPacket::new(data);
+                let packet = UdpPacket::new_unchecked(data);
                 match UdpRepr::parse(&packet, &ip_repr.src_addr(), &ip_repr.dst_addr(), cksum) {
                     Ok(repr) => endpoint.port == repr.src_port,
                     Err(_) => false,
@@ -275,12 +275,16 @@ impl<'a, 'b> IcmpSocket<'a, 'b> {
             // Echo Request/Reply with the identifier field matching the endpoint
             // port.
             #[cfg(feature = "proto-ipv4")]
-            (&Endpoint::Ident(bound_ident), &IcmpRepr::Ipv4(Icmpv4Repr::EchoRequest { ident, .. })) |
-            (&Endpoint::Ident(bound_ident), &IcmpRepr::Ipv4(Icmpv4Repr::EchoReply { ident, .. })) =>
+            (&Endpoint::Ident(bound_ident),
+             &IcmpRepr::Ipv4(Icmpv4Repr::EchoRequest { ident, .. })) |
+            (&Endpoint::Ident(bound_ident),
+             &IcmpRepr::Ipv4(Icmpv4Repr::EchoReply { ident, .. })) =>
                 ident == bound_ident,
             #[cfg(feature = "proto-ipv6")]
-            (&Endpoint::Ident(bound_ident), &IcmpRepr::Ipv6(Icmpv6Repr::EchoRequest { ident, .. })) |
-            (&Endpoint::Ident(bound_ident), &IcmpRepr::Ipv6(Icmpv6Repr::EchoReply { ident, .. })) =>
+            (&Endpoint::Ident(bound_ident),
+             &IcmpRepr::Ipv6(Icmpv6Repr::EchoRequest { ident, .. })) |
+            (&Endpoint::Ident(bound_ident),
+             &IcmpRepr::Ipv6(Icmpv6Repr::EchoReply { ident, .. })) =>
                 ident == bound_ident,
             _ => false,
         }
@@ -291,17 +295,21 @@ impl<'a, 'b> IcmpSocket<'a, 'b> {
         match icmp_repr {
             #[cfg(feature = "proto-ipv4")]
             &IcmpRepr::Ipv4(ref icmp_repr) => {
-                let packet_buf = self.rx_buffer.enqueue(icmp_repr.buffer_len(), ip_repr.src_addr())?;
-                icmp_repr.emit(&mut Icmpv4Packet::new(packet_buf), &ChecksumCapabilities::default());
+                let packet_buf = self.rx_buffer.enqueue(icmp_repr.buffer_len(),
+                                                        ip_repr.src_addr())?;
+                icmp_repr.emit(&mut Icmpv4Packet::new_unchecked(packet_buf),
+                               &ChecksumCapabilities::default());
 
                 net_trace!("{}:{}: receiving {} octets",
                            self.meta.handle, icmp_repr.buffer_len(), packet_buf.len());
             },
             #[cfg(feature = "proto-ipv6")]
             &IcmpRepr::Ipv6(ref icmp_repr) => {
-                let packet_buf = self.rx_buffer.enqueue(icmp_repr.buffer_len(), ip_repr.src_addr())?;
+                let packet_buf = self.rx_buffer.enqueue(icmp_repr.buffer_len(),
+                                                        ip_repr.src_addr())?;
                 icmp_repr.emit(&ip_repr.src_addr(), &ip_repr.dst_addr(),
-                               &mut Icmpv6Packet::new(packet_buf), &ChecksumCapabilities::default());
+                               &mut Icmpv6Packet::new_unchecked(packet_buf),
+                               &ChecksumCapabilities::default());
 
                 net_trace!("{}:{}: receiving {} octets",
                            self.meta.handle, icmp_repr.buffer_len(), packet_buf.len());
@@ -321,7 +329,7 @@ impl<'a, 'b> IcmpSocket<'a, 'b> {
             match *remote_endpoint {
                 #[cfg(feature = "proto-ipv4")]
                 IpAddress::Ipv4(ipv4_addr) => {
-                    let packet = Icmpv4Packet::new(&*packet_buf);
+                    let packet = Icmpv4Packet::new_unchecked(&*packet_buf);
                     let repr = Icmpv4Repr::parse(&packet, &ChecksumCapabilities::ignored())?;
                     let ip_repr = IpRepr::Ipv4(Ipv4Repr {
                         src_addr:    Ipv4Address::default(),
@@ -334,7 +342,7 @@ impl<'a, 'b> IcmpSocket<'a, 'b> {
                 },
                 #[cfg(feature = "proto-ipv6")]
                 IpAddress::Ipv6(ipv6_addr) => {
-                    let packet = Icmpv6Packet::new(&*packet_buf);
+                    let packet = Icmpv6Packet::new_unchecked(&*packet_buf);
                     let src_addr = Ipv6Address::default();
                     let repr = Icmpv6Repr::parse(&src_addr.into(), &ipv6_addr.into(), &packet, &ChecksumCapabilities::ignored())?;
                     let ip_repr = IpRepr::Ipv6(Ipv6Repr {
@@ -443,7 +451,7 @@ mod test_ipv4 {
         assert!(socket.can_send());
 
         let mut bytes = [0xff; 24];
-        let mut packet = Icmpv4Packet::new(&mut bytes);
+        let mut packet = Icmpv4Packet::new_unchecked(&mut bytes);
         ECHOV4_REPR.emit(&mut packet, &caps.checksum);
 
         assert_eq!(socket.send_slice(&packet.into_inner()[..], REMOTE_IPV4.into()), Ok(()));
@@ -473,7 +481,7 @@ mod test_ipv4 {
         let caps = DeviceCapabilities::default();
 
         let mut bytes = [0xff; 24];
-        let mut packet = Icmpv4Packet::new(&mut bytes);
+        let mut packet = Icmpv4Packet::new_unchecked(&mut bytes);
         ECHOV4_REPR.emit(&mut packet, &caps.checksum);
 
         s.set_hop_limit(Some(0x2a));
@@ -502,7 +510,7 @@ mod test_ipv4 {
         let caps = DeviceCapabilities::default();
 
         let mut bytes = [0xff; 24];
-        let mut packet = Icmpv4Packet::new(&mut bytes);
+        let mut packet = Icmpv4Packet::new_unchecked(&mut bytes);
         ECHOV4_REPR.emit(&mut packet, &caps.checksum);
         let data = &packet.into_inner()[..];
 
@@ -526,7 +534,7 @@ mod test_ipv4 {
 
         let caps = DeviceCapabilities::default();
         let mut bytes = [0xff; 20];
-        let mut packet = Icmpv4Packet::new(&mut bytes);
+        let mut packet = Icmpv4Packet::new_unchecked(&mut bytes);
         let icmp_repr = Icmpv4Repr::EchoRequest {
             ident:  0x4321,
             seq_no: 0x5678,
@@ -547,7 +555,7 @@ mod test_ipv4 {
         let caps = DeviceCapabilities::default();
 
         let mut bytes = [0xff; 18];
-        let mut packet = UdpPacket::new(&mut bytes);
+        let mut packet = UdpPacket::new_unchecked(&mut bytes);
         UDP_REPR.emit(&mut packet, &REMOTE_IPV4.into(), &LOCAL_IPV4.into(), &caps.checksum);
 
         let data = &packet.into_inner()[..];
@@ -581,7 +589,7 @@ mod test_ipv4 {
         assert!(socket.can_recv());
 
         let mut bytes = [0x00; 46];
-        let mut packet = Icmpv4Packet::new(&mut bytes[..]);
+        let mut packet = Icmpv4Packet::new_unchecked(&mut bytes[..]);
         icmp_repr.emit(&mut packet, &caps.checksum);
         assert_eq!(socket.recv(), Ok((&packet.into_inner()[..], REMOTE_IPV4.into())));
         assert!(!socket.can_recv());
@@ -642,7 +650,7 @@ mod test_ipv6 {
         assert!(socket.can_send());
 
         let mut bytes = vec![0xff; 24];
-        let mut packet = Icmpv6Packet::new(&mut bytes);
+        let mut packet = Icmpv6Packet::new_unchecked(&mut bytes);
         ECHOV6_REPR.emit(&LOCAL_IPV6.into(), &REMOTE_IPV6.into(), &mut packet, &caps.checksum);
 
         assert_eq!(socket.send_slice(&packet.into_inner()[..], REMOTE_IPV6.into()), Ok(()));
@@ -672,7 +680,7 @@ mod test_ipv6 {
         let caps = DeviceCapabilities::default();
 
         let mut bytes = vec![0xff; 24];
-        let mut packet = Icmpv6Packet::new(&mut bytes);
+        let mut packet = Icmpv6Packet::new_unchecked(&mut bytes);
         ECHOV6_REPR.emit(&LOCAL_IPV6.into(), &REMOTE_IPV6.into(), &mut packet, &caps.checksum);
 
         s.set_hop_limit(Some(0x2a));
@@ -701,7 +709,7 @@ mod test_ipv6 {
         let caps = DeviceCapabilities::default();
 
         let mut bytes = [0xff; 24];
-        let mut packet = Icmpv6Packet::new(&mut bytes);
+        let mut packet = Icmpv6Packet::new_unchecked(&mut bytes);
         ECHOV6_REPR.emit(&LOCAL_IPV6.into(), &REMOTE_IPV6.into(), &mut packet, &caps.checksum);
         let data = &packet.into_inner()[..];
 
@@ -725,7 +733,7 @@ mod test_ipv6 {
 
         let caps = DeviceCapabilities::default();
         let mut bytes = [0xff; 20];
-        let mut packet = Icmpv6Packet::new(&mut bytes);
+        let mut packet = Icmpv6Packet::new_unchecked(&mut bytes);
         let icmp_repr = Icmpv6Repr::EchoRequest {
             ident:  0x4321,
             seq_no: 0x5678,
@@ -746,7 +754,7 @@ mod test_ipv6 {
         let caps = DeviceCapabilities::default();
 
         let mut bytes = [0xff; 18];
-        let mut packet = UdpPacket::new(&mut bytes);
+        let mut packet = UdpPacket::new_unchecked(&mut bytes);
         UDP_REPR.emit(&mut packet, &REMOTE_IPV6.into(), &LOCAL_IPV6.into(), &caps.checksum);
 
         let data = &packet.into_inner()[..];
@@ -780,7 +788,7 @@ mod test_ipv6 {
         assert!(socket.can_recv());
 
         let mut bytes = [0x00; 66];
-        let mut packet = Icmpv6Packet::new(&mut bytes[..]);
+        let mut packet = Icmpv6Packet::new_unchecked(&mut bytes[..]);
         icmp_repr.emit(&LOCAL_IPV6.into(), &REMOTE_IPV6.into(), &mut packet, &caps.checksum);
         assert_eq!(socket.recv(), Ok((&packet.into_inner()[..], REMOTE_IPV6.into())));
         assert!(!socket.can_recv());

--- a/src/socket/raw.rs
+++ b/src/socket/raw.rs
@@ -168,7 +168,7 @@ impl<'a, 'b> RawSocket<'a, 'b> {
                         packet.set_checksum(0);
                     }
 
-                    let packet = Ipv4Packet::new(&*packet.into_inner());
+                    let packet = Ipv4Packet::new_unchecked(&*packet.into_inner());
                     let ipv4_repr = Ipv4Repr::parse(&packet, checksum_caps)?;
                     Ok((IpRepr::Ipv4(ipv4_repr), packet.payload()))
                 }
@@ -176,7 +176,7 @@ impl<'a, 'b> RawSocket<'a, 'b> {
                 IpVersion::Ipv6 => {
                     let mut packet = Ipv6Packet::new_checked(buffer.as_mut())?;
                     if packet.next_header() != protocol { return Err(Error::Unaddressable) }
-                    let packet = Ipv6Packet::new(&*packet.into_inner());
+                    let packet = Ipv6Packet::new_unchecked(&*packet.into_inner());
                     let ipv6_repr = Ipv6Repr::parse(&packet)?;
                     Ok((IpRepr::Ipv6(ipv6_repr), packet.payload()))
                 }
@@ -393,14 +393,14 @@ mod test {
             let mut socket = ipv4_locals::socket(buffer(0), buffer(2));
 
             let mut wrong_version = ipv4_locals::PACKET_BYTES.clone();
-            Ipv4Packet::new(&mut wrong_version).set_version(6);
+            Ipv4Packet::new_unchecked(&mut wrong_version).set_version(6);
 
             assert_eq!(socket.send_slice(&wrong_version[..]), Ok(()));
             assert_eq!(socket.dispatch(&checksum_caps, |_| unreachable!()),
                        Ok(()));
 
             let mut wrong_protocol = ipv4_locals::PACKET_BYTES.clone();
-            Ipv4Packet::new(&mut wrong_protocol).set_protocol(IpProtocol::Tcp);
+            Ipv4Packet::new_unchecked(&mut wrong_protocol).set_protocol(IpProtocol::Tcp);
 
             assert_eq!(socket.send_slice(&wrong_protocol[..]), Ok(()));
             assert_eq!(socket.dispatch(&checksum_caps, |_| unreachable!()),
@@ -411,14 +411,14 @@ mod test {
             let mut socket = ipv6_locals::socket(buffer(0), buffer(2));
 
             let mut wrong_version = ipv6_locals::PACKET_BYTES.clone();
-            Ipv6Packet::new(&mut wrong_version[..]).set_version(4);
+            Ipv6Packet::new_unchecked(&mut wrong_version[..]).set_version(4);
 
             assert_eq!(socket.send_slice(&wrong_version[..]), Ok(()));
             assert_eq!(socket.dispatch(&checksum_caps, |_| unreachable!()),
                        Ok(()));
 
             let mut wrong_protocol = ipv6_locals::PACKET_BYTES.clone();
-            Ipv6Packet::new(&mut wrong_protocol[..]).set_next_header(IpProtocol::Tcp);
+            Ipv6Packet::new_unchecked(&mut wrong_protocol[..]).set_next_header(IpProtocol::Tcp);
 
             assert_eq!(socket.send_slice(&wrong_protocol[..]), Ok(()));
             assert_eq!(socket.dispatch(&checksum_caps, |_| unreachable!()),
@@ -434,7 +434,7 @@ mod test {
             assert!(!socket.can_recv());
 
             let mut cksumd_packet = ipv4_locals::PACKET_BYTES.clone();
-            Ipv4Packet::new(&mut cksumd_packet).fill_checksum();
+            Ipv4Packet::new_unchecked(&mut cksumd_packet).fill_checksum();
 
             assert_eq!(socket.recv(), Err(Error::Exhausted));
             assert!(socket.accepts(&ipv4_locals::HEADER_REPR));

--- a/src/socket/ref_.rs
+++ b/src/socket/ref_.rs
@@ -55,7 +55,7 @@ impl<'a, T: Session + 'a> Ref<'a, T> {
     /// map a `&mut SocketRef<'a, XSocket>` to a `&'a mut XSocket` (note the lifetimes);
     /// be sure to call [new] afterwards.
     ///
-    /// [new]: #method.new
+    /// [new_unchecked]: #method.new_unchecked
     pub fn into_inner(mut ref_: Self) -> &'a mut T {
         ref_.consumed = true;
         ref_.socket

--- a/src/wire/arp.rs
+++ b/src/wire/arp.rs
@@ -64,16 +64,16 @@ mod field {
 
 impl<T: AsRef<[u8]>> Packet<T> {
     /// Imbue a raw octet buffer with ARP packet structure.
-    pub fn new(buffer: T) -> Packet<T> {
+    pub fn new_unchecked(buffer: T) -> Packet<T> {
         Packet { buffer }
     }
 
-    /// Shorthand for a combination of [new] and [check_len].
+    /// Shorthand for a combination of [new_unchecked] and [check_len].
     ///
-    /// [new]: #method.new
+    /// [new_unchecked]: #method.new_unchecked
     /// [check_len]: #method.check_len
     pub fn new_checked(buffer: T) -> Result<Packet<T>> {
-        let packet = Self::new(buffer);
+        let packet = Self::new_unchecked(buffer);
         packet.check_len()?;
         Ok(packet)
     }
@@ -385,7 +385,7 @@ mod test {
 
     #[test]
     fn test_deconstruct() {
-        let packet = Packet::new(&PACKET_BYTES[..]);
+        let packet = Packet::new_unchecked(&PACKET_BYTES[..]);
         assert_eq!(packet.hardware_type(), Hardware::Ethernet);
         assert_eq!(packet.protocol_type(), Protocol::Ipv4);
         assert_eq!(packet.hardware_len(), 6);
@@ -400,7 +400,7 @@ mod test {
     #[test]
     fn test_construct() {
         let mut bytes = vec![0xa5; 28];
-        let mut packet = Packet::new(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes);
         packet.set_hardware_type(Hardware::Ethernet);
         packet.set_protocol_type(Protocol::Ipv4);
         packet.set_hardware_len(6);
@@ -429,7 +429,7 @@ mod test {
 
     #[test]
     fn test_parse() {
-        let packet = Packet::new(&PACKET_BYTES[..]);
+        let packet = Packet::new_unchecked(&PACKET_BYTES[..]);
         let repr = Repr::parse(&packet).unwrap();
         assert_eq!(repr, packet_repr());
     }
@@ -437,7 +437,7 @@ mod test {
     #[test]
     fn test_emit() {
         let mut bytes = vec![0xa5; 28];
-        let mut packet = Packet::new(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes);
         packet_repr().emit(&mut packet);
         assert_eq!(&packet.into_inner()[..], &PACKET_BYTES[..]);
     }

--- a/src/wire/dhcpv4.rs
+++ b/src/wire/dhcpv4.rs
@@ -280,16 +280,16 @@ mod field {
 
 impl<T: AsRef<[u8]>> Packet<T> {
     /// Imbue a raw octet buffer with DHCP packet structure.
-    pub fn new(buffer: T) -> Packet<T> {
+    pub fn new_unchecked(buffer: T) -> Packet<T> {
         Packet { buffer }
     }
 
-    /// Shorthand for a combination of [new] and [check_len].
+    /// Shorthand for a combination of [new_unchecked] and [check_len].
     ///
-    /// [new]: #method.new
+    /// [new_unchecked]: #method.new_unchecked
     /// [check_len]: #method.check_len
     pub fn new_checked(buffer: T) -> Result<Packet<T>> {
-        let packet = Self::new(buffer);
+        let packet = Self::new_unchecked(buffer);
         packet.check_len()?;
         Ok(packet)
     }
@@ -792,7 +792,7 @@ mod test {
 
     #[test]
     fn test_deconstruct_discover() {
-        let packet = Packet::new(DISCOVER_BYTES);
+        let packet = Packet::new_unchecked(DISCOVER_BYTES);
         assert_eq!(packet.magic_number(), MAGIC_COOKIE);
         assert_eq!(packet.opcode(), OpCode::Request);
         assert_eq!(packet.hardware_type(), Hardware::Ethernet);
@@ -834,7 +834,7 @@ mod test {
     #[test]
     fn test_construct_discover() {
         let mut bytes = vec![0xa5; 272];
-        let mut packet = Packet::new(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes);
         packet.set_magic_number(MAGIC_COOKIE);
         packet.set_sname_and_boot_file_to_zero();
         packet.set_opcode(OpCode::Request);
@@ -889,7 +889,7 @@ mod test {
 
     #[test]
     fn test_parse_discover() {
-        let packet = Packet::new(DISCOVER_BYTES);
+        let packet = Packet::new_unchecked(DISCOVER_BYTES);
         let repr = Repr::parse(&packet).unwrap();
         assert_eq!(repr, discover_repr());
     }
@@ -898,7 +898,7 @@ mod test {
     fn test_emit_discover() {
         let repr = discover_repr();
         let mut bytes = vec![0xa5; repr.buffer_len()];
-        let mut packet = Packet::new(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes);
         repr.emit(&mut packet).unwrap();
         let packet = &packet.into_inner()[..];
         let packet_len = packet.len();

--- a/src/wire/ethernet.rs
+++ b/src/wire/ethernet.rs
@@ -93,16 +93,16 @@ mod field {
 
 impl<T: AsRef<[u8]>> Frame<T> {
     /// Imbue a raw octet buffer with Ethernet frame structure.
-    pub fn new(buffer: T) -> Frame<T> {
+    pub fn new_unchecked(buffer: T) -> Frame<T> {
         Frame { buffer }
     }
 
-    /// Shorthand for a combination of [new] and [check_len].
+    /// Shorthand for a combination of [new_unchecked] and [check_len].
     ///
-    /// [new]: #method.new
+    /// [new_unchecked]: #method.new_unchecked
     /// [check_len]: #method.check_len
     pub fn new_checked(buffer: T) -> Result<Frame<T>> {
-        let packet = Self::new(buffer);
+        let packet = Self::new_unchecked(buffer);
         packet.check_len()?;
         Ok(packet)
     }
@@ -317,7 +317,7 @@ mod test_ipv4 {
 
     #[test]
     fn test_deconstruct() {
-        let frame = Frame::new(&FRAME_BYTES[..]);
+        let frame = Frame::new_unchecked(&FRAME_BYTES[..]);
         assert_eq!(frame.dst_addr(), Address([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]));
         assert_eq!(frame.src_addr(), Address([0x11, 0x12, 0x13, 0x14, 0x15, 0x16]));
         assert_eq!(frame.ethertype(), EtherType::Ipv4);
@@ -327,7 +327,7 @@ mod test_ipv4 {
     #[test]
     fn test_construct() {
         let mut bytes = vec![0xa5; 64];
-        let mut frame = Frame::new(&mut bytes);
+        let mut frame = Frame::new_unchecked(&mut bytes);
         frame.set_dst_addr(Address([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]));
         frame.set_src_addr(Address([0x11, 0x12, 0x13, 0x14, 0x15, 0x16]));
         frame.set_ethertype(EtherType::Ipv4);
@@ -361,7 +361,7 @@ mod test_ipv6 {
 
     #[test]
     fn test_deconstruct() {
-        let frame = Frame::new(&FRAME_BYTES[..]);
+        let frame = Frame::new_unchecked(&FRAME_BYTES[..]);
         assert_eq!(frame.dst_addr(), Address([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]));
         assert_eq!(frame.src_addr(), Address([0x11, 0x12, 0x13, 0x14, 0x15, 0x16]));
         assert_eq!(frame.ethertype(), EtherType::Ipv6);
@@ -371,7 +371,7 @@ mod test_ipv6 {
     #[test]
     fn test_construct() {
         let mut bytes = vec![0xa5; 54];
-        let mut frame = Frame::new(&mut bytes);
+        let mut frame = Frame::new_unchecked(&mut bytes);
         frame.set_dst_addr(Address([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]));
         frame.set_src_addr(Address([0x11, 0x12, 0x13, 0x14, 0x15, 0x16]));
         frame.set_ethertype(EtherType::Ipv6);

--- a/src/wire/icmpv6.rs
+++ b/src/wire/icmpv6.rs
@@ -251,16 +251,16 @@ pub(super) mod field {
 
 impl<T: AsRef<[u8]>> Packet<T> {
     /// Imbue a raw octet buffer with ICMPv6 packet structure.
-    pub fn new(buffer: T) -> Packet<T> {
+    pub fn new_unchecked(buffer: T) -> Packet<T> {
         Packet { buffer }
     }
 
-    /// Shorthand for a combination of [new] and [check_len].
+    /// Shorthand for a combination of [new_unchecked] and [check_len].
     ///
-    /// [new]: #method.new
+    /// [new_unchecked]: #method.new_unchecked
     /// [check_len]: #method.check_len
     pub fn new_checked(buffer: T) -> Result<Packet<T>> {
-        let packet = Self::new(buffer);
+        let packet = Self::new_unchecked(buffer);
         packet.check_len()?;
         Ok(packet)
     }
@@ -656,7 +656,7 @@ impl<'a> Repr<'a> {
                    packet: &mut Packet<&mut T>, checksum_caps: &ChecksumCapabilities)
             where T: AsRef<[u8]> + AsMut<[u8]> + ?Sized {
         fn emit_contained_packet(buffer: &mut [u8], header: Ipv6Repr, data: &[u8]) {
-            let mut ip_packet = Ipv6Packet::new(buffer);
+            let mut ip_packet = Ipv6Packet::new_unchecked(buffer);
             header.emit(&mut ip_packet);
             let payload = &mut ip_packet.into_inner()[header.buffer_len()..];
             payload.copy_from_slice(&data[..]);
@@ -812,7 +812,7 @@ mod test {
 
     #[test]
     fn test_echo_deconstruct() {
-        let packet = Packet::new(&ECHO_PACKET_BYTES[..]);
+        let packet = Packet::new_unchecked(&ECHO_PACKET_BYTES[..]);
         assert_eq!(packet.msg_type(), Message::EchoRequest);
         assert_eq!(packet.msg_code(), 0);
         assert_eq!(packet.checksum(), 0x19b3);
@@ -826,7 +826,7 @@ mod test {
     #[test]
     fn test_echo_construct() {
         let mut bytes = vec![0xa5; 12];
-        let mut packet = Packet::new(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes);
         packet.set_msg_type(Message::EchoRequest);
         packet.set_msg_code(0);
         packet.set_echo_ident(0x1234);
@@ -838,7 +838,7 @@ mod test {
 
     #[test]
     fn test_echo_repr_parse() {
-        let packet = Packet::new(&ECHO_PACKET_BYTES[..]);
+        let packet = Packet::new_unchecked(&ECHO_PACKET_BYTES[..]);
         let repr = Repr::parse(&MOCK_IP_ADDR_1, &MOCK_IP_ADDR_2,
                                &packet, &ChecksumCapabilities::default()).unwrap();
         assert_eq!(repr, echo_packet_repr());
@@ -848,7 +848,7 @@ mod test {
     fn test_echo_emit() {
         let repr = echo_packet_repr();
         let mut bytes = vec![0xa5; repr.buffer_len()];
-        let mut packet = Packet::new(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes);
         repr.emit(&MOCK_IP_ADDR_1, &MOCK_IP_ADDR_2,
                   &mut packet, &ChecksumCapabilities::default());
         assert_eq!(&packet.into_inner()[..], &ECHO_PACKET_BYTES[..]);
@@ -856,7 +856,7 @@ mod test {
 
     #[test]
     fn test_too_big_deconstruct() {
-        let packet = Packet::new(&PKT_TOO_BIG_BYTES[..]);
+        let packet = Packet::new_unchecked(&PKT_TOO_BIG_BYTES[..]);
         assert_eq!(packet.msg_type(), Message::PktTooBig);
         assert_eq!(packet.msg_code(), 0);
         assert_eq!(packet.checksum(), 0x0fc9);
@@ -869,7 +869,7 @@ mod test {
     #[test]
     fn test_too_big_construct() {
         let mut bytes = vec![0xa5; 60];
-        let mut packet = Packet::new(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes);
         packet.set_msg_type(Message::PktTooBig);
         packet.set_msg_code(0);
         packet.set_pkt_too_big_mtu(1500);
@@ -880,7 +880,7 @@ mod test {
 
     #[test]
     fn test_too_big_repr_parse() {
-        let packet = Packet::new(&PKT_TOO_BIG_BYTES[..]);
+        let packet = Packet::new_unchecked(&PKT_TOO_BIG_BYTES[..]);
         let repr = Repr::parse(&MOCK_IP_ADDR_1, &MOCK_IP_ADDR_2,
                                &packet, &ChecksumCapabilities::default()).unwrap();
         assert_eq!(repr, too_big_packet_repr());
@@ -890,7 +890,7 @@ mod test {
     fn test_too_big_emit() {
         let repr = too_big_packet_repr();
         let mut bytes = vec![0xa5; repr.buffer_len()];
-        let mut packet = Packet::new(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes);
         repr.emit(&MOCK_IP_ADDR_1, &MOCK_IP_ADDR_2,
                   &mut packet, &ChecksumCapabilities::default());
         assert_eq!(&packet.into_inner()[..], &PKT_TOO_BIG_BYTES[..]);

--- a/src/wire/igmp.rs
+++ b/src/wire/igmp.rs
@@ -53,16 +53,16 @@ impl fmt::Display for Message {
 /// [RFC 2236]: https://tools.ietf.org/html/rfc2236
 impl<T: AsRef<[u8]>> Packet<T> {
     /// Imbue a raw octet buffer with IGMPv2 packet structure.
-    pub fn new(buffer: T) -> Packet<T> {
+    pub fn new_unchecked(buffer: T) -> Packet<T> {
         Packet { buffer }
     }
 
-    /// Shorthand for a combination of [new] and [check_len].
+    /// Shorthand for a combination of [new_unchecked] and [check_len].
     ///
-    /// [new]: #method.new
+    /// [new_unchecked]: #method.new_unchecked
     /// [check_len]: #method.check_len
     pub fn new_checked(buffer: T) -> Result<Packet<T>> {
-        let packet = Self::new(buffer);
+        let packet = Self::new_unchecked(buffer);
         packet.check_len()?;
         Ok(packet)
     }
@@ -379,7 +379,7 @@ mod test {
 
     #[test]
     fn test_leave_group_deconstruct() {
-        let packet = Packet::new(&LEAVE_PACKET_BYTES[..]);
+        let packet = Packet::new_unchecked(&LEAVE_PACKET_BYTES[..]);
         assert_eq!(packet.msg_type(), Message::LeaveGroup);
         assert_eq!(packet.max_resp_code(), 0);
         assert_eq!(packet.checksum(), 0x269);
@@ -390,7 +390,7 @@ mod test {
 
     #[test]
     fn test_report_deconstruct() {
-        let packet = Packet::new(&REPORT_PACKET_BYTES[..]);
+        let packet = Packet::new_unchecked(&REPORT_PACKET_BYTES[..]);
         assert_eq!(packet.msg_type(), Message::MembershipReportV2);
         assert_eq!(packet.max_resp_code(), 0);
         assert_eq!(packet.checksum(), 0x08da);
@@ -402,7 +402,7 @@ mod test {
     #[test]
     fn test_leave_construct() {
         let mut bytes = vec![0xa5; 8];
-        let mut packet = Packet::new(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes);
         packet.set_msg_type(Message::LeaveGroup);
         packet.set_max_resp_code(0);
         packet.set_group_address(Ipv4Address::from_bytes(&[224, 0, 6, 150]));
@@ -413,7 +413,7 @@ mod test {
     #[test]
     fn test_report_construct() {
         let mut bytes = vec![0xa5; 8];
-        let mut packet = Packet::new(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes);
         packet.set_msg_type(Message::MembershipReportV2);
         packet.set_max_resp_code(0);
         packet.set_group_address(Ipv4Address::from_bytes(&[225, 0, 0, 37]));

--- a/src/wire/ip.rs
+++ b/src/wire/ip.rs
@@ -684,10 +684,10 @@ impl Repr {
                 panic!("unspecified IP representation"),
             #[cfg(feature = "proto-ipv4")]
             &Repr::Ipv4(repr) =>
-                repr.emit(&mut Ipv4Packet::new(buffer), &_checksum_caps),
+                repr.emit(&mut Ipv4Packet::new_unchecked(buffer), &_checksum_caps),
             #[cfg(feature = "proto-ipv6")]
             &Repr::Ipv6(repr) =>
-                repr.emit(&mut Ipv6Packet::new(buffer)),
+                repr.emit(&mut Ipv6Packet::new_unchecked(buffer)),
             &Repr::__Nonexhaustive =>
                 unreachable!()
         }

--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -241,16 +241,16 @@ mod field {
 
 impl<T: AsRef<[u8]>> Packet<T> {
     /// Imbue a raw octet buffer with IPv4 packet structure.
-    pub fn new(buffer: T) -> Packet<T> {
+    pub fn new_unchecked(buffer: T) -> Packet<T> {
         Packet { buffer }
     }
 
-    /// Shorthand for a combination of [new] and [check_len].
+    /// Shorthand for a combination of [new_unchecked] and [check_len].
     ///
-    /// [new]: #method.new
+    /// [new_unchecked]: #method.new_unchecked
     /// [check_len]: #method.check_len
     pub fn new_checked(buffer: T) -> Result<Packet<T>> {
-        let packet = Self::new(buffer);
+        let packet = Self::new_unchecked(buffer);
         packet.check_len()?;
         Ok(packet)
     }
@@ -704,7 +704,7 @@ mod test {
 
     #[test]
     fn test_deconstruct() {
-        let packet = Packet::new(&PACKET_BYTES[..]);
+        let packet = Packet::new_unchecked(&PACKET_BYTES[..]);
         assert_eq!(packet.version(), 4);
         assert_eq!(packet.header_len(), 20);
         assert_eq!(packet.dscp(), 0);
@@ -726,7 +726,7 @@ mod test {
     #[test]
     fn test_construct() {
         let mut bytes = vec![0xa5; 30];
-        let mut packet = Packet::new(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes);
         packet.set_version(4);
         packet.set_header_len(20);
         packet.clear_flags();
@@ -752,9 +752,9 @@ mod test {
         bytes.extend(&PACKET_BYTES[..]);
         bytes.push(0);
 
-        assert_eq!(Packet::new(&bytes).payload().len(),
+        assert_eq!(Packet::new_unchecked(&bytes).payload().len(),
                    PAYLOAD_BYTES.len());
-        assert_eq!(Packet::new(&mut bytes).payload_mut().len(),
+        assert_eq!(Packet::new_unchecked(&mut bytes).payload_mut().len(),
                    PAYLOAD_BYTES.len());
     }
 
@@ -762,7 +762,7 @@ mod test {
     fn test_total_len_overflow() {
         let mut bytes = vec![];
         bytes.extend(&PACKET_BYTES[..]);
-        Packet::new(&mut bytes).set_total_len(128);
+        Packet::new_unchecked(&mut bytes).set_total_len(128);
 
         assert_eq!(Packet::new_checked(&bytes).unwrap_err(),
                    Error::Truncated);
@@ -791,7 +791,7 @@ mod test {
 
     #[test]
     fn test_parse() {
-        let packet = Packet::new(&REPR_PACKET_BYTES[..]);
+        let packet = Packet::new_unchecked(&REPR_PACKET_BYTES[..]);
         let repr = Repr::parse(&packet, &ChecksumCapabilities::default()).unwrap();
         assert_eq!(repr, packet_repr());
     }
@@ -800,10 +800,10 @@ mod test {
     fn test_parse_bad_version() {
         let mut bytes = vec![0; 24];
         bytes.copy_from_slice(&REPR_PACKET_BYTES[..]);
-        let mut packet = Packet::new(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes);
         packet.set_version(6);
         packet.fill_checksum();
-        let packet = Packet::new(&*packet.into_inner());
+        let packet = Packet::new_unchecked(&*packet.into_inner());
         assert_eq!(Repr::parse(&packet, &ChecksumCapabilities::default()), Err(Error::Malformed));
     }
 
@@ -818,7 +818,7 @@ mod test {
     fn test_emit() {
         let repr = packet_repr();
         let mut bytes = vec![0xa5; repr.buffer_len() + REPR_PAYLOAD_BYTES.len()];
-        let mut packet = Packet::new(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes);
         repr.emit(&mut packet, &ChecksumCapabilities::default());
         packet.payload_mut().copy_from_slice(&REPR_PAYLOAD_BYTES);
         assert_eq!(&packet.into_inner()[..], &REPR_PACKET_BYTES[..]);

--- a/src/wire/ipv6option.rs
+++ b/src/wire/ipv6option.rs
@@ -87,16 +87,16 @@ mod field {
 
 impl<T: AsRef<[u8]>> Ipv6Option<T> {
     /// Create a raw octet buffer with an IPv6 Extension Header Option structure.
-    pub fn new(buffer: T) -> Ipv6Option<T> {
+    pub fn new_unchecked(buffer: T) -> Ipv6Option<T> {
         Ipv6Option { buffer }
     }
 
-    /// Shorthand for a combination of [new] and [check_len].
+    /// Shorthand for a combination of [new_unchecked] and [check_len].
     ///
-    /// [new]: #method.new
+    /// [new_unchecked]: #method.new_unchecked
     /// [check_len]: #method.check_len
     pub fn new_checked(buffer: T) -> Result<Ipv6Option<T>> {
-        let opt = Self::new(buffer);
+        let opt = Self::new_unchecked(buffer);
         opt.check_len()?;
         Ok(opt)
     }
@@ -376,57 +376,64 @@ mod test {
     fn test_check_len() {
         let bytes = [0u8];
         // zero byte buffer
-        assert_eq!(Err(Error::Truncated), Ipv6Option::new(&bytes[..0]).check_len());
+        assert_eq!(Err(Error::Truncated),
+                   Ipv6Option::new_unchecked(&bytes[..0]).check_len());
         // pad1
-        assert_eq!(Ok(()), Ipv6Option::new(&IPV6OPTION_BYTES_PAD1).check_len());
+        assert_eq!(Ok(()),
+                   Ipv6Option::new_unchecked(&IPV6OPTION_BYTES_PAD1).check_len());
 
         // padn with truncated data
-        assert_eq!(Err(Error::Truncated), Ipv6Option::new(&IPV6OPTION_BYTES_PADN[..2]).check_len());
+        assert_eq!(Err(Error::Truncated),
+                   Ipv6Option::new_unchecked(&IPV6OPTION_BYTES_PADN[..2]).check_len());
         // padn
-        assert_eq!(Ok(()), Ipv6Option::new(&IPV6OPTION_BYTES_PADN).check_len());
+        assert_eq!(Ok(()),
+                   Ipv6Option::new_unchecked(&IPV6OPTION_BYTES_PADN).check_len());
 
         // unknown option type with truncated data
-        assert_eq!(Err(Error::Truncated), Ipv6Option::new(&IPV6OPTION_BYTES_UNKNOWN[..4]).check_len());
-        assert_eq!(Err(Error::Truncated), Ipv6Option::new(&IPV6OPTION_BYTES_UNKNOWN[..1]).check_len());
+        assert_eq!(Err(Error::Truncated),
+                   Ipv6Option::new_unchecked(&IPV6OPTION_BYTES_UNKNOWN[..4]).check_len());
+        assert_eq!(Err(Error::Truncated),
+                   Ipv6Option::new_unchecked(&IPV6OPTION_BYTES_UNKNOWN[..1]).check_len());
         // unknown type
-        assert_eq!(Ok(()), Ipv6Option::new(&IPV6OPTION_BYTES_UNKNOWN).check_len());
+        assert_eq!(Ok(()),
+                   Ipv6Option::new_unchecked(&IPV6OPTION_BYTES_UNKNOWN).check_len());
     }
 
     #[test]
     #[should_panic(expected = "index out of bounds")]
     fn test_data_len() {
-        let opt = Ipv6Option::new(&IPV6OPTION_BYTES_PAD1);
+        let opt = Ipv6Option::new_unchecked(&IPV6OPTION_BYTES_PAD1);
         opt.data_len();
     }
 
     #[test]
     fn test_option_deconstruct() {
         // one octet of padding
-        let opt = Ipv6Option::new(&IPV6OPTION_BYTES_PAD1);
+        let opt = Ipv6Option::new_unchecked(&IPV6OPTION_BYTES_PAD1);
         assert_eq!(opt.option_type(), Type::Pad1);
 
         // two octets of padding
         let bytes:  [u8; 2] = [0x1, 0x0];
-        let opt = Ipv6Option::new(&bytes);
+        let opt = Ipv6Option::new_unchecked(&bytes);
         assert_eq!(opt.option_type(), Type::PadN);
         assert_eq!(opt.data_len(), 0);
 
         // three octets of padding
-        let opt = Ipv6Option::new(&IPV6OPTION_BYTES_PADN);
+        let opt = Ipv6Option::new_unchecked(&IPV6OPTION_BYTES_PADN);
         assert_eq!(opt.option_type(), Type::PadN);
         assert_eq!(opt.data_len(), 1);
         assert_eq!(opt.data(), &[0]);
 
         // extra bytes in buffer
         let bytes:  [u8; 10] = [0x1, 0x7, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff];
-        let opt = Ipv6Option::new(&bytes);
+        let opt = Ipv6Option::new_unchecked(&bytes);
         assert_eq!(opt.option_type(), Type::PadN);
         assert_eq!(opt.data_len(), 7);
         assert_eq!(opt.data(), &[0, 0, 0, 0, 0, 0, 0]);
 
         // unrecognized option
         let bytes:  [u8; 1] = [0xff];
-        let opt = Ipv6Option::new(&bytes);
+        let opt = Ipv6Option::new_unchecked(&bytes);
         assert_eq!(opt.option_type(), Type::Unknown(255));
 
         // unrecognized option without length and data
@@ -436,42 +443,42 @@ mod test {
     #[test]
     fn test_option_parse() {
         // one octet of padding
-        let opt = Ipv6Option::new(&IPV6OPTION_BYTES_PAD1);
+        let opt = Ipv6Option::new_unchecked(&IPV6OPTION_BYTES_PAD1);
         let pad1 = Repr::parse(&opt).unwrap();
         assert_eq!(pad1, Repr::Pad1);
         assert_eq!(pad1.buffer_len(), 1);
 
         // two or more octets of padding
-        let opt = Ipv6Option::new(&IPV6OPTION_BYTES_PADN);
+        let opt = Ipv6Option::new_unchecked(&IPV6OPTION_BYTES_PADN);
         let padn = Repr::parse(&opt).unwrap();
         assert_eq!(padn, Repr::PadN(1));
         assert_eq!(padn.buffer_len(), 3);
 
         // unrecognized option type
         let data = [0u8; 3];
-        let opt = Ipv6Option::new(&IPV6OPTION_BYTES_UNKNOWN);
+        let opt = Ipv6Option::new_unchecked(&IPV6OPTION_BYTES_UNKNOWN);
         let unknown = Repr::parse(&opt).unwrap();
-        assert_eq!(unknown, Repr::Unknown { type_: Type::Unknown(255), length: 3, data: &data});
+        assert_eq!(unknown, Repr::Unknown { type_: Type::Unknown(255), length: 3, data: &data });
     }
 
     #[test]
     fn test_option_emit() {
         let repr = Repr::Pad1;
         let mut bytes = [255u8; 1]; // don't assume bytes are initialized to zero
-        let mut opt = Ipv6Option::new(&mut bytes);
+        let mut opt = Ipv6Option::new_unchecked(&mut bytes);
         repr.emit(&mut opt);
         assert_eq!(opt.into_inner(), &IPV6OPTION_BYTES_PAD1);
 
         let repr = Repr::PadN(1);
         let mut bytes = [255u8; 3]; // don't assume bytes are initialized to zero
-        let mut opt = Ipv6Option::new(&mut bytes);
+        let mut opt = Ipv6Option::new_unchecked(&mut bytes);
         repr.emit(&mut opt);
         assert_eq!(opt.into_inner(), &IPV6OPTION_BYTES_PADN);
 
         let data = [0u8; 3];
         let repr = Repr::Unknown { type_: Type::Unknown(255), length: 3, data: &data };
         let mut bytes = [254u8; 5]; // don't assume bytes are initialized to zero
-        let mut opt = Ipv6Option::new(&mut bytes);
+        let mut opt = Ipv6Option::new_unchecked(&mut bytes);
         repr.emit(&mut opt);
         assert_eq!(opt.into_inner(), &IPV6OPTION_BYTES_UNKNOWN);
     }

--- a/src/wire/ipv6routing.rs
+++ b/src/wire/ipv6routing.rs
@@ -146,9 +146,9 @@ impl<T: AsRef<[u8]>> Header<T> {
         Header { buffer }
     }
 
-    /// Shorthand for a combination of [new] and [check_len].
+    /// Shorthand for a combination of [new_unchecked] and [check_len].
     ///
-    /// [new]: #method.new
+    /// [new_unchecked]: #method.new_unchecked
     /// [check_len]: #method.check_len
     pub fn new_checked(buffer: T) -> Result<Header<T>> {
         let header = Self::new(buffer);

--- a/src/wire/mld.rs
+++ b/src/wire/mld.rs
@@ -172,16 +172,16 @@ pub struct AddressRecord<T: AsRef<[u8]>> {
 
 impl<T: AsRef<[u8]>> AddressRecord<T> {
     /// Imbue a raw octet buffer with a Address Record structure.
-    pub fn new(buffer: T) -> Self {
+    pub fn new_unchecked(buffer: T) -> Self {
         Self { buffer }
     }
 
-    /// Shorthand for a combination of [new] and [check_len].
+    /// Shorthand for a combination of [new_unchecked] and [check_len].
     ///
-    /// [new]: #method.new
+    /// [new_unchecked]: #method.new_unchecked
     /// [check_len]: #method.check_len
     pub fn new_checked(buffer: T) -> Result<Self> {
-        let packet = Self::new(buffer);
+        let packet = Self::new_unchecked(buffer);
         packet.check_len()?;
         Ok(packet)
     }
@@ -459,7 +459,7 @@ mod test {
 
     #[test]
     fn test_query_deconstruct() {
-        let packet = Packet::new(&QUERY_PACKET_BYTES[..]);
+        let packet = Packet::new_unchecked(&QUERY_PACKET_BYTES[..]);
         assert_eq!(packet.msg_type(), Message::MldQuery);
         assert_eq!(packet.msg_code(), 0);
         assert_eq!(packet.checksum(), 0x7374);
@@ -476,7 +476,7 @@ mod test {
     #[test]
     fn test_query_construct() {
         let mut bytes = vec![0xff; 44];
-        let mut packet = Packet::new(&mut bytes[..]);
+        let mut packet = Packet::new_unchecked(&mut bytes[..]);
         packet.set_msg_type(Message::MldQuery);
         packet.set_msg_code(0);
         packet.set_max_resp_code(0x0400);
@@ -494,12 +494,12 @@ mod test {
 
     #[test]
     fn test_record_deconstruct() {
-        let packet = Packet::new(&REPORT_PACKET_BYTES[..]);
+        let packet = Packet::new_unchecked(&REPORT_PACKET_BYTES[..]);
         assert_eq!(packet.msg_type(), Message::MldReport);
         assert_eq!(packet.msg_code(), 0);
         assert_eq!(packet.checksum(), 0x7385);
         assert_eq!(packet.nr_mcast_addr_rcrds(), 0x01);
-        let addr_rcrd = AddressRecord::new(packet.payload());
+        let addr_rcrd = AddressRecord::new_unchecked(packet.payload());
         assert_eq!(addr_rcrd.record_type(), RecordType::ModeIsInclude);
         assert_eq!(addr_rcrd.aux_data_len(), 0x00);
         assert_eq!(addr_rcrd.num_srcs(), 0x01);
@@ -511,13 +511,13 @@ mod test {
     #[test]
     fn test_record_construct() {
         let mut bytes = vec![0xff; 44];
-        let mut packet = Packet::new(&mut bytes[..]);
+        let mut packet = Packet::new_unchecked(&mut bytes[..]);
         packet.set_msg_type(Message::MldReport);
         packet.set_msg_code(0);
         packet.clear_reserved();
         packet.set_nr_mcast_addr_rcrds(1);
         {
-            let mut addr_rcrd = AddressRecord::new(packet.payload_mut());
+            let mut addr_rcrd = AddressRecord::new_unchecked(packet.payload_mut());
             addr_rcrd.set_record_type(RecordType::ModeIsInclude);
             addr_rcrd.set_aux_data_len(0);
             addr_rcrd.set_num_srcs(1);
@@ -532,7 +532,7 @@ mod test {
 
     #[test]
     fn test_query_repr_parse() {
-        let packet = Packet::new(&QUERY_PACKET_BYTES[..]);
+        let packet = Packet::new_unchecked(&QUERY_PACKET_BYTES[..]);
         let repr = Icmpv6Repr::parse(&Ipv6Address::LINK_LOCAL_ALL_NODES.into(),
                                      &Ipv6Address::LINK_LOCAL_ALL_ROUTERS.into(),
                                      &packet,
@@ -542,7 +542,7 @@ mod test {
 
     #[test]
     fn test_report_repr_parse() {
-        let packet = Packet::new(&REPORT_PACKET_BYTES[..]);
+        let packet = Packet::new_unchecked(&REPORT_PACKET_BYTES[..]);
         let repr = Icmpv6Repr::parse(&Ipv6Address::LINK_LOCAL_ALL_NODES.into(),
                                      &Ipv6Address::LINK_LOCAL_ALL_ROUTERS.into(),
                                      &packet,
@@ -553,7 +553,7 @@ mod test {
     #[test]
     fn test_query_repr_emit() {
         let mut bytes = [0x2a; 44];
-        let mut packet = Packet::new(&mut bytes[..]);
+        let mut packet = Packet::new_unchecked(&mut bytes[..]);
         let repr = create_repr(Message::MldQuery);
         repr.emit(&Ipv6Address::LINK_LOCAL_ALL_NODES.into(),
                   &Ipv6Address::LINK_LOCAL_ALL_ROUTERS.into(),
@@ -565,7 +565,7 @@ mod test {
     #[test]
     fn test_report_repr_emit() {
         let mut bytes = [0x2a; 44];
-        let mut packet = Packet::new(&mut bytes[..]);
+        let mut packet = Packet::new_unchecked(&mut bytes[..]);
         let repr = create_repr(Message::MldReport);
         repr.emit(&Ipv6Address::LINK_LOCAL_ALL_NODES.into(),
                   &Ipv6Address::LINK_LOCAL_ALL_ROUTERS.into(),

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -23,8 +23,8 @@ returned `Ok(())`, then no accessor or setter method will panic; however, the gu
 provided by `Packet::check_len()` may no longer hold after changing certain fields,
 which are listed in the documentation for the specific packet.
 
-The `Packet::new_checked` method is a shorthand for a combination of `Packet::new` and
-`Packet::check_len`.
+The `Packet::new_checked` method is a shorthand for a combination of `Packet::new_unchecked`
+and `Packet::check_len`.
 When parsing untrusted input, it is *necessary* to use `Packet::new_checked()`;
 so long as the buffer is not modified, no accessor will fail.
 When emitting output, though, it is *incorrect* to use `Packet::new_checked()`;
@@ -56,7 +56,7 @@ let repr = Ipv4Repr {
 };
 let mut buffer = vec![0; repr.buffer_len() + repr.payload_len];
 { // emission
-    let mut packet = Ipv4Packet::new(&mut buffer);
+    let mut packet = Ipv4Packet::new_unchecked(&mut buffer);
     repr.emit(&mut packet, &ChecksumCapabilities::default());
 }
 { // parsing

--- a/src/wire/ndisc.rs
+++ b/src/wire/ndisc.rs
@@ -305,7 +305,8 @@ impl<'a> Repr<'a> {
                             if opt.data_len() < 6 {
                                 return Err(Error::Truncated)
                             } else {
-                                let ip_packet = Ipv6Packet::new(&opt.data()[offset + 8..]);
+                                let ip_packet =
+                                    Ipv6Packet::new_unchecked(&opt.data()[offset + 8..]);
                                 let ip_repr = Ipv6Repr::parse(&ip_packet)?;
                                 let data = &opt.data()[offset + 8 + ip_repr.buffer_len()..];
                                 redirected_hdr = Some(NdiscRedirectedHeader {
@@ -375,7 +376,7 @@ impl<'a> Repr<'a> {
                 packet.set_msg_code(0);
                 packet.clear_reserved();
                 if let Some(lladdr) = lladdr {
-                    let mut opt_pkt = NdiscOption::new(packet.payload_mut());
+                    let mut opt_pkt = NdiscOption::new_unchecked(packet.payload_mut());
                     NdiscOptionRepr::SourceLinkLayerAddr(lladdr).emit(&mut opt_pkt);
                 }
             },
@@ -391,17 +392,20 @@ impl<'a> Repr<'a> {
                 packet.set_retrans_time(retrans_time);
                 let mut offset = 0;
                 if let Some(lladdr) = lladdr {
-                    let mut opt_pkt = NdiscOption::new(packet.payload_mut());
+                    let mut opt_pkt =
+                        NdiscOption::new_unchecked(packet.payload_mut());
                     NdiscOptionRepr::SourceLinkLayerAddr(lladdr).emit(&mut opt_pkt);
                     offset += 8;
                 }
                 if let Some(mtu) = mtu {
-                    let mut opt_pkt = NdiscOption::new(&mut packet.payload_mut()[offset..]);
+                    let mut opt_pkt =
+                        NdiscOption::new_unchecked(&mut packet.payload_mut()[offset..]);
                     NdiscOptionRepr::Mtu(mtu).emit(&mut opt_pkt);
                     offset += 8;
                 }
                 if let Some(prefix_info) = prefix_info {
-                    let mut opt_pkt = NdiscOption::new(&mut packet.payload_mut()[offset..]);
+                    let mut opt_pkt =
+                        NdiscOption::new_unchecked(&mut packet.payload_mut()[offset..]);
                     NdiscOptionRepr::PrefixInformation(prefix_info).emit(&mut opt_pkt)
                 }
             },
@@ -412,7 +416,8 @@ impl<'a> Repr<'a> {
                 packet.clear_reserved();
                 packet.set_target_addr(target_addr);
                 if let Some(lladdr) = lladdr {
-                    let mut opt_pkt = NdiscOption::new(packet.payload_mut());
+                    let mut opt_pkt =
+                        NdiscOption::new_unchecked(packet.payload_mut());
                     NdiscOptionRepr::SourceLinkLayerAddr(lladdr).emit(&mut opt_pkt);
                 }
             },
@@ -424,7 +429,8 @@ impl<'a> Repr<'a> {
                 packet.set_neighbor_flags(flags);
                 packet.set_target_addr(target_addr);
                 if let Some(lladdr) = lladdr {
-                    let mut opt_pkt = NdiscOption::new(packet.payload_mut());
+                    let mut opt_pkt =
+                        NdiscOption::new_unchecked(packet.payload_mut());
                     NdiscOptionRepr::TargetLinkLayerAddr(lladdr).emit(&mut opt_pkt);
                 }
             },
@@ -437,14 +443,16 @@ impl<'a> Repr<'a> {
                 packet.set_dest_addr(dest_addr);
                 let offset = match lladdr {
                     Some(lladdr) => {
-                        let mut opt_pkt = NdiscOption::new(packet.payload_mut());
+                        let mut opt_pkt =
+                            NdiscOption::new_unchecked(packet.payload_mut());
                         NdiscOptionRepr::TargetLinkLayerAddr(lladdr).emit(&mut opt_pkt);
                         8
                     },
                     None => 0,
                 };
                 if let Some(redirected_hdr) = redirected_hdr {
-                    let mut opt_pkt = NdiscOption::new(&mut packet.payload_mut()[offset..]);
+                    let mut opt_pkt =
+                        NdiscOption::new_unchecked(&mut packet.payload_mut()[offset..]);
                     NdiscOptionRepr::RedirectedHeader(redirected_hdr).emit(&mut opt_pkt);
                 }
             },
@@ -485,7 +493,7 @@ mod test {
 
     #[test]
     fn test_router_advert_deconstruct() {
-        let packet = Packet::new(&ROUTER_ADVERT_BYTES[..]);
+        let packet = Packet::new_unchecked(&ROUTER_ADVERT_BYTES[..]);
         assert_eq!(packet.msg_type(), Message::RouterAdvert);
         assert_eq!(packet.msg_code(), 0);
         assert_eq!(packet.current_hop_limit(), 64);
@@ -499,7 +507,7 @@ mod test {
     #[test]
     fn test_router_advert_construct() {
         let mut bytes = vec![0x0; 24];
-        let mut packet = Packet::new(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes);
         packet.set_msg_type(Message::RouterAdvert);
         packet.set_msg_code(0);
         packet.set_current_hop_limit(64);
@@ -514,7 +522,7 @@ mod test {
 
     #[test]
     fn test_router_advert_repr_parse() {
-        let packet = Packet::new(&ROUTER_ADVERT_BYTES[..]);
+        let packet = Packet::new_unchecked(&ROUTER_ADVERT_BYTES[..]);
         assert_eq!(Icmpv6Repr::parse(&MOCK_IP_ADDR_1, &MOCK_IP_ADDR_2,
                                      &packet, &ChecksumCapabilities::default()).unwrap(),
                    create_repr());
@@ -523,7 +531,7 @@ mod test {
     #[test]
     fn test_router_advert_repr_emit() {
         let mut bytes = vec![0x2a; 24];
-        let mut packet = Packet::new(&mut bytes[..]);
+        let mut packet = Packet::new_unchecked(&mut bytes[..]);
         create_repr().emit(&MOCK_IP_ADDR_1, &MOCK_IP_ADDR_2,
                            &mut packet, &ChecksumCapabilities::default());
         assert_eq!(&packet.into_inner()[..], &ROUTER_ADVERT_BYTES[..]);

--- a/src/wire/tcp.rs
+++ b/src/wire/tcp.rs
@@ -107,16 +107,16 @@ mod field {
 
 impl<T: AsRef<[u8]>> Packet<T> {
     /// Imbue a raw octet buffer with TCP packet structure.
-    pub fn new(buffer: T) -> Packet<T> {
+    pub fn new_unchecked(buffer: T) -> Packet<T> {
         Packet { buffer }
     }
 
-    /// Shorthand for a combination of [new] and [check_len].
+    /// Shorthand for a combination of [new_unchecked] and [check_len].
     ///
-    /// [new]: #method.new
+    /// [new_unchecked]: #method.new_unchecked
     /// [check_len]: #method.check_len
     pub fn new_checked(buffer: T) -> Result<Packet<T>> {
-        let packet = Self::new(buffer);
+        let packet = Self::new_unchecked(buffer);
         packet.check_len()?;
         Ok(packet)
     }
@@ -927,7 +927,7 @@ mod test {
     #[test]
     #[cfg(feature = "proto-ipv4")]
     fn test_deconstruct() {
-        let packet = Packet::new(&PACKET_BYTES[..]);
+        let packet = Packet::new_unchecked(&PACKET_BYTES[..]);
         assert_eq!(packet.src_port(), 48896);
         assert_eq!(packet.dst_port(), 80);
         assert_eq!(packet.seq_number(), SeqNumber(0x01234567));
@@ -951,7 +951,7 @@ mod test {
     #[cfg(feature = "proto-ipv4")]
     fn test_construct() {
         let mut bytes = vec![0xa5; PACKET_BYTES.len()];
-        let mut packet = Packet::new(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes);
         packet.set_src_port(48896);
         packet.set_dst_port(80);
         packet.set_seq_number(SeqNumber(0x01234567));
@@ -976,14 +976,14 @@ mod test {
     #[test]
     #[cfg(feature = "proto-ipv4")]
     fn test_truncated() {
-        let packet = Packet::new(&PACKET_BYTES[..23]);
+        let packet = Packet::new_unchecked(&PACKET_BYTES[..23]);
         assert_eq!(packet.check_len(), Err(Error::Truncated));
     }
 
     #[test]
     fn test_impossible_len() {
         let mut bytes = vec![0; 20];
-        let mut packet = Packet::new(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes);
         packet.set_header_len(10);
         assert_eq!(packet.check_len(), Err(Error::Malformed));
     }
@@ -1015,7 +1015,7 @@ mod test {
     #[test]
     #[cfg(feature = "proto-ipv4")]
     fn test_parse() {
-        let packet = Packet::new(&SYN_PACKET_BYTES[..]);
+        let packet = Packet::new_unchecked(&SYN_PACKET_BYTES[..]);
         let repr = Repr::parse(&packet, &SRC_ADDR.into(), &DST_ADDR.into(), &ChecksumCapabilities::default()).unwrap();
         assert_eq!(repr, packet_repr());
     }
@@ -1025,7 +1025,7 @@ mod test {
     fn test_emit() {
         let repr = packet_repr();
         let mut bytes = vec![0xa5; repr.buffer_len()];
-        let mut packet = Packet::new(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes);
         repr.emit(&mut packet, &SRC_ADDR.into(), &DST_ADDR.into(), &ChecksumCapabilities::default());
         assert_eq!(&packet.into_inner()[..], &SYN_PACKET_BYTES[..]);
     }


### PR DESCRIPTION
Fixes #195.

r? @dlrobertson, did I miss anything?