### PR TITLE
Specify concrete type for Bound::Unbounded

### DIFF
--- a/src/iface/route.rs
+++ b/src/iface/route.rs
@@ -117,7 +117,7 @@ impl<'a> Routes<'a> {
             _ => unimplemented!()
         };
 
-        for (prefix, route) in self.storage.range((Bound::Unbounded, Bound::Included(cidr))).rev() {
+        for (prefix, route) in self.storage.range((Bound::Unbounded::<IpCidr>, Bound::Included(cidr))).rev() {
             // TODO: do something with route.preferred_until
             if let Some(expires_at) = route.expires_at {
                 if timestamp > expires_at {


### PR DESCRIPTION
Somehow type inference got confused. Fixes #340.