### PR TITLE
test_icmp_reply_size: fix for ipv4-only case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
     - rust: nightly
       env: FEATURES='std proto-ipv4 proto-igmp socket-raw' MODE='test'
     - rust: nightly
+      env: FEATURES='std proto-ipv4 socket-udp socket-tcp' MODE='test'
+    - rust: nightly
       env: FEATURES='std proto-ipv6 socket-udp' MODE='test'
     - rust: nightly
       env: FEATURES='std proto-ipv6 socket-tcp' MODE='test'

--- a/src/iface/ethernet.rs
+++ b/src/iface/ethernet.rs
@@ -2195,7 +2195,7 @@ mod test {
             dst_addr: src_addr,
             protocol: IpProtocol::Icmp,
             hop_limit: 64,
-            payload_len: expected_icmpv4_repr.buffer_len()
+            payload_len: expected_icmp_repr.buffer_len()
         };
 
         // The expected packet does not exceed the IPV4_MIN_MTU


### PR DESCRIPTION
Had this in #186 before but is actually not related.

I added another Travis-CI case for it. If these are too many now, please propose where to put the `proto-ipv4,socket-udp` without `proto-ipv6` combination.