### PR TITLE
dhcpv4: use offered ip in requested ip option

### DIFF
--- a/src/dhcp/clientv4.rs
+++ b/src/dhcp/clientv4.rs
@@ -198,7 +198,7 @@ impl Client {
         };
         net_debug!("DHCP recv {:?} from {} ({})", dhcp_repr.message_type, src_ip, server_identifier);
 
-        // once we recieve the ack, we can pass the config to the user
+        // once we receive the ack, we can pass the config to the user
         let config = if dhcp_repr.message_type == DhcpMessageType::Ack {
                let address = dhcp_repr.subnet_mask
                    .and_then(|mask| IpAddress::Ipv4(mask).to_prefix_len())


### PR DESCRIPTION
Instead of configuring the ifaces ip address when a dhcp server offers
and ip, the client now use the requested_ip dhcp option, based on the offered ip
(yiaddr). The user now only has to configure the iface once the dhcp
transaction has completed (Ack'd).

Closes #302.

cc: @astro 