### PR TITLE
SNTP wire protocol and client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ matrix:
       env: FEATURES='std ethernet proto-ipv4 socket-icmp socket-tcp' MODE='test'
     - rust: nightly
       env: FEATURES='std ethernet proto-ipv6 socket-icmp socket-tcp' MODE='test'
+    - rust: nightly
+      env: FEATURES='std ethernet proto-ipv4 app-sntp' MODE='test'
     ### Test select feature permutations, chosen to be as aggressive as possible
     - rust: nightly
       env: FEATURES='ethernet proto-ipv4 proto-ipv6 socket-raw socket-udp socket-tcp socket-icmp std'
@@ -40,7 +42,7 @@ matrix:
       env: FEATURES='proto-ipv4 proto-ipv6 socket-raw socket-udp socket-tcp socket-icmp alloc'
         MODE='test'
     - rust: nightly
-      env: FEATURES='ethernet proto-ipv4 proto-ipv6 proto-igmp proto-dhcpv4 socket-raw socket-udp socket-tcp socket-icmp'
+      env: FEATURES='ethernet proto-ipv4 proto-ipv6 proto-igmp proto-dhcpv4 socket-raw socket-udp socket-tcp socket-icmp app-sntp'
         MODE='build'
     - rust: nightly
       env: MODE='fuzz run' ARGS='packet_parser -- -max_len=1536 -max_total_time=30'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ ethernet = []
 "socket-udp" = []
 "socket-tcp" = []
 "socket-icmp" = []
+"app-sntp" = ["socket-udp"]
 default = [
   "std", "log", # needed for `cargo test --no-default-features --features default` :/
   "ethernet",
@@ -93,6 +94,10 @@ required-features = ["std", "phy-tap_interface", "proto-ipv4", "socket-raw", "so
 [[example]]
 name = "dhcp_client"
 required-features = ["std", "phy-tap_interface", "proto-ipv4", "proto-dhcpv4", "socket-raw"]
+
+[[example]]
+name = "sntp"
+required-features = ["std", "phy-tap_interface", "proto-ipv4", "app-sntp"]
 
 [profile.release]
 debug = 2

--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ The TCP protocol is supported over IPv4 and IPv6, and server and client TCP sock
   * Probing Zero Windows is **not** implemented.
   * Packetization Layer Path MTU Discovery [PLPMTU](https://tools.ietf.org/rfc/rfc4821.txt) is **not** implemented.
 
+### Application layer
+
+The following application protocols are implemented:
+
+  * Simple Network Time Protocol (SNTP)
+
 ## Installation
 
 To use the _smoltcp_ library in your project, add the following to `Cargo.toml`:
@@ -189,6 +195,12 @@ Enable [IPv4] and [IPv6] respectively.
 
 [IPv4]: https://tools.ietf.org/rfc/rfc791.txt
 [IPv6]: https://tools.ietf.org/rfc/rfc8200.txt
+
+### Feature `app-sntp`
+
+Enables `smoltcp::apps::sntp::Client`.
+
+This feature is disabled by default.
 
 ## Hosted usage examples
 
@@ -377,6 +389,23 @@ throughput: 2.556 Gbps
 $ cargo run -q --release --example benchmark tap0 writer
 throughput: 5.301 Gbps
 ```
+
+### examples/sntp.rs
+
+_examples/sntp.rs_ implements a Simple Network Time Protocol client.
+
+The host is assigned the hardware address `02-00-00-00-00-02` and IPv4 address `192.168.69.1`.
+
+Read its [source code](/examples/sntp.rs), then run it as:
+
+```sh
+cargo run --example sntp --features app-sntp -- tap0 SERVER
+```
+
+where `SERVER` is a valid NTP server (eg. `62.112.134.4`).
+
+The SNTP client will send a unicast SNTP request to the server, and if a valid response
+is received, it will print out the timestamp received, converted in Unix seconds.
 
 ## Bare-metal usage examples
 

--- a/examples/sntp.rs
+++ b/examples/sntp.rs
@@ -1,0 +1,87 @@
+#[macro_use]
+extern crate log;
+extern crate env_logger;
+extern crate getopts;
+extern crate smoltcp;
+
+mod utils;
+
+use smoltcp::apps::sntp::Client;
+use smoltcp::iface::{EthernetInterfaceBuilder, NeighborCache, Routes};
+use smoltcp::phy::wait as phy_wait;
+use smoltcp::socket::{SocketSet, UdpPacketMetadata, UdpSocketBuffer};
+use smoltcp::time::Instant;
+use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr, Ipv4Address};
+use std::collections::BTreeMap;
+use std::os::unix::io::AsRawFd;
+use std::str::FromStr;
+
+fn main() {
+    utils::setup_logging("");
+
+    let (mut opts, mut free) = utils::create_options();
+    utils::add_tap_options(&mut opts, &mut free);
+    utils::add_middleware_options(&mut opts, &mut free);
+    free.push("SERVER");
+
+    let mut matches = utils::parse_options(&opts, free);
+    let device = utils::parse_tap_options(&mut matches);
+    let fd = device.as_raw_fd();
+    let device = utils::parse_middleware_options(&mut matches, device, /*loopback=*/ false);
+    let server = IpAddress::from_str(&matches.free[0]).expect("invalid address format");
+
+    let neighbor_cache = NeighborCache::new(BTreeMap::new());
+
+    let sntp_rx_buffer = UdpSocketBuffer::new([UdpPacketMetadata::EMPTY; 1], vec![0; 900]);
+    let sntp_tx_buffer = UdpSocketBuffer::new([UdpPacketMetadata::EMPTY; 1], vec![0; 600]);
+    let mut sockets = SocketSet::new(vec![]);
+
+    let ethernet_addr = EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x02]);
+    let ip_addrs = [IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24)];
+    let default_v4_gw = Ipv4Address::new(192, 168, 69, 100);
+
+    let mut routes_storage = [None; 2];
+    let mut routes = Routes::new(&mut routes_storage[..]);
+    routes.add_default_ipv4_route(default_v4_gw).unwrap();
+
+    let mut iface = EthernetInterfaceBuilder::new(device)
+        .ethernet_addr(ethernet_addr)
+        .neighbor_cache(neighbor_cache)
+        .ip_addrs(ip_addrs)
+        .routes(routes)
+        .finalize();
+
+    let mut sntp = Client::new(
+        &mut sockets,
+        sntp_rx_buffer,
+        sntp_tx_buffer,
+        server,
+        Instant::now(),
+    );
+
+    loop {
+        let timestamp = Instant::now();
+
+        iface
+            .poll(&mut sockets, timestamp)
+            .map(|_| ())
+            .unwrap_or_else(|e| error!("poll error: {}", e));
+
+        let network_time = sntp.poll(&mut sockets, timestamp).unwrap_or_else(|e| {
+            error!("sntp: {}", e);
+            None
+        });
+
+        if let Some(t) = network_time {
+            info!("sntp time: {:?}", t);
+        }
+
+        let mut timeout = sntp.next_poll(timestamp);
+
+        iface
+            .poll_delay(&sockets, timestamp)
+            .map(|sockets_timeout| timeout = sockets_timeout);
+
+        phy_wait(fd, Some(timeout)).unwrap_or_else(|e| error!("wait: {}", e));
+    }
+}

--- a/src/apps/mod.rs
+++ b/src/apps/mod.rs
@@ -1,0 +1,14 @@
+/*! Application-layer protocols.
+
+The `apps` module deals with *application-layer protocols*. It contains the
+communications protocols used in process-to-process communications across an
+IP computer network. Examples include [SSH], [FTP], [SNTP], [HTTP] etc.
+
+[SSH]: https://en.wikipedia.org/wiki/Secure_Shell
+[FTP]: https://en.wikipedia.org/wiki/File_Transfer_Protocol
+[SNTP]: https://en.wikipedia.org/wiki/Network_Time_Protocol#SNTP
+[HTTP]: https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol
+*/
+
+#[cfg(feature = "app-sntp")]
+pub mod sntp;

--- a/src/apps/sntp.rs
+++ b/src/apps/sntp.rs
@@ -1,0 +1,191 @@
+use log::trace;
+use socket::{SocketHandle, SocketSet, UdpSocket, UdpSocketBuffer};
+use time::{Duration, Instant};
+use wire::{
+    IpAddress, IpEndpoint, SntpLeapIndicator, SntpPacket, SntpProtocolMode, SntpRepr, SntpStratum,
+    SntpTimestamp,
+};
+use {Error, Result};
+
+/// Default to one hour interval between requests.
+const REQUEST_INTERVAL: u64 = 60 * 60;
+
+/// Number of seconds between 1970 and Feb 7, 2036 06:28:16 UTC (epoch 1)
+const DIFF_SEC_1970_2036: u32 = 2085978496;
+
+/// IANA port for SNTP servers.
+const SNTP_PORT: u16 = 123;
+
+/// SNTPv4 client.
+///
+/// You must call `Client::poll()` after `Interface::poll()` to send
+/// and receive SNTP packets.
+pub struct Client {
+    udp_handle: SocketHandle,
+    ntp_server: IpAddress,
+    /// When to send next request
+    next_request: Instant,
+}
+
+impl Client {
+    /// Create a new SNTPv4 client performing requests to the specified server.
+    ///
+    /// # Usage
+    ///
+    /// ```rust
+    /// use smoltcp::socket::{SocketSet, UdpSocketBuffer, UdpPacketMetadata};
+    /// use smoltcp::apps::sntp::Client;
+    /// use smoltcp::time::Instant;
+    /// use smoltcp::wire::IpAddress;
+    ///
+    /// let mut sockets = SocketSet::new(vec![]);
+    /// let sntp_rx_buffer = UdpSocketBuffer::new(
+    ///     [UdpPacketMetadata::EMPTY; 1],
+    ///     vec![0; 128]
+    /// );
+    /// let sntp_tx_buffer = UdpSocketBuffer::new(
+    ///     [UdpPacketMetadata::EMPTY; 1],
+    ///     vec![0; 128]
+    /// );
+    /// let mut sntp = Client::new(
+    ///     &mut sockets,
+    ///     sntp_rx_buffer, sntp_tx_buffer,
+    ///     IpAddress::v4(62, 112, 134, 4),
+    ///     Instant::now()
+    /// );
+    /// ```
+    pub fn new<'a, 'b, 'c>(
+        sockets: &mut SocketSet<'a, 'b, 'c>,
+        rx_buffer: UdpSocketBuffer<'b, 'c>,
+        tx_buffer: UdpSocketBuffer<'b, 'c>,
+        ntp_server: IpAddress,
+        now: Instant,
+    ) -> Self
+    where
+        'b: 'c,
+    {
+        let socket = UdpSocket::new(rx_buffer, tx_buffer);
+        let udp_handle = sockets.add(socket);
+
+        trace!("SNTP initialised");
+
+        Client {
+            udp_handle,
+            ntp_server,
+            next_request: now,
+        }
+    }
+
+    /// Returns the duration until the next packet request.
+    ///
+    /// Useful for suspending execution after polling.
+    pub fn next_poll(&self, now: Instant) -> Duration {
+        self.next_request - now
+    }
+
+    /// Processes incoming packets, and sends SNTP requests when timeouts expire.
+    ///
+    /// If a valid response is received, the Unix timestamp (ie. seconds since
+    /// epoch) corresponding to the received NTP timestamp is returned.
+    pub fn poll(&mut self, sockets: &mut SocketSet, now: Instant) -> Result<Option<u32>> {
+        let mut socket = sockets.get::<UdpSocket>(self.udp_handle);
+
+        // Bind the socket if necessary
+        if !socket.is_open() {
+            socket.bind(IpEndpoint {
+                addr: IpAddress::Unspecified,
+                port: SNTP_PORT,
+            })?;
+        }
+
+        // Process incoming packets
+        let timestamp = match socket.recv() {
+            Ok((payload, _)) => self.receive(payload, now),
+            Err(Error::Exhausted) => None,
+            Err(e) => return Err(e),
+        };
+
+        if timestamp.is_some() {
+            Ok(timestamp)
+        } else {
+            // Send request if the timeout has expired
+            if socket.can_send() && now >= self.next_request {
+                self.request(&mut *socket, now)?;
+            }
+            Ok(None)
+        }
+    }
+
+    /// Processes a response from the SNTP server.
+    fn receive(&mut self, data: &[u8], now: Instant) -> Option<u32> {
+        let sntp_packet = match SntpPacket::new_checked(data) {
+            Ok(sntp_packet) => sntp_packet,
+            Err(e) => {
+                net_debug!("SNTP invalid pkt: {:?}", e);
+                return None;
+            }
+        };
+        let sntp_repr = match SntpRepr::parse(&sntp_packet) {
+            Ok(sntp_repr) => sntp_repr,
+            Err(e) => {
+                net_debug!("SNTP error parsing pkt: {:?}", e);
+                return None;
+            }
+        };
+
+        if sntp_repr.protocol_mode != SntpProtocolMode::Server {
+            net_debug!(
+                "Invalid mode in SNTP response: {:?}",
+                sntp_repr.protocol_mode
+            );
+            return None;
+        }
+        if sntp_repr.stratum == SntpStratum::KissOfDeath {
+            net_debug!("SNTP kiss o' death received, updating delay");
+            self.next_request = now + Duration::from_secs(REQUEST_INTERVAL);
+            return None;
+        }
+
+        // Perform conversion from NTP timestamp to Unix timestamp
+        let timestamp = sntp_repr
+            .xmit_timestamp
+            .sec
+            .wrapping_add(DIFF_SEC_1970_2036);
+
+        Some(timestamp)
+    }
+
+    /// Sends a request to the configured SNTP ntp_server.
+    fn request(&mut self, socket: &mut UdpSocket, now: Instant) -> Result<()> {
+        let sntp_repr = SntpRepr {
+            leap_indicator: SntpLeapIndicator::NoWarning,
+            version: 4,
+            protocol_mode: SntpProtocolMode::Client,
+            stratum: SntpStratum::KissOfDeath,
+            poll_interval: 0,
+            precision: 0,
+            root_delay: 0,
+            root_dispersion: 0,
+            ref_identifier: [0, 0, 0, 0],
+            ref_timestamp: SntpTimestamp { sec: 0, frac: 0 },
+            orig_timestamp: SntpTimestamp { sec: 0, frac: 0 },
+            recv_timestamp: SntpTimestamp { sec: 0, frac: 0 },
+            xmit_timestamp: SntpTimestamp { sec: 0, frac: 0 },
+        };
+
+        self.next_request = now + Duration::from_secs(REQUEST_INTERVAL);
+
+        let endpoint = IpEndpoint {
+            addr: self.ntp_server,
+            port: SNTP_PORT,
+        };
+
+        net_trace!("SNTP send request to {}: {:?}", endpoint, sntp_repr);
+
+        let mut packet = socket.send(sntp_repr.buffer_len(), endpoint)?;
+        let mut sntp_packet = SntpPacket::new_unchecked(&mut packet);
+        sntp_repr.emit(&mut sntp_packet)?;
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,7 @@ use core::fmt;
 mod macros;
 mod parsers;
 
+pub mod apps;
 pub mod storage;
 pub mod phy;
 pub mod wire;

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -113,6 +113,9 @@ mod tcp;
 #[cfg(feature = "proto-dhcpv4")]
 pub(crate) mod dhcpv4;
 
+#[cfg(feature = "app-sntp")]
+mod sntp;
+
 pub use self::pretty_print::PrettyPrinter;
 
 #[cfg(feature = "ethernet")]
@@ -222,3 +225,11 @@ pub use self::tcp::{SeqNumber as TcpSeqNumber,
 pub use self::dhcpv4::{Packet as DhcpPacket,
                        Repr as DhcpRepr,
                        MessageType as DhcpMessageType};
+
+#[cfg(feature = "app-sntp")]
+pub use self::sntp::{Packet as SntpPacket,
+                     Repr as SntpRepr,
+                     LeapIndicator as SntpLeapIndicator,
+                     ProtocolMode as SntpProtocolMode,
+                     Timestamp as SntpTimestamp,
+                     Stratum as SntpStratum};

--- a/src/wire/sntp.rs
+++ b/src/wire/sntp.rs
@@ -1,0 +1,568 @@
+// See https://tools.ietf.org/html/rfc4330 for the SNTPv4 specification.
+
+use byteorder::{ByteOrder, NetworkEndian};
+
+use {Error, Result};
+
+enum_with_unknown! {
+    /// The SNTP leap indicator field.
+    pub enum LeapIndicator(u8) {
+        NoWarning = 0,
+        LastMinute61Sec = 1,
+        LastMinute59Sec = 2,
+        AlarmCondition = 3,
+    }
+}
+
+enum_with_unknown! {
+    /// The SNTP protocol mode.
+    ///
+    /// Only unicast mode is supported at the time.
+    pub enum ProtocolMode(u8) {
+        Reserved = 0,
+        SymmetricActive = 1,
+        SymmetricPassive = 2,
+        Client = 3,
+        Server = 4,
+        Broadcast = 5,
+        NtpControlMessage = 6,
+        Private = 7,
+    }
+}
+
+/// The SNTP stratum.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Stratum {
+    KissOfDeath,
+    Primary,
+    Secondary(u8),
+    Reserved(u8),
+}
+
+impl From<u8> for Stratum {
+    fn from(s: u8) -> Self {
+        match s {
+            0 => Stratum::KissOfDeath,
+            1 => Stratum::Primary,
+            2..=15 => Stratum::Secondary(s),
+            _ => Stratum::Reserved(s),
+        }
+    }
+}
+
+impl Into<u8> for Stratum {
+    fn into(self) -> u8 {
+        match self {
+            Stratum::KissOfDeath => 0,
+            Stratum::Primary => 1,
+            Stratum::Secondary(s) | Stratum::Reserved(s) => s,
+        }
+    }
+}
+
+/// An SNTP timestamp, represented as integer and fractional part.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
+pub struct Timestamp {
+    pub(crate) sec: u32,
+    pub(crate) frac: u32,
+}
+
+impl Timestamp {
+    fn parse(buffer: &[u8]) -> Result<Timestamp> {
+        let sec = NetworkEndian::read_u32(buffer.get(0..4).ok_or(Error::Truncated)?);
+        let frac = NetworkEndian::read_u32(buffer.get(4..8).ok_or(Error::Truncated)?);
+        Ok(Timestamp { sec, frac })
+    }
+
+    fn emit(&self, buffer: &mut [u8]) {
+        NetworkEndian::write_u32(&mut buffer[0..4], self.sec);
+        NetworkEndian::write_u32(&mut buffer[4..8], self.frac);
+    }
+}
+
+/// A read/write wrapper around a Simple Network Time Protocol v4 packet buffer.
+#[derive(Debug, PartialEq)]
+pub struct Packet<T: AsRef<[u8]>> {
+    buffer: T,
+}
+
+pub(crate) mod field {
+    #![allow(non_snake_case)]
+    #![allow(unused)]
+
+    use wire::field::*;
+
+    pub const LI_VN_MODE: usize = 0;
+    pub const STRATUM: usize = 1;
+    pub const POLL: usize = 2;
+    pub const PRECISION: usize = 3;
+    pub const ROOT_DELAY: Field = 4..8;
+    pub const ROOT_DISPERSION: Field = 8..12;
+    pub const REFERENCE_IDENTIFIER: Field = 12..16;
+    pub const REFERENCE_TIMESTAMP: Field = 16..24;
+    pub const ORIGINATE_TIMESTAMP: Field = 24..32;
+    pub const RECEIVE_TIMESTAMP: Field = 32..40;
+    pub const TRANSMIT_TIMESTAMP: Field = 40..48;
+    pub const KEY_IDENTIFIER: Field = 48..52;
+    pub const MESSAGE_DIGEST: Field = 52..68;
+
+    // Offsets and masks for LI_VN_MODE bitfield
+    pub const LI_MASK: u8 = 0xc0;
+    pub const LI_SHIFT: u8 = 6;
+    pub const VN_MASK: u8 = 0x38;
+    pub const VN_SHIFT: u8 = 3;
+    pub const MODE_MASK: u8 = 0x07;
+    pub const MODE_SHIFT: u8 = 0x00;
+}
+
+impl<T: AsRef<[u8]>> Packet<T> {
+    /// Imbue a raw octet buffer with SNTP packet structure.
+    pub fn new_unchecked(buffer: T) -> Packet<T> {
+        Packet { buffer }
+    }
+
+    /// Shorthand for a combination of [new_unchecked] and [check_len].
+    ///
+    /// [new_unchecked]: #method.new_unchecked
+    /// [check_len]: #method.check_len
+    pub fn new_checked(buffer: T) -> Result<Packet<T>> {
+        let packet = Self::new_unchecked(buffer);
+        packet.check_len()?;
+        Ok(packet)
+    }
+
+    /// Ensure that no accessor method will panic if called.
+    /// Returns `Err(Error::Truncated)` if the buffer is too short.
+    ///
+    /// [set_header_len]: #method.set_header_len
+    pub fn check_len(&self) -> Result<()> {
+        let len = self.buffer.as_ref().len();
+        if len < field::TRANSMIT_TIMESTAMP.end {
+            Err(Error::Truncated)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Consume the packet, returning the underlying buffer.
+    pub fn into_inner(self) -> T {
+        self.buffer
+    }
+
+    /// Returns the leap indicator of this packet.
+    pub fn leap_indicator(&self) -> LeapIndicator {
+        let data = self.buffer.as_ref();
+        LeapIndicator::from((data[field::LI_VN_MODE] & field::LI_MASK) >> field::LI_SHIFT)
+    }
+
+    /// Returns the version of this packet.
+    pub fn version(&self) -> u8 {
+        let data = self.buffer.as_ref();
+        (data[field::LI_VN_MODE] & field::VN_MASK) >> field::VN_SHIFT
+    }
+
+    /// Returns the protocol mode of this packet.
+    pub fn protocol_mode(&self) -> ProtocolMode {
+        let data = self.buffer.as_ref();
+        ProtocolMode::from((data[field::LI_VN_MODE] & field::MODE_MASK) >> field::MODE_SHIFT)
+    }
+
+    /// Returns the stratum of this packet.
+    pub fn stratum(&self) -> Stratum {
+        self.buffer.as_ref()[field::STRATUM].into()
+    }
+
+    /// Returns the poll interval of this packet.
+    pub fn poll_interval(&self) -> u8 {
+        self.buffer.as_ref()[field::POLL]
+    }
+
+    /// Returns the precision of this packet.
+    pub fn precision(&self) -> i8 {
+        self.buffer.as_ref()[field::PRECISION] as i8
+    }
+
+    /// Returns the root delay of this packet.
+    pub fn root_delay(&self) -> i32 {
+        let data = self.buffer.as_ref();
+        NetworkEndian::read_i32(&data[field::ROOT_DELAY])
+    }
+
+    /// Returns the root dispersion of this packet.
+    pub fn root_dispersion(&self) -> u32 {
+        let data = self.buffer.as_ref();
+        NetworkEndian::read_u32(&data[field::ROOT_DISPERSION])
+    }
+
+    /// Returns the reference identifier of this packet.
+    pub fn ref_identifier(&self) -> [u8; 4] {
+        let d = &self.buffer.as_ref()[field::REFERENCE_IDENTIFIER];
+        [d[0], d[1], d[2], d[3]]
+    }
+
+    /// Returns the reference timestamp of this packet.
+    pub fn ref_timestamp(&self) -> Result<Timestamp> {
+        let data = self.buffer.as_ref();
+        Timestamp::parse(&data[field::REFERENCE_TIMESTAMP])
+    }
+
+    /// Returns the originate timestamp of this packet.
+    pub fn orig_timestamp(&self) -> Result<Timestamp> {
+        let data = self.buffer.as_ref();
+        Timestamp::parse(&data[field::ORIGINATE_TIMESTAMP])
+    }
+
+    /// Returns the receive timestamp of this packet.
+    pub fn recv_timestamp(&self) -> Result<Timestamp> {
+        let data = self.buffer.as_ref();
+        Timestamp::parse(&data[field::RECEIVE_TIMESTAMP])
+    }
+
+    /// Returns the transmit timestamp of this packet.
+    pub fn xmit_timestamp(&self) -> Result<Timestamp> {
+        let data = self.buffer.as_ref();
+        Timestamp::parse(&data[field::TRANSMIT_TIMESTAMP])
+    }
+}
+
+impl<T: AsRef<[u8]> + AsMut<[u8]>> Packet<T> {
+    /// Sets the leap indicator for this packet.
+    pub fn set_leap_indicator(&mut self, li: LeapIndicator) {
+        let data = self.buffer.as_mut();
+        let li: u8 = li.into();
+        data[field::LI_VN_MODE] &= !field::LI_MASK;
+        data[field::LI_VN_MODE] |= li << field::LI_SHIFT;
+    }
+
+    /// Sets the version number for this packet.
+    pub fn set_version(&mut self, vn: u8) {
+        let data = self.buffer.as_mut();
+        data[field::LI_VN_MODE] &= !field::VN_MASK;
+        data[field::LI_VN_MODE] |= vn << field::VN_SHIFT;
+    }
+
+    /// Sets the protocol mode for this packet.
+    pub fn set_protocol_mode(&mut self, mode: ProtocolMode) {
+        let data = self.buffer.as_mut();
+        let mode: u8 = mode.into();
+        data[field::LI_VN_MODE] &= !field::MODE_MASK;
+        data[field::LI_VN_MODE] |= mode << field::MODE_SHIFT;
+    }
+
+    /// Sets the stratum for this packet.
+    pub fn set_stratum(&mut self, stratum: Stratum) {
+        self.buffer.as_mut()[field::STRATUM] = stratum.into();
+    }
+
+    /// Sets the poll interval for this packet.
+    pub fn set_poll_interval(&mut self, poll: u8) {
+        self.buffer.as_mut()[field::POLL] = poll;
+    }
+
+    /// Sets the precision for this packet.
+    pub fn set_precision(&mut self, precision: i8) {
+        self.buffer.as_mut()[field::PRECISION] = precision as u8;
+    }
+
+    /// Sets the root delay for this packet.
+    pub fn set_root_delay(&mut self, delay: i32) {
+        let data = &mut self.buffer.as_mut()[field::ROOT_DELAY];
+        NetworkEndian::write_i32(data, delay);
+    }
+
+    /// Sets the root dispersion for this packet.
+    pub fn set_root_dispersion(&mut self, disp: u32) {
+        let data = &mut self.buffer.as_mut()[field::ROOT_DISPERSION];
+        NetworkEndian::write_u32(data, disp);
+    }
+
+    /// Sets the reference identifier for this packet.
+    pub fn set_ref_identifier(&mut self, id: [u8; 4]) {
+        self.buffer.as_mut()[field::REFERENCE_IDENTIFIER].copy_from_slice(&id[..]);
+    }
+
+    /// Sets the reference timestamp for this packet.
+    pub fn set_ref_timestamp(&mut self, ts: Timestamp) {
+        let field = &mut self.buffer.as_mut()[field::REFERENCE_TIMESTAMP];
+        ts.emit(field);
+    }
+
+    /// Sets the originate timestamp for this packet.
+    pub fn set_orig_timestamp(&mut self, ts: Timestamp) {
+        let field = &mut self.buffer.as_mut()[field::ORIGINATE_TIMESTAMP];
+        ts.emit(field);
+    }
+
+    /// Sets the receive timestamp for this packet.
+    pub fn set_recv_timestamp(&mut self, ts: Timestamp) {
+        let field = &mut self.buffer.as_mut()[field::RECEIVE_TIMESTAMP];
+        ts.emit(field);
+    }
+    /// Sets the transmit timestamp for this packet.
+    pub fn set_xmit_timestamp(&mut self, ts: Timestamp) {
+        let field = &mut self.buffer.as_mut()[field::TRANSMIT_TIMESTAMP];
+        ts.emit(field);
+    }
+}
+
+/// A high-level representation of a Simple Network Time Protocol v4 packet.
+///
+/// SNTPv4 messages have the following layout
+/// (see [RFC 4330](https://tools.ietf.org/html/rfc4330) for details):
+///
+/// ```no_rust
+///                      1                   2                   3
+///  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |LI | VN  |Mode |    Stratum    |     Poll      |   Precision    |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |                          Root  Delay                           |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |                       Root  Dispersion                         |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |                     Reference Identifier                       |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |                                                                |
+/// |                    Reference Timestamp (64)                    |
+/// |                                                                |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |                                                                |
+/// |                    Originate Timestamp (64)                    |
+/// |                                                                |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |                                                                |
+/// |                     Receive Timestamp (64)                     |
+/// |                                                                |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |                                                                |
+/// |                     Transmit Timestamp (64)                    |
+/// |                                                                |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |                 Key Identifier (optional) (32)                 |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |                                                                |
+/// |                                                                |
+/// |                 Message Digest (optional) (128)                |
+/// |                                                                |
+/// |                                                                |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// ```
+///
+/// Note that most of these fields are ignored right now, as only unicast mode
+/// is supported, without any advanced features (delays, response checks, etc.).
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct Repr {
+    /// Leap indicator for leap second insertion/deletion.
+    pub leap_indicator: LeapIndicator,
+    /// Version number.
+    pub version: u8,
+    /// Protocol mode. Only unicast mode is supported.
+    pub protocol_mode: ProtocolMode,
+    /// Stratum of the server in an SNTP response.
+    pub stratum: Stratum,
+    /// Maximum interval between successive messages.
+    pub poll_interval: u8,
+    /// Precision of the system clock in seconds.
+    pub precision: i8,
+    /// Total roundtrip delay to the primary reference source.
+    /// Signed fixed-point in 16.16 format.
+    pub root_delay: i32,
+    /// Maximum error due to clock frequency tolerances.
+    /// Unsigned fixed-point in 16.16 format.
+    pub root_dispersion: u32,
+    /// Bitstring identifying the particular reference source.
+    pub ref_identifier: [u8; 4],
+    /// The time at which the system clock was last set or corrected.
+    pub ref_timestamp: Timestamp,
+    /// The time at which the request departed the client for the server.
+    pub orig_timestamp: Timestamp,
+    /// The time at which the request arrived at the server
+    /// or the reply arrived at the client.
+    pub recv_timestamp: Timestamp,
+    /// The time at which the request departed the client
+    /// or the reply departed the server.
+    pub xmit_timestamp: Timestamp,
+}
+
+impl Repr {
+    /// Return the length of a packet that will be emitted
+    /// from this high-level representation.
+    pub fn buffer_len(&self) -> usize {
+        field::KEY_IDENTIFIER.start
+    }
+
+    /// Parse an SNTP packet and return a high-level representation.
+    pub fn parse<T>(packet: &Packet<&T>) -> Result<Self>
+    where
+        T: AsRef<[u8]> + ?Sized,
+    {
+        Ok(Repr {
+            leap_indicator: packet.leap_indicator(),
+            version: packet.version(),
+            protocol_mode: packet.protocol_mode(),
+            stratum: packet.stratum(),
+            poll_interval: packet.poll_interval(),
+            precision: packet.precision(),
+            root_delay: packet.root_delay(),
+            root_dispersion: packet.root_dispersion(),
+            ref_identifier: packet.ref_identifier(),
+            ref_timestamp: packet.ref_timestamp()?,
+            orig_timestamp: packet.orig_timestamp()?,
+            recv_timestamp: packet.recv_timestamp()?,
+            xmit_timestamp: packet.xmit_timestamp()?,
+        })
+    }
+
+    /// Emit a high-level representation into an SNTP packet.
+    pub fn emit<T>(&self, packet: &mut Packet<&mut T>) -> Result<()>
+    where
+        T: AsRef<[u8]> + AsMut<[u8]> + ?Sized,
+    {
+        packet.set_leap_indicator(self.leap_indicator);
+        packet.set_version(self.version);
+        packet.set_protocol_mode(self.protocol_mode);
+        packet.set_stratum(self.stratum);
+        packet.set_poll_interval(self.poll_interval);
+        packet.set_precision(self.precision);
+        packet.set_root_delay(self.root_delay);
+        packet.set_root_dispersion(self.root_dispersion);
+        packet.set_ref_identifier(self.ref_identifier);
+        packet.set_ref_timestamp(self.ref_timestamp);
+        packet.set_orig_timestamp(self.orig_timestamp);
+        packet.set_recv_timestamp(self.recv_timestamp);
+        packet.set_xmit_timestamp(self.xmit_timestamp);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    static PACKET_BYTES: [u8; 48] = [
+        0x24, 0x02, 0x00, 0xe6, 0x00, 0x00, 0x01, 0x20, 0x00, 0x00, 0x00, 0x6f, 0x50, 0x42, 0xe0,
+        0x02, 0xe2, 0x6c, 0x32, 0xf1, 0x0e, 0xd5, 0xfe, 0xa9, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0xe2, 0x6c, 0x35, 0x11, 0x6a, 0x8c, 0xe6, 0x47, 0xe2, 0x6c, 0x35, 0x11, 0x6a,
+        0x8d, 0xf8, 0x8f,
+    ];
+
+    #[test]
+    fn test_deconstruct() {
+        let packet = Packet::new_unchecked(&PACKET_BYTES[..]);
+        assert_eq!(packet.leap_indicator(), LeapIndicator::NoWarning);
+        assert_eq!(packet.version(), 4);
+        assert_eq!(packet.protocol_mode(), ProtocolMode::Server);
+        assert_eq!(packet.stratum(), Stratum::Secondary(2));
+        assert_eq!(packet.poll_interval(), 0);
+        assert_eq!(packet.precision(), -26);
+        assert_eq!(packet.root_delay(), 0x120);
+        assert_eq!(packet.root_dispersion(), 0x6f);
+        assert_eq!(packet.ref_identifier(), [80, 66, 224, 2]);
+        assert_eq!(
+            packet.ref_timestamp(),
+            Ok(Timestamp {
+                sec: 0xe26c32f1,
+                frac: 0x0ed5fea9,
+            })
+        );
+        assert_eq!(
+            packet.orig_timestamp(),
+            Ok(Timestamp {
+                sec: 0x00000000,
+                frac: 0x00000000
+            })
+        );
+        assert_eq!(
+            packet.recv_timestamp(),
+            Ok(Timestamp {
+                sec: 0xe26c3511,
+                frac: 0x6a8ce647,
+            })
+        );
+        assert_eq!(
+            packet.xmit_timestamp(),
+            Ok(Timestamp {
+                sec: 0xe26c3511,
+                frac: 0x6a8df88f
+            })
+        )
+    }
+
+    #[test]
+    fn test_construct() {
+        let mut bytes = vec![0xa5; 48];
+        let mut packet = Packet::new_unchecked(&mut bytes);
+        packet.set_leap_indicator(LeapIndicator::NoWarning);
+        packet.set_version(4);
+        packet.set_protocol_mode(ProtocolMode::Server);
+        packet.set_stratum(Stratum::Secondary(2));
+        packet.set_poll_interval(0);
+        packet.set_precision(-26);
+        packet.set_root_delay(0x120);
+        packet.set_root_dispersion(0x6f);
+        packet.set_ref_identifier([80, 66, 224, 2]);
+        packet.set_ref_timestamp(Timestamp {
+            sec: 0xe26c32f1,
+            frac: 0x0ed5fea9,
+        });
+        packet.set_orig_timestamp(Timestamp {
+            sec: 0x00000000,
+            frac: 0x00000000,
+        });
+        packet.set_recv_timestamp(Timestamp {
+            sec: 0xe26c3511,
+            frac: 0x6a8ce647,
+        });
+        packet.set_xmit_timestamp(Timestamp {
+            sec: 0xe26c3511,
+            frac: 0x6a8df88f,
+        });
+        assert_eq!(&packet.into_inner()[..], &PACKET_BYTES[..]);
+    }
+
+    fn packet_repr() -> Repr {
+        Repr {
+            leap_indicator: LeapIndicator::NoWarning,
+            version: 4,
+            protocol_mode: ProtocolMode::Server,
+            stratum: Stratum::Secondary(2),
+            poll_interval: 0,
+            precision: -26,
+            root_delay: 0x120,
+            root_dispersion: 0x6f,
+            ref_identifier: [80, 66, 224, 2],
+            ref_timestamp: Timestamp {
+                sec: 0xe26c32f1,
+                frac: 0x0ed5fea9,
+            },
+            orig_timestamp: Timestamp {
+                sec: 0x00000000,
+                frac: 0x00000000,
+            },
+            recv_timestamp: Timestamp {
+                sec: 0xe26c3511,
+                frac: 0x6a8ce647,
+            },
+            xmit_timestamp: Timestamp {
+                sec: 0xe26c3511,
+                frac: 0x6a8df88f,
+            },
+        }
+    }
+
+    #[test]
+    fn test_parse() {
+        let packet = Packet::new_unchecked(&PACKET_BYTES[..]);
+        let repr = Repr::parse(&packet).unwrap();
+        assert_eq!(repr, packet_repr());
+    }
+
+    #[test]
+    fn test_emit() {
+        let mut bytes = vec![0xa5; 48];
+        let mut packet = Packet::new_unchecked(&mut bytes);
+        packet_repr().emit(&mut packet).unwrap();
+        assert_eq!(&packet.into_inner()[..], &PACKET_BYTES[..]);
+    }
+}


### PR DESCRIPTION
Hi, this is an attempt at implementing a Simple Network Time Protocol (SNTP) over UDP sockets.

The client is pretty barebones: only unicast mode with a single server is supported, more advanced stuff like root delay and dispersion are skipped, and no adjustments are performed on the received timestamp.

Even so, I've tested it and it works pretty well, with an accuracy at least in the sub-second range. For timekeeping in embedded applications, which I plan to use it on, should be plenty good. However, let me know if more features need to be added to make it worth merging.

I've also taken the liberty to create an additional `apps` module for application-layer protocols, in case anyone decides to implement something else like TFTP or similar, to keep the crate more tidy. I'm not married to the idea though.
