### PR TITLE
CI: check for bench breakages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ matrix:
       env: MODE='fuzz run' ARGS='packet_parser -- -max_len=1536 -max_total_time=30'
     - rust: nightly
       env: FEATURES='default' MODE='clippy'
+    - rust: nightly
+      env: FEATURES='default' MODE='check --bench bench'
     - os: osx
       rust: nightly
       env: FEATURES='default' MODE='build'
@@ -57,6 +59,9 @@ matrix:
     # Clippy sometimes fails to compile and this shouldn't gate merges
     - rust: nightly
       env: FEATURES='default' MODE='clippy'
+    # See if the bench actually breaks
+    - rust: nightly
+      env: FEATURES='default' MODE='check --bench bench'
 before_script:
   - if [ "$MODE" == "fuzz run" ]; then cargo install cargo-fuzz; fi
   - if [ "$MODE" == "clippy" ]; then cargo install clippy; fi


### PR DESCRIPTION
It seems I am not the only one who accidentally adds a new feature or updates a struct and breaks the bench code. That means the CI should check it.

It is currently allowed to fail, because there are pre-existing issues in master, one of which I plan to fix, another of which I have not looked into.