### PR TITLE
Allow more integer types when creating Instants

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -28,13 +28,13 @@ pub struct Instant {
 
 impl Instant {
     /// Create a new `Instant` from a number of milliseconds.
-    pub fn from_millis(millis: i64) -> Instant {
-        Instant { millis }
+    pub fn from_millis<T: Into<i64>>(millis: T) -> Instant {
+        Instant { millis: millis.into() }
     }
 
     /// Create a new `Instant` from a number of seconds.
-    pub fn from_secs(secs: i64) -> Instant {
-        Instant { millis: secs * 1000 }
+    pub fn from_secs<T: Into<i64>>(secs: T) -> Instant {
+        Instant { millis: secs.into() * 1000 }
     }
 
     /// Create a new `Instant` from the current [std::time::SystemTime].
@@ -279,7 +279,7 @@ mod test {
         assert_eq!(Instant::from(::std::time::UNIX_EPOCH),
                    Instant::from_millis(0));
         assert_eq!(epoc, ::std::time::UNIX_EPOCH);
-        epoc = Instant::from_millis(2085955200 * 1000).into();
+        epoc = Instant::from_millis(2085955200i64 * 1000).into();
         assert_eq!(epoc, ::std::time::UNIX_EPOCH + ::std::time::Duration::from_secs(2085955200));
     }
 


### PR DESCRIPTION
This allows any type that can be converted into an `i64` to be used when
creating an Instant. Because this is no longer a concrete type, this
change may break existing code like the following:

    error: attempt to multiply with overflow
       --> src/time.rs:282:37
        |
    282 |         epoc = Instant::from_millis(2085955200 * 1000).into();
        |                                     ^^^^^^^^^^^^^^^^^
        |
        = note: #[deny(const_err)] on by default