### PR TITLE
make fill method public #273

### DIFF
--- a/src/iface/neighbor.rs
+++ b/src/iface/neighbor.rs
@@ -87,7 +87,7 @@ impl<'a> Cache<'a> {
     }
 
     pub fn fill(&mut self, protocol_addr: IpAddress, hardware_addr: EthernetAddress,
-                       timestamp: Instant) {
+                timestamp: Instant) {
         debug_assert!(protocol_addr.is_unicast());
         debug_assert!(hardware_addr.is_unicast());
 


### PR DESCRIPTION
By having the fill method public, a NeighborCache can be prefilled with IP/MAC pairs. This solves #273 