### PR TITLE
Document that Packetization Layer Path MTU Discovery in TCP is not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The TCP protocol is supported over IPv4 and IPv6, and server and client TCP sock
   * Timestamping is **not** supported.
   * Urgent pointer is **ignored**.
   * Probing Zero Windows is **not** implemented.
+  * Packetization Layer Path MTU Discovery [PLPMTU](https://tools.ietf.org/rfc/rfc4821.txt) is **not** implemented.
 
 ## Installation
 


### PR DESCRIPTION
[PLPMTU](https://tools.ietf.org/rfc/rfc4821.txt) should be used if ICMP messages are dropped by the network.

Of course allowing IP fragmentation or reacting on ICMP Destination Unreachable messages with `FragRequired` would be the first step to fix some situations. But limiting the segment size in TCP and setting a lower MSS value in the header fixes situations where ICMP does not come through and MSS clamping of middleboxes fails for some reason.