### PR TITLE
Pad output of `Display` on `Instant`

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -168,7 +168,7 @@ impl Duration {
 
 impl fmt::Display for Duration {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}.{}s", self.secs(), self.millis())
+        write!(f, "{}.{:03}s", self.secs(), self.millis())
     }
 }
 


### PR DESCRIPTION
Currently, `println!("{}", Instant::from_millis(1001))` will print 0.1, because call to millis will be left aligned. This change pads the millis call to with up to 3 leading zeros:
```
 Millis | Old   | New
--------+-------+-----
    0   | 0.    | 0.000
 1000   | 1.0   | 1.000
 1001   | 1.1   | 1.001
 1100   | 1.100 | 1.100
```