### PR TITLE
Partially revert "Suppress ICMP error replies […]", still allow reception by other sockets.

### DIFF
--- a/src/iface/ethernet.rs
+++ b/src/iface/ethernet.rs
@@ -956,6 +956,8 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
 
         #[cfg(feature = "socket-raw")]
         let handled_by_raw_socket = self.raw_socket_filter(sockets, &ip_repr, ip_payload);
+        #[cfg(not(feature = "socket-raw"))]
+        let handled_by_raw_socket = false;
 
         if !self.has_ip_addr(ipv4_repr.dst_addr) &&
            !ipv4_repr.dst_addr.is_broadcast() &&
@@ -988,7 +990,6 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
             IpProtocol::Tcp =>
                 self.process_tcp(sockets, timestamp, ip_repr, ip_payload),
 
-            #[cfg(feature = "socket-raw")]
             _ if handled_by_raw_socket =>
                 Ok(Packet::None),
 


### PR DESCRIPTION
Sorry to steal your time again, but did anyone notice that in #293 I broke normal sockets when a RawSocket was listening on that proto?

This PR reverts most of the changes and moves ICMP reply prevention into `process_udp()`. This solves any ICMP errors for the DHCP case but doesn't affect any other non-UDP protocol.

The test from #293 is kept, another one is added for this specific problem.

To further improve error reply behaviour in the presence of RawSockets it would probably be useful to let the RawSockets validate incoming packets, so that would practically be a filter...