### PR TITLE
Re-export dhcp::clientv4::Config

### DIFF
--- a/src/dhcp/mod.rs
+++ b/src/dhcp/mod.rs
@@ -2,4 +2,4 @@ pub const UDP_SERVER_PORT: u16 = 67;
 pub const UDP_CLIENT_PORT: u16 = 68;
 
 mod clientv4;
-pub use self::clientv4::Client as Dhcpv4Client;
+pub use self::clientv4::{Client as Dhcpv4Client, Config as Dhcpv4Config};


### PR DESCRIPTION
The dhcpv4 client currently doesn't expose the Config struct returned by the poll function.