### PR TITLE
Fix support table rendering in toplevel doc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,17 +66,17 @@
 //! of a packet, it is still logged correctly and in full.
 //!
 //! ## Packet and representation layer support
-//!  | Protocol | Packet | Representation |
-//!  |----------|--------|----------------|
-//!  | Ethernet | Yes    | Yes            |
-//!  | ARP      | Yes    | Yes            |
-//!  | IPv4     | Yes    | Yes            |
-//!  | ICMPv4   | Yes    | Yes            |
-//!  | IGMPv1/2 | Yes    | Yes            |
-//!  | IPv6     | Yes    | Yes            |
-//!  | ICMPv6   | Yes    | Yes            |
-//!  | TCP      | Yes    | Yes            |
-//!  | UDP      | Yes    | Yes            |
+//! | Protocol | Packet | Representation |
+//! |----------|--------|----------------|
+//! | Ethernet | Yes    | Yes            |
+//! | ARP      | Yes    | Yes            |
+//! | IPv4     | Yes    | Yes            |
+//! | ICMPv4   | Yes    | Yes            |
+//! | IGMPv1/2 | Yes    | Yes            |
+//! | IPv6     | Yes    | Yes            |
+//! | ICMPv6   | Yes    | Yes            |
+//! | TCP      | Yes    | Yes            |
+//! | UDP      | Yes    | Yes            |
 //!
 //! [wire]: wire/index.html
 //! [osi]: https://en.wikipedia.org/wiki/OSI_model


### PR DESCRIPTION
As [seen](https://docs.rs/smoltcp/0.6.0/smoltcp/#packet-and-representation-layer-support) on docs.rs:
![before SS](https://user-images.githubusercontent.com/6709544/79408757-67200980-7f9c-11ea-8876-f37db36a0633.png)

With patch:
![after SS](https://user-images.githubusercontent.com/6709544/79408805-8880f580-7f9c-11ea-85c5-eee69ff5da31.png)
