### PR TITLE
Remove an unused mut qualifier on a variable

### DIFF
--- a/src/socket/raw.rs
+++ b/src/socket/raw.rs
@@ -174,7 +174,7 @@ impl<'a, 'b> RawSocket<'a, 'b> {
                 }
                 #[cfg(feature = "proto-ipv6")]
                 IpVersion::Ipv6 => {
-                    let mut packet = Ipv6Packet::new_checked(buffer.as_mut())?;
+                    let packet = Ipv6Packet::new_checked(buffer.as_mut())?;
                     if packet.next_header() != protocol { return Err(Error::Unaddressable) }
                     let packet = Ipv6Packet::new_unchecked(&*packet.into_inner());
                     let ipv6_repr = Ipv6Repr::parse(&packet)?;


### PR DESCRIPTION
Fixes a denied lint uncovered on a recent nightly compiler version,
apparently through improved analysis. The code in question is only
compiled with the proto-ipv6 feature and older compiler versions did not
detect the unused qualifier, sometime around 2019-04-23.