### PR TITLE
convert ioctl parameter type

### DIFF
--- a/src/phy/sys/mod.rs
+++ b/src/phy/sys/mod.rs
@@ -75,7 +75,7 @@ fn ifreq_for(name: &str) -> ifreq {
 fn ifreq_ioctl(lower: libc::c_int, ifreq: &mut ifreq,
                cmd: libc::c_ulong) -> io::Result<libc::c_int> {
     unsafe {
-        let res = libc::ioctl(lower, cmd, ifreq as *mut ifreq);
+        let res = libc::ioctl(lower, cmd as _, ifreq as *mut ifreq);
         if res == -1 { return Err(io::Error::last_os_error()) }
     }
 


### PR DESCRIPTION
`ioctl` type errors under musl.

```
error[E0308]: mismatched types
  --> /root/.cargo/git/checkouts/smoltcp-a623d622316b6317/d64d6b9/src/phy/sys/mod.rs:78:38
   |
78 |         let res = libc::ioctl(lower, cmd, ifreq as *mut ifreq);
   |                                      ^^^ expected `i32`, found `u64`
   |
help: you can convert an `u64` to `i32` and panic if the converted value wouldn't fit
   |
78 |         let res = libc::ioctl(lower, cmd.try_into().unwrap(), ifreq as *mut ifreq);
   |                                      ^^^^^^^^^^^^^^^^^^^^^^^
```