### PR TITLE
Fix crash in server example due to returning length bigger than received buffer.

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -135,6 +135,7 @@ fn main() {
 
             if socket.may_recv() {
                 let data = socket.recv(|buffer| {
+                    let recvd_len = buffer.len();
                     let mut data = buffer.to_owned();
                     if data.len() > 0 {
                         debug!("tcp:6970 recv data: {:?}",
@@ -143,7 +144,7 @@ fn main() {
                         data.reverse();
                         data.extend(b"\n");
                     }
-                    (data.len(), data)
+                    (recvd_len, data)
                 }).unwrap();
                 if socket.can_send() && data.len() > 0 {
                     debug!("tcp:6970 send data: {:?}",


### PR DESCRIPTION
The`server` example has a bug in the reverse-echo port. It appends a `\n` to the buffer, and then returns the length of the modified buffer for the socket to dequeue, which is too big by 1. The  For some reason this only crashes when receiving lots of data. This PR fixes it.

To reproduce the crash:

```
RUST_BACKTRACE=1 cargo run --example server -- tap0
socat stdio tcp4-connect:192.168.69.1:6970 < /dev/urandom

thread 'main' panicked at 'assertion failed: size <= max_size', /home/dirbaio/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/macros.rs:13:23
stack backtrace:
   0: backtrace::backtrace::libunwind::trace
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/libunwind.rs:86
   1: backtrace::backtrace::trace_unsynchronized
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/mod.rs:66
   2: std::sys_common::backtrace::_print_fmt
             at src/libstd/sys_common/backtrace.rs:78
   3: <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt
             at src/libstd/sys_common/backtrace.rs:59
   4: core::fmt::write
             at src/libcore/fmt/mod.rs:1069
   5: std::io::Write::write_fmt
             at src/libstd/io/mod.rs:1504
   6: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:62
   7: std::sys_common::backtrace::print
             at src/libstd/sys_common/backtrace.rs:49
   8: std::panicking::default_hook::{{closure}}
             at src/libstd/panicking.rs:198
   9: std::panicking::default_hook
             at src/libstd/panicking.rs:218
  10: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:511
  11: std::panicking::begin_panic
             at /home/dirbaio/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/panicking.rs:438
  12: smoltcp::storage::ring_buffer::RingBuffer<T>::dequeue_many_with
             at /home/dirbaio/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/macros.rs:13
  13: smoltcp::socket::tcp::TcpSocket::recv::{{closure}}
             at ./src/socket/tcp.rs:736
  14: smoltcp::socket::tcp::TcpSocket::recv_impl
             at ./src/socket/tcp.rs:717
  15: smoltcp::socket::tcp::TcpSocket::recv
             at ./src/socket/tcp.rs:735
  16: server::main
             at examples/server.rs:137
  17: std::rt::lang_start::{{closure}}
             at /home/dirbaio/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/rt.rs:67
  18: std::rt::lang_start_internal::{{closure}}
             at src/libstd/rt.rs:52
  19: std::panicking::try::do_call
             at src/libstd/panicking.rs:331
  20: std::panicking::try
             at src/libstd/panicking.rs:274
  21: std::panic::catch_unwind
             at src/libstd/panic.rs:394
  22: std::rt::lang_start_internal
             at src/libstd/rt.rs:51
  23: std::rt::lang_start
             at /home/dirbaio/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/rt.rs:67
  24: main
  25: __libc_start_main
  26: _start
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

```