### PR TITLE
Assign map instead of using mem::replace.

### DIFF
--- a/src/iface/neighbor.rs
+++ b/src/iface/neighbor.rs
@@ -6,9 +6,6 @@ use managed::ManagedMap;
 use wire::{EthernetAddress, IpAddress};
 use time::{Duration, Instant};
 
-#[cfg(any(feature = "std", feature = "alloc"))]
-use core::mem;
-
 /// A cached neighbor.
 ///
 /// A neighbor mapping translates from a protocol address to a hardware address,
@@ -104,7 +101,7 @@ impl<'a> Cache<'a> {
                         .filter(|(_, v)| timestamp < v.expires_at)
                         .collect();
 
-                    mem::replace(map, new_btree_map);
+                    *map = new_btree_map;
                 }
             }
         };


### PR DESCRIPTION
This fixes build on latest nightly. The cause of the breakage
is this commit:

https://github.com/rust-lang/rust/commit/7c4ca59f4b10d20f0f3e902f847641311abb093c

which added a #[must_use = "if you don't need the old value, you
can just assign the new value directly"] hint to mem::replace.