### PR TITLE
Allow TCPSockets in a SocketSet without 'static storage lifetime

### DIFF
--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1646,8 +1646,8 @@ impl<'a> TcpSocket<'a> {
     }
 }
 
-impl<'a> Into<Socket<'a, 'static>> for TcpSocket<'a> {
-    fn into(self) -> Socket<'a, 'static> {
+impl<'a> Into<Socket<'a, 'a>> for TcpSocket<'a> {
+    fn into(self) -> Socket<'a, 'a> {
         Socket::Tcp(self)
     }
 }


### PR DESCRIPTION
`TCPSocket` buffers are type `RingBuffer<'a, _>` whilst other socket types have buffers with type `PacketBuffer<'a, 'b, _>`.

There is an enum over socket types `pub enum Socket<'a, 'b: 'a>`, which is in turn used by `set::Item` and `SocketSet`. The lifetime `'b` is not required for `TcpSocket`, but the `Into<Socket>` implementation for `TCPSocket` specifies the `'static` lifetime for `'b`.

Therefore using `TCPSocket` in a `SocketSet` currently requires the lifetime `'b` for other sockets to be `'static` which is unnecessarily restrictive. This patch fixes this.

The lifetime signature of socket specifies `'b: 'a`, that is `'b` outlives `'a`. Instead of `'static`, this is also satisfied by `impl<'a> Into<Socket<'a, 'a>> for TcpSocket<'a>` as `'a` "outlives" `'a` by definition.

The example [here](https://gist.github.com/richardeoin/b562e79d0d499e00a8bf4944f00594d9) fails to compile without this patch (tested on `rustc 1.38.0-nightly (07e0c3651 2019-07-16)`)