### PR TITLE
Update recommended version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ To use the _smoltcp_ library in your project, add the following to `Cargo.toml`:
 
 ```toml
 [dependencies]
-smoltcp = "0.4"
+smoltcp = "0.5"
 ```
 
 The default configuration assumes a hosted environment, for ease of evaluation.
@@ -133,7 +133,7 @@ You probably want to disable default features and configure them one by one:
 
 ```toml
 [dependencies]
-smoltcp = { version = "0.4", default-features = false, features = ["log"] }
+smoltcp = { version = "0.5", default-features = false, features = ["log"] }
 ```
 
 ### Feature `std`


### PR DESCRIPTION
0.4.x is really old at this point and mentioning it in the README can cause
some confusion because it doesn't align with features called out in the README.