### PR TITLE
replace the use of the deprecated item 'std::sync::atomic::ATOMIC_BOOL_INIT'

### DIFF
--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -10,7 +10,7 @@ mod utils;
 
 use std::cmp;
 use std::collections::BTreeMap;
-use std::sync::atomic::{Ordering, AtomicBool, ATOMIC_BOOL_INIT};
+use std::sync::atomic::{Ordering, AtomicBool};
 use std::thread;
 use std::io::{Read, Write};
 use std::net::TcpStream;
@@ -59,7 +59,7 @@ fn client(kind: Client) {
     CLIENT_DONE.store(true, Ordering::SeqCst);
 }
 
-static CLIENT_DONE: AtomicBool = ATOMIC_BOOL_INIT;
+static CLIENT_DONE: AtomicBool = AtomicBool::new(false);
 
 fn main() {
     #[cfg(feature = "log")]


### PR DESCRIPTION
Fix a warning during compilation, removing deprecated item:

```
warning: use of deprecated item 'std::sync::atomic::ATOMIC_BOOL_INIT': the `new` function is now preferred
  --> examples/benchmark.rs:13:47
   |
13 | use std::sync::atomic::{Ordering, AtomicBool, ATOMIC_BOOL_INIT};
   |                                               ^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: use of deprecated item 'std::sync::atomic::ATOMIC_BOOL_INIT': the `new` function is now preferred
  --> examples/benchmark.rs:62:34
   |
62 | static CLIENT_DONE: AtomicBool = ATOMIC_BOOL_INIT;
   |                                  ^^^^^^^^^^^^^^^^ help: replace the use of the deprecated item: `AtomicBool::new(false)`
```