### PR TITLE
Add support for IP mediums, v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,35 +12,41 @@ matrix:
       env: FEATURES='default' MODE='test'
     ### Test select feature permutations, chosen to be as orthogonal as possible
     - rust: nightly
-      env: FEATURES='std ethernet phy-raw_socket proto-ipv6 socket-udp' MODE='test'
+      env: FEATURES='std medium-ethernet phy-raw_socket proto-ipv6 socket-udp' MODE='test'
     - rust: nightly
-      env: FEATURES='std ethernet phy-tap_interface proto-ipv6 socket-udp' MODE='test'
+      env: FEATURES='std medium-ethernet phy-tap_interface proto-ipv6 socket-udp' MODE='test'
     - rust: nightly
-      env: FEATURES='std ethernet proto-ipv4 proto-igmp socket-raw' MODE='test'
+      env: FEATURES='std medium-ethernet proto-ipv4 proto-igmp socket-raw' MODE='test'
     - rust: nightly
-      env: FEATURES='std ethernet proto-ipv4 socket-udp socket-tcp' MODE='test'
+      env: FEATURES='std medium-ethernet proto-ipv4 socket-udp socket-tcp' MODE='test'
     - rust: nightly
-      env: FEATURES='std ethernet proto-ipv4 proto-dhcpv4 socket-udp' MODE='test'
+      env: FEATURES='std medium-ethernet proto-ipv4 proto-dhcpv4 socket-udp' MODE='test'
     - rust: nightly
-      env: FEATURES='std ethernet proto-ipv6 socket-udp' MODE='test'
+      env: FEATURES='std medium-ethernet proto-ipv6 socket-udp' MODE='test'
     - rust: nightly
-      env: FEATURES='std ethernet proto-ipv6 socket-tcp' MODE='test'
+      env: FEATURES='std medium-ethernet proto-ipv6 socket-tcp' MODE='test'
     - rust: nightly
-      env: FEATURES='std ethernet proto-ipv4 socket-icmp socket-tcp' MODE='test'
+      env: FEATURES='std medium-ethernet proto-ipv4 socket-icmp socket-tcp' MODE='test'
     - rust: nightly
-      env: FEATURES='std ethernet proto-ipv6 socket-icmp socket-tcp' MODE='test'
+      env: FEATURES='std medium-ethernet proto-ipv6 socket-icmp socket-tcp' MODE='test'
     ### Test select feature permutations, chosen to be as aggressive as possible
     - rust: nightly
-      env: FEATURES='ethernet proto-ipv4 proto-ipv6 socket-raw socket-udp socket-tcp socket-icmp std'
+      env: FEATURES='medium-ethernet medium-ip proto-ipv4 proto-ipv6 proto-dhcpv4 proto-igmp socket-raw socket-udp socket-tcp socket-icmp std'
         MODE='test'
     - rust: nightly
-      env: FEATURES='ethernet proto-ipv4 proto-ipv6 socket-raw socket-udp socket-tcp socket-icmp alloc'
+      env: FEATURES='medium-ip proto-ipv4 proto-ipv6 proto-igmp socket-raw socket-udp socket-tcp socket-icmp std'
+        MODE='test'
+    - rust: nightly
+      env: FEATURES='medium-ethernet proto-ipv4 proto-ipv6 socket-raw socket-udp socket-tcp socket-icmp std'
+        MODE='test'
+    - rust: nightly
+      env: FEATURES='medium-ethernet proto-ipv4 proto-ipv6 socket-raw socket-udp socket-tcp socket-icmp alloc'
         MODE='test'
     - rust: nightly
       env: FEATURES='proto-ipv4 proto-ipv6 socket-raw socket-udp socket-tcp socket-icmp alloc'
         MODE='test'
     - rust: nightly
-      env: FEATURES='ethernet proto-ipv4 proto-ipv6 proto-igmp proto-dhcpv4 socket-raw socket-udp socket-tcp socket-icmp'
+      env: FEATURES='medium-ethernet proto-ipv4 proto-ipv6 proto-igmp proto-dhcpv4 socket-raw socket-udp socket-tcp socket-icmp'
         MODE='build'
     - rust: nightly
       env: MODE='fuzz run' ARGS='packet_parser -- -max_len=1536 -max_total_time=30'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,5 +95,9 @@ required-features = ["std", "phy-tap_interface", "proto-ipv4", "socket-raw", "so
 name = "dhcp_client"
 required-features = ["std", "phy-tap_interface", "proto-ipv4", "proto-dhcpv4", "socket-raw"]
 
+[[example]]
+name = "tunhttpclient"
+required-features = ["std", "phy-tun_interface", "proto-ipv4", "proto-ipv6", "socket-tcp"]
+
 [profile.release]
 debug = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ verbose = []
 ethernet = []
 "phy-raw_socket" = ["std", "libc"]
 "phy-tap_interface" = ["std", "libc"]
+"phy-tun_interface" = ["std", "libc"]
 "proto-ipv4" = []
 "proto-igmp" = ["proto-ipv4"]
 "proto-dhcpv4" = ["proto-ipv4", "socket-raw"]
@@ -45,7 +46,7 @@ ethernet = []
 default = [
   "std", "log", # needed for `cargo test --no-default-features --features default` :/
   "ethernet",
-  "phy-raw_socket", "phy-tap_interface",
+  "phy-raw_socket", "phy-tap_interface", "phy-tun_interface",
   "proto-ipv4", "proto-igmp", "proto-ipv6",
   "socket-raw", "socket-icmp", "socket-udp", "socket-tcp"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,8 @@ url = "1.0"
 std = ["managed/std"]
 alloc = ["managed/alloc"]
 verbose = []
-ethernet = []
+"medium-ethernet" = []
+"medium-ip" = []
 "phy-raw_socket" = ["std", "libc"]
 "phy-tap_interface" = ["std", "libc"]
 "phy-tun_interface" = ["std", "libc"]
@@ -45,7 +46,7 @@ ethernet = []
 "socket-icmp" = []
 default = [
   "std", "log", # needed for `cargo test --no-default-features --features default` :/
-  "ethernet",
+  "medium-ethernet", "medium-ip",
   "phy-raw_socket", "phy-tap_interface", "phy-tun_interface",
   "proto-ipv4", "proto-igmp", "proto-ipv6",
   "socket-raw", "socket-icmp", "socket-udp", "socket-tcp"

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -17,7 +17,7 @@ use std::net::TcpStream;
 use std::os::unix::io::AsRawFd;
 use smoltcp::phy::wait as phy_wait;
 use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr};
-use smoltcp::iface::{NeighborCache, EthernetInterfaceBuilder};
+use smoltcp::iface::{NeighborCache, InterfaceBuilder};
 use smoltcp::socket::SocketSet;
 use smoltcp::socket::{TcpSocket, TcpSocketBuffer};
 use smoltcp::time::{Duration, Instant};
@@ -94,7 +94,7 @@ fn main() {
 
     let ethernet_addr = EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]);
     let ip_addrs = [IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24)];
-    let mut iface = EthernetInterfaceBuilder::new(device)
+    let mut iface = InterfaceBuilder::new(device)
             .ethernet_addr(ethernet_addr)
             .neighbor_cache(neighbor_cache)
             .ip_addrs(ip_addrs)

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -11,7 +11,7 @@ use std::collections::BTreeMap;
 use std::os::unix::io::AsRawFd;
 use smoltcp::phy::wait as phy_wait;
 use smoltcp::wire::{EthernetAddress, Ipv4Address, IpAddress, IpCidr};
-use smoltcp::iface::{NeighborCache, EthernetInterfaceBuilder, Routes};
+use smoltcp::iface::{NeighborCache, InterfaceBuilder, Routes};
 use smoltcp::socket::{SocketSet, TcpSocket, TcpSocketBuffer};
 use smoltcp::time::Instant;
 
@@ -43,7 +43,7 @@ fn main() {
     let mut routes_storage = [None; 1];
     let mut routes = Routes::new(&mut routes_storage[..]);
     routes.add_default_ipv4_route(default_v4_gw).unwrap();
-    let mut iface = EthernetInterfaceBuilder::new(device)
+    let mut iface = InterfaceBuilder::new(device)
             .ethernet_addr(ethernet_addr)
             .neighbor_cache(neighbor_cache)
             .ip_addrs(ip_addrs)

--- a/examples/dhcp_client.rs
+++ b/examples/dhcp_client.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeMap;
 use std::os::unix::io::AsRawFd;
 use smoltcp::phy::wait as phy_wait;
 use smoltcp::wire::{EthernetAddress, Ipv4Address, IpCidr, Ipv4Cidr};
-use smoltcp::iface::{NeighborCache, EthernetInterfaceBuilder, Routes};
+use smoltcp::iface::{NeighborCache, InterfaceBuilder, Routes};
 use smoltcp::socket::{SocketSet, RawSocketBuffer, RawPacketMetadata};
 use smoltcp::time::Instant;
 use smoltcp::dhcp::Dhcpv4Client;
@@ -33,7 +33,7 @@ fn main() {
     let ip_addrs = [IpCidr::new(Ipv4Address::UNSPECIFIED.into(), 0)];
     let mut routes_storage = [None; 1];
     let routes = Routes::new(&mut routes_storage[..]);
-    let mut iface = EthernetInterfaceBuilder::new(device)
+    let mut iface = InterfaceBuilder::new(device)
             .ethernet_addr(ethernet_addr)
             .neighbor_cache(neighbor_cache)
             .ip_addrs(ip_addrs)

--- a/examples/httpclient.rs
+++ b/examples/httpclient.rs
@@ -14,7 +14,7 @@ use std::os::unix::io::AsRawFd;
 use url::Url;
 use smoltcp::phy::wait as phy_wait;
 use smoltcp::wire::{EthernetAddress, Ipv4Address, Ipv6Address, IpAddress, IpCidr};
-use smoltcp::iface::{NeighborCache, EthernetInterfaceBuilder, Routes};
+use smoltcp::iface::{NeighborCache, InterfaceBuilder, Routes};
 use smoltcp::socket::{SocketSet, TcpSocket, TcpSocketBuffer};
 use smoltcp::time::Instant;
 
@@ -51,7 +51,7 @@ fn main() {
     let mut routes = Routes::new(&mut routes_storage[..]);
     routes.add_default_ipv4_route(default_v4_gw).unwrap();
     routes.add_default_ipv6_route(default_v6_gw).unwrap();
-    let mut iface = EthernetInterfaceBuilder::new(device)
+    let mut iface = InterfaceBuilder::new(device)
             .ethernet_addr(ethernet_addr)
             .neighbor_cache(neighbor_cache)
             .ip_addrs(ip_addrs)

--- a/examples/loopback.rs
+++ b/examples/loopback.rs
@@ -16,9 +16,9 @@ extern crate getopts;
 mod utils;
 
 use core::str;
-use smoltcp::phy::Loopback;
+use smoltcp::phy::{Loopback, Medium};
 use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr};
-use smoltcp::iface::{NeighborCache, EthernetInterfaceBuilder};
+use smoltcp::iface::{NeighborCache, InterfaceBuilder};
 use smoltcp::socket::{SocketSet, TcpSocket, TcpSocketBuffer};
 use smoltcp::time::{Duration, Instant};
 
@@ -72,7 +72,7 @@ mod mock {
 
 fn main() {
     let clock = mock::Clock::new();
-    let device = Loopback::new();
+    let device = Loopback::new(Medium::Ethernet);
 
     #[cfg(feature = "std")]
     let device = {
@@ -92,7 +92,7 @@ fn main() {
     let mut neighbor_cache = NeighborCache::new(&mut neighbor_cache_entries[..]);
 
     let mut ip_addrs = [IpCidr::new(IpAddress::v4(127, 0, 0, 1), 8)];
-    let mut iface = EthernetInterfaceBuilder::new(device)
+    let mut iface = InterfaceBuilder::new(device)
             .ethernet_addr(EthernetAddress::default())
             .neighbor_cache(neighbor_cache)
             .ip_addrs(ip_addrs)

--- a/examples/multicast.rs
+++ b/examples/multicast.rs
@@ -12,7 +12,7 @@ use std::os::unix::io::AsRawFd;
 use smoltcp::phy::wait as phy_wait;
 use smoltcp::wire::{EthernetAddress, IpVersion, IpProtocol, IpAddress, IpCidr, Ipv4Address,
                     Ipv4Packet, IgmpPacket, IgmpRepr};
-use smoltcp::iface::{NeighborCache, EthernetInterfaceBuilder};
+use smoltcp::iface::{NeighborCache, InterfaceBuilder};
 use smoltcp::socket::{SocketSet,
                       RawSocket, RawSocketBuffer, RawPacketMetadata,
                       UdpSocket, UdpSocketBuffer, UdpPacketMetadata};
@@ -42,7 +42,7 @@ fn main() {
     let ethernet_addr = EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x02]);
     let ip_addr = IpCidr::new(IpAddress::from(local_addr), 24);
     let mut ipv4_multicast_storage = [None; 1];
-    let mut iface = EthernetInterfaceBuilder::new(device)
+    let mut iface = InterfaceBuilder::new(device)
             .ethernet_addr(ethernet_addr)
             .neighbor_cache(neighbor_cache)
             .ip_addrs([ip_addr])

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -17,7 +17,7 @@ use smoltcp::phy::wait as phy_wait;
 use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr,
                     Ipv6Address, Icmpv6Repr, Icmpv6Packet,
                     Ipv4Address, Icmpv4Repr, Icmpv4Packet};
-use smoltcp::iface::{NeighborCache, EthernetInterfaceBuilder, Routes};
+use smoltcp::iface::{NeighborCache, InterfaceBuilder, Routes};
 use smoltcp::socket::{SocketSet, IcmpSocket, IcmpSocketBuffer, IcmpPacketMetadata, IcmpEndpoint};
 use std::collections::HashMap;
 use byteorder::{ByteOrder, NetworkEndian};
@@ -103,7 +103,7 @@ fn main() {
     let mut routes = Routes::new(&mut routes_storage[..]);
     routes.add_default_ipv4_route(default_v4_gw).unwrap();
     routes.add_default_ipv6_route(default_v6_gw).unwrap();
-    let mut iface = EthernetInterfaceBuilder::new(device)
+    let mut iface = InterfaceBuilder::new(device)
             .ethernet_addr(ethernet_addr)
             .ip_addrs(ip_addrs)
             .routes(routes)

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -12,7 +12,7 @@ use std::fmt::Write;
 use std::os::unix::io::AsRawFd;
 use smoltcp::phy::wait as phy_wait;
 use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr};
-use smoltcp::iface::{NeighborCache, EthernetInterfaceBuilder};
+use smoltcp::iface::{NeighborCache, InterfaceBuilder};
 use smoltcp::socket::SocketSet;
 use smoltcp::socket::{UdpSocket, UdpSocketBuffer, UdpPacketMetadata};
 use smoltcp::socket::{TcpSocket, TcpSocketBuffer};
@@ -58,7 +58,7 @@ fn main() {
         IpCidr::new(IpAddress::v6(0xfdaa, 0, 0, 0, 0, 0, 0, 1), 64),
         IpCidr::new(IpAddress::v6(0xfe80, 0, 0, 0, 0, 0, 0, 1), 64)
     ];
-    let mut iface = EthernetInterfaceBuilder::new(device)
+    let mut iface = InterfaceBuilder::new(device)
             .ethernet_addr(ethernet_addr)
             .neighbor_cache(neighbor_cache)
             .ip_addrs(ip_addrs)

--- a/examples/tunhttpclient.rs
+++ b/examples/tunhttpclient.rs
@@ -1,0 +1,124 @@
+#[macro_use]
+extern crate log;
+extern crate env_logger;
+extern crate getopts;
+extern crate rand;
+extern crate url;
+extern crate smoltcp;
+
+mod utils;
+
+use smoltcp::phy::wait as phy_wait;
+use std::str::{self, FromStr};
+use std::collections::BTreeMap;
+use std::os::unix::io::AsRawFd;
+use url::Url;
+use smoltcp::wire::{Ipv4Address, Ipv6Address, IpAddress, IpCidr};
+use smoltcp::iface::{NeighborCache, InterfaceBuilder, Routes};
+use smoltcp::socket::{SocketSet, TcpSocket, TcpSocketBuffer};
+use smoltcp::time::Instant;
+use smoltcp::phy::TunInterface;
+
+fn main() {
+    /*
+        Usage:
+
+        Create tun1:
+
+        sudo ip tuntap add dev tun1 mode tun user `id -un`
+        sudo ip link set dev tun1 up
+        sudo ip addr add dev tun1 local 192.168.69.0 remote 192.168.69.1
+        sudo iptables -t filter -I FORWARD -i tun1 -o eth0 -j ACCEPT
+        sudo iptables -t filter -I FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+        sudo iptables -t nat -I POSTROUTING -o eth0 -j MASQUERADE
+        sudo sysctl net.ipv4.ip_forward=1
+
+        ./tunhttpclient 172.217.28.238 http://google.com
+
+        You should get HTML from google (IP might change throughout history, ping to see)
+    */
+    utils::setup_logging("");
+
+    let (mut opts, mut free) = utils::create_options();
+    utils::add_middleware_options(&mut opts, &mut free);
+    free.push("ADDRESS");
+    free.push("URL");
+
+    let mut matches = utils::parse_options(&opts, free);
+    let device = TunInterface::new("tun1").unwrap();
+    let fd = device.as_raw_fd();
+    let device = utils::parse_middleware_options(&mut matches, device, /*loopback=*/false);
+    let address = IpAddress::from_str(&matches.free[0]).expect("invalid address format");
+    let url = Url::parse(&matches.free[1]).expect("invalid url format");
+
+    let tcp_rx_buffer = TcpSocketBuffer::new(vec![0; 1024]);
+    let tcp_tx_buffer = TcpSocketBuffer::new(vec![0; 1024]);
+    let tcp_socket = TcpSocket::new(tcp_rx_buffer, tcp_tx_buffer);
+
+    let ip_addrs = [IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24),
+                    IpCidr::new(IpAddress::v6(0xfdaa, 0, 0, 0, 0, 0, 0, 1), 64),
+                    IpCidr::new(IpAddress::v6(0xfe80, 0, 0, 0, 0, 0, 0, 1), 64)];
+    let default_v4_gw = Ipv4Address::new(192, 168, 69, 100);
+    let default_v6_gw = Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 0x100);
+    let mut routes_storage = [None; 2];
+    let mut routes = Routes::new(&mut routes_storage[..]);
+    routes.add_default_ipv4_route(default_v4_gw).unwrap();
+    routes.add_default_ipv6_route(default_v6_gw).unwrap();
+    let mut iface = InterfaceBuilder::new(device)
+            .ip_addrs(ip_addrs)
+            .routes(routes)
+            .finalize();
+
+    let mut sockets = SocketSet::new(vec![]);
+    let tcp_handle = sockets.add(tcp_socket);
+
+    enum State { Connect, Request, Response };
+    let mut state = State::Connect;
+
+    loop {
+        let timestamp = Instant::now();
+        match iface.poll(&mut sockets, timestamp) {
+            Ok(_) => {},
+            Err(e) => {
+                debug!("poll error: {}",e);
+            }
+        }
+
+        {
+            let mut socket = sockets.get::<TcpSocket>(tcp_handle);
+
+            state = match state {
+                State::Connect if !socket.is_active() => {
+                    debug!("connecting");
+                    let local_port = 49152 + rand::random::<u16>() % 16384;
+                    socket.connect((address, url.port().unwrap_or(80)), local_port).unwrap();
+                    State::Request
+                }
+                State::Request if socket.may_send() => {
+                    debug!("sending request");
+                    let http_get = "GET ".to_owned() + url.path() + " HTTP/1.1\r\n";
+                    socket.send_slice(http_get.as_ref()).expect("cannot send");
+                    let http_host = "Host: ".to_owned() + url.host_str().unwrap() + "\r\n";
+                    socket.send_slice(http_host.as_ref()).expect("cannot send");
+                    socket.send_slice(b"Connection: close\r\n").expect("cannot send");
+                    socket.send_slice(b"\r\n").expect("cannot send");
+                    State::Response
+                }
+                State::Response if socket.can_recv() => {
+                    socket.recv(|data| {
+                        println!("{}", str::from_utf8(data).unwrap_or("(invalid utf8)"));
+                        (data.len(), ())
+                    }).unwrap();
+                    State::Response
+                }
+                State::Response if !socket.may_recv() => {
+                    debug!("received complete response");
+                    break
+                }
+                _ => state
+            }
+        }
+        
+        phy_wait(fd, iface.poll_delay(&sockets, timestamp)).expect("wait error");
+    }
+}

--- a/fuzz/fuzz_targets/tcp_headers.rs
+++ b/fuzz/fuzz_targets/tcp_headers.rs
@@ -9,7 +9,7 @@ use core::cmp;
 use smoltcp::phy::Loopback;
 use smoltcp::wire::{EthernetAddress, EthernetFrame, EthernetProtocol};
 use smoltcp::wire::{IpAddress, IpCidr, Ipv4Packet, Ipv6Packet, TcpPacket};
-use smoltcp::iface::{NeighborCache, EthernetInterfaceBuilder};
+use smoltcp::iface::{NeighborCache, InterfaceBuilder};
 use smoltcp::socket::{SocketSet, TcpSocket, TcpSocketBuffer};
 use smoltcp::time::{Duration, Instant};
 
@@ -130,7 +130,7 @@ fuzz_target!(|data: &[u8]| {
     let neighbor_cache = NeighborCache::new(&mut neighbor_cache_entries[..]);
 
     let ip_addrs = [IpCidr::new(IpAddress::v4(127, 0, 0, 1), 8)];
-    let mut iface = EthernetInterfaceBuilder::new(device)
+    let mut iface = InterfaceBuilder::new(device)
             .ethernet_addr(EthernetAddress::default())
             .neighbor_cache(neighbor_cache)
             .ip_addrs(ip_addrs)

--- a/fuzz/fuzz_targets/tcp_headers.rs
+++ b/fuzz/fuzz_targets/tcp_headers.rs
@@ -6,7 +6,7 @@ use std as core;
 extern crate getopts;
 
 use core::cmp;
-use smoltcp::phy::Loopback;
+use smoltcp::phy::{Loopback, Medium};
 use smoltcp::wire::{EthernetAddress, EthernetFrame, EthernetProtocol};
 use smoltcp::wire::{IpAddress, IpCidr, Ipv4Packet, Ipv6Packet, TcpPacket};
 use smoltcp::iface::{NeighborCache, InterfaceBuilder};
@@ -118,7 +118,7 @@ fuzz_target!(|data: &[u8]| {
         utils::add_middleware_options(&mut opts, &mut free);
 
         let mut matches = utils::parse_options(&opts, free);
-        let device = utils::parse_middleware_options(&mut matches, Loopback::new(),
+        let device = utils::parse_middleware_options(&mut matches, Loopback::new(Medium::Ethernet),
                                                      /*loopback=*/true);
 
         smoltcp::phy::FuzzInjector::new(device,

--- a/src/dhcp/clientv4.rs
+++ b/src/dhcp/clientv4.rs
@@ -6,7 +6,7 @@ use wire::{IpVersion, IpProtocol, IpEndpoint, IpAddress,
 use wire::dhcpv4::field as dhcpv4_field;
 use socket::{SocketSet, SocketHandle, RawSocket, RawSocketBuffer};
 use phy::{Device, ChecksumCapabilities};
-use iface::EthernetInterface as Interface;
+use iface::Interface as Interface;
 use time::{Instant, Duration};
 use super::{UDP_SERVER_PORT, UDP_CLIENT_PORT};
 

--- a/src/iface/ethernet.rs
+++ b/src/iface/ethernet.rs
@@ -269,7 +269,6 @@ impl<'b, 'c, 'e, DeviceT> InterfaceBuilder<'b, 'c, 'e, DeviceT>
 
 #[derive(Debug, PartialEq)]
 enum Packet<'a> {
-    None,
     #[cfg(feature = "proto-ipv4")]
     Arp(ArpRepr),
     #[cfg(feature = "proto-ipv4")]
@@ -289,7 +288,6 @@ enum Packet<'a> {
 impl<'a> Packet<'a> {
     fn neighbor_addr(&self) -> Option<IpAddress> {
         match self {
-            &Packet::None => None,
             #[cfg(feature = "proto-ipv4")]
             &Packet::Arp(_) => None,
             #[cfg(feature = "proto-ipv4")]
@@ -562,10 +560,15 @@ impl<'b, 'c, 'e, DeviceT> Interface<'b, 'c, 'e, DeviceT>
                     err
                 }).and_then(|response| {
                     processed_any = true;
-                    inner.dispatch(tx_token, timestamp, response).map_err(|err| {
-                        net_debug!("cannot dispatch response packet: {}", err);
-                        err
-                    })
+                    match response {
+                        Some(packet) => {
+                            inner.dispatch(tx_token, timestamp, packet).map_err(|err| {
+                                net_debug!("cannot dispatch response packet: {}", err);
+                                err
+                            })
+                        }
+                        None => Ok(())
+                    }
                 })
             })?;
         }
@@ -768,7 +771,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
 
     fn process_ethernet<'frame, T: AsRef<[u8]>>
                        (&mut self, sockets: &mut SocketSet, timestamp: Instant, frame: &'frame T) ->
-                       Result<Packet<'frame>>
+                       Result<Option<Packet<'frame>>>
     {
         let eth_frame = EthernetFrame::new_checked(frame)?;
 
@@ -777,7 +780,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
            !eth_frame.dst_addr().is_multicast() &&
            eth_frame.dst_addr() != self.ethernet_addr
         {
-            return Ok(Packet::None)
+            return Ok(None)
         }
 
         match eth_frame.ethertype() {
@@ -798,7 +801,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
     #[cfg(feature = "proto-ipv4")]
     fn process_arp<'frame, T: AsRef<[u8]>>
                   (&mut self, timestamp: Instant, eth_frame: &EthernetFrame<&'frame T>) ->
-                  Result<Packet<'frame>>
+                  Result<Option<Packet<'frame>>>
     {
         let arp_packet = ArpPacket::new_checked(eth_frame.payload())?;
         let arp_repr = ArpRepr::parse(&arp_packet)?;
@@ -821,15 +824,15 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
                 }
 
                 if operation == ArpOperation::Request && self.has_ip_addr(target_protocol_addr) {
-                    Ok(Packet::Arp(ArpRepr::EthernetIpv4 {
+                    Ok(Some(Packet::Arp(ArpRepr::EthernetIpv4 {
                         operation: ArpOperation::Reply,
                         source_hardware_addr: self.ethernet_addr,
                         source_protocol_addr: target_protocol_addr,
                         target_hardware_addr: source_hardware_addr,
                         target_protocol_addr: source_protocol_addr
-                    }))
+                    })))
                 } else {
-                    Ok(Packet::None)
+                    Ok(None)
                 }
             }
 
@@ -863,7 +866,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
     fn process_ipv6<'frame, T: AsRef<[u8]>>
                    (&mut self, sockets: &mut SocketSet, timestamp: Instant,
                     eth_frame: &EthernetFrame<&'frame T>) ->
-                   Result<Packet<'frame>>
+                   Result<Option<Packet<'frame>>>
     {
         let ipv6_packet = Ipv6Packet::new_checked(eth_frame.payload())?;
         let ipv6_repr = Ipv6Repr::parse(&ipv6_packet)?;
@@ -900,7 +903,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
     fn process_nxt_hdr<'frame>
                    (&mut self, sockets: &mut SocketSet, timestamp: Instant, ipv6_repr: Ipv6Repr,
                     nxt_hdr: IpProtocol, handled_by_raw_socket: bool, ip_payload: &'frame [u8])
-                   -> Result<Packet<'frame>>
+                   -> Result<Option<Packet<'frame>>>
     {
         match nxt_hdr {
             IpProtocol::Icmpv6 =>
@@ -919,7 +922,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
 
             #[cfg(feature = "socket-raw")]
             _ if handled_by_raw_socket =>
-                Ok(Packet::None),
+                Ok(None),
 
             _ => {
                 // Send back as much of the original payload as we can.
@@ -941,7 +944,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
     fn process_ipv4<'frame, T: AsRef<[u8]>>
                    (&mut self, sockets: &mut SocketSet, timestamp: Instant,
                     eth_frame: &EthernetFrame<&'frame T>) ->
-                   Result<Packet<'frame>>
+                   Result<Option<Packet<'frame>>>
     {
         let ipv4_packet = Ipv4Packet::new_checked(eth_frame.payload())?;
         let checksum_caps = self.device_capabilities.checksum.clone();
@@ -975,12 +978,12 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
             // Ignore IP packets not directed at us, or broadcast, or any of the multicast groups.
             // If AnyIP is enabled, also check if the packet is routed locally.
             if !self.any_ip {
-                return Ok(Packet::None);
+                return Ok(None);
             } else if match self.routes.lookup(&IpAddress::Ipv4(ipv4_repr.dst_addr), timestamp) {
                 Some(router_addr) => !self.has_ip_addr(router_addr),
                 None => true,
             } {
-                return Ok(Packet::None);
+                return Ok(None);
             }
         }
 
@@ -1001,7 +1004,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
                 self.process_tcp(sockets, timestamp, ip_repr, ip_payload),
 
             _ if handled_by_raw_socket =>
-                Ok(Packet::None),
+                Ok(None),
 
             _ => {
                 // Send back as much of the original payload as we can.
@@ -1024,7 +1027,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
     /// after a query is broadcasted by a router; this is not currently done.
     #[cfg(feature = "proto-igmp")]
     fn process_igmp<'frame>(&mut self, timestamp: Instant, ipv4_repr: Ipv4Repr,
-                            ip_payload: &'frame [u8]) -> Result<Packet<'frame>> {
+                            ip_payload: &'frame [u8]) -> Result<Option<Packet<'frame>>> {
         let igmp_packet = IgmpPacket::new_checked(ip_payload)?;
         let igmp_repr = IgmpRepr::parse(&igmp_packet)?;
 
@@ -1068,12 +1071,12 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
             IgmpRepr::LeaveGroup{ .. } => (),
         }
 
-        Ok(Packet::None)
+        Ok(None)
     }
 
     #[cfg(feature = "proto-ipv6")]
     fn process_icmpv6<'frame>(&mut self, _sockets: &mut SocketSet, timestamp: Instant,
-                              ip_repr: IpRepr, ip_payload: &'frame [u8]) -> Result<Packet<'frame>>
+                              ip_repr: IpRepr, ip_payload: &'frame [u8]) -> Result<Option<Packet<'frame>>>
     {
         let icmp_packet = Icmpv6Packet::new_checked(ip_payload)?;
         let checksum_caps = self.device_capabilities.checksum.clone();
@@ -1114,18 +1117,18 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
             }
 
             // Ignore any echo replies.
-            Icmpv6Repr::EchoReply { .. } => Ok(Packet::None),
+            Icmpv6Repr::EchoReply { .. } => Ok(None),
 
             // Forward any NDISC packets to the ndisc packet handler
             Icmpv6Repr::Ndisc(repr) if ip_repr.hop_limit() == 0xff => match ip_repr {
                 IpRepr::Ipv6(ipv6_repr) => self.process_ndisc(timestamp, ipv6_repr, repr),
-                _ => Ok(Packet::None)
+                _ => Ok(None)
             },
 
             // Don't report an error if a packet with unknown type
             // has been handled by an ICMP socket
             #[cfg(feature = "socket-icmp")]
-            _ if handled_by_icmp_socket => Ok(Packet::None),
+            _ if handled_by_icmp_socket => Ok(None),
 
             // FIXME: do something correct here?
             _ => Err(Error::Unrecognized),
@@ -1134,8 +1137,8 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
 
     #[cfg(feature = "proto-ipv6")]
     fn process_ndisc<'frame>(&mut self, timestamp: Instant, ip_repr: Ipv6Repr,
-                             repr: NdiscRepr<'frame>) -> Result<Packet<'frame>> {
-        let packet = match repr {
+                             repr: NdiscRepr<'frame>) -> Result<Option<Packet<'frame>>> {
+        match repr {
             NdiscRepr::NeighborAdvert { lladdr, target_addr, flags } => {
                 let ip_addr = ip_repr.src_addr.into();
                 match lladdr {
@@ -1150,7 +1153,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
                     },
                     _ => (),
                 }
-                Ok(Packet::None)
+                Ok(None)
             }
             NdiscRepr::NeighborSolicit { target_addr, lladdr, .. } => {
                 match lladdr {
@@ -1172,20 +1175,19 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
                         hop_limit: 0xff,
                         payload_len: advert.buffer_len()
                     };
-                    Ok(Packet::Icmpv6((ip_repr, advert)))
+                    Ok(Some(Packet::Icmpv6((ip_repr, advert))))
                 } else {
-                    Ok(Packet::None)
+                    Ok(None)
                 }
             }
-            _ => Ok(Packet::None)
-        };
-        packet
+            _ => Ok(None)
+        }
     }
 
     #[cfg(feature = "proto-ipv6")]
     fn process_hopbyhop<'frame>(&mut self, sockets: &mut SocketSet, timestamp: Instant,
                                 ipv6_repr: Ipv6Repr, handled_by_raw_socket: bool,
-                                ip_payload: &'frame [u8]) -> Result<Packet<'frame>>
+                                ip_payload: &'frame [u8]) -> Result<Option<Packet<'frame>>>
     {
         let hbh_pkt = Ipv6HopByHopHeader::new_checked(ip_payload)?;
         let hbh_repr = Ipv6HopByHopRepr::parse(&hbh_pkt)?;
@@ -1197,7 +1199,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
                     match Ipv6OptionFailureType::from(type_) {
                         Ipv6OptionFailureType::Skip => (),
                         Ipv6OptionFailureType::Discard => {
-                            return Ok(Packet::None);
+                            return Ok(None);
                         },
                         _ => {
                             // FIXME(dlrobertson): Send an ICMPv6 parameter problem message
@@ -1215,7 +1217,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
 
     #[cfg(feature = "proto-ipv4")]
     fn process_icmpv4<'frame>(&self, _sockets: &mut SocketSet, ip_repr: IpRepr,
-                              ip_payload: &'frame [u8]) -> Result<Packet<'frame>>
+                              ip_payload: &'frame [u8]) -> Result<Option<Packet<'frame>>>
     {
         let icmp_packet = Icmpv4Packet::new_checked(ip_payload)?;
         let checksum_caps = self.device_capabilities.checksum.clone();
@@ -1254,12 +1256,12 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
             },
 
             // Ignore any echo replies.
-            Icmpv4Repr::EchoReply { .. } => Ok(Packet::None),
+            Icmpv4Repr::EchoReply { .. } => Ok(None),
 
             // Don't report an error if a packet with unknown type
             // has been handled by an ICMP socket
             #[cfg(feature = "socket-icmp")]
-            _ if handled_by_icmp_socket => Ok(Packet::None),
+            _ if handled_by_icmp_socket => Ok(None),
 
             // FIXME: do something correct here?
             _ => Err(Error::Unrecognized),
@@ -1269,11 +1271,11 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
     #[cfg(feature = "proto-ipv4")]
     fn icmpv4_reply<'frame, 'icmp: 'frame>
                    (&self, ipv4_repr: Ipv4Repr, icmp_repr: Icmpv4Repr<'icmp>) ->
-                   Packet<'frame>
+                   Option<Packet<'frame>>
     {
         if !ipv4_repr.src_addr.is_unicast() {
             // Do not send ICMP replies to non-unicast sources
-            Packet::None
+            None
         } else if ipv4_repr.dst_addr.is_unicast() {
             // Reply as normal when src_addr and dst_addr are both unicast
             let ipv4_reply_repr = Ipv4Repr {
@@ -1283,7 +1285,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
                 payload_len: icmp_repr.buffer_len(),
                 hop_limit:   64
             };
-            Packet::Icmpv4((ipv4_reply_repr, icmp_repr))
+            Some(Packet::Icmpv4((ipv4_reply_repr, icmp_repr)))
         } else if ipv4_repr.dst_addr.is_broadcast() {
             // Only reply to broadcasts for echo replies and not other ICMP messages
             match icmp_repr {
@@ -1296,21 +1298,21 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
                             payload_len: icmp_repr.buffer_len(),
                             hop_limit:   64
                         };
-                        Packet::Icmpv4((ipv4_reply_repr, icmp_repr))
+                        Some(Packet::Icmpv4((ipv4_reply_repr, icmp_repr)))
                     },
-                    None => Packet::None,
+                    None => None,
                 },
-                _ => Packet::None,
+                _ => None,
             }
         } else {
-            Packet::None
+            None
         }
     }
 
     #[cfg(feature = "proto-ipv6")]
     fn icmpv6_reply<'frame, 'icmp: 'frame>
                    (&self, ipv6_repr: Ipv6Repr, icmp_repr: Icmpv6Repr<'icmp>) ->
-                   Packet<'frame>
+                   Option<Packet<'frame>>
     {
         if ipv6_repr.dst_addr.is_unicast() {
             let ipv6_reply_repr = Ipv6Repr {
@@ -1320,17 +1322,17 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
                 payload_len: icmp_repr.buffer_len(),
                 hop_limit:   64
             };
-            Packet::Icmpv6((ipv6_reply_repr, icmp_repr))
+            Some(Packet::Icmpv6((ipv6_reply_repr, icmp_repr)))
         } else {
             // Do not send any ICMP replies to a broadcast destination address.
-            Packet::None
+            None
         }
     }
 
     #[cfg(feature = "socket-udp")]
     fn process_udp<'frame>(&self, sockets: &mut SocketSet,
                            ip_repr: IpRepr, handled_by_raw_socket: bool, ip_payload: &'frame [u8]) ->
-                          Result<Packet<'frame>>
+                          Result<Option<Packet<'frame>>>
     {
         let (src_addr, dst_addr) = (ip_repr.src_addr(), ip_repr.dst_addr());
         let udp_packet = UdpPacket::new_checked(ip_payload)?;
@@ -1342,7 +1344,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
 
             match udp_socket.process(&ip_repr, &udp_repr) {
                 // The packet is valid and handled by socket.
-                Ok(()) => return Ok(Packet::None),
+                Ok(()) => return Ok(None),
                 // The packet is malformed, or the socket buffer is full.
                 Err(e) => return Err(e)
             }
@@ -1352,10 +1354,10 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
         match ip_repr {
             #[cfg(feature = "proto-ipv4")]
             IpRepr::Ipv4(_) if handled_by_raw_socket =>
-                Ok(Packet::None),
+                Ok(None),
             #[cfg(feature = "proto-ipv6")]
             IpRepr::Ipv6(_) if handled_by_raw_socket =>
-                Ok(Packet::None),
+                Ok(None),
             #[cfg(feature = "proto-ipv4")]
             IpRepr::Ipv4(ipv4_repr) => {
                 let payload_len = icmp_reply_payload_len(ip_payload.len(), IPV4_MIN_MTU,
@@ -1386,7 +1388,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
     #[cfg(feature = "socket-tcp")]
     fn process_tcp<'frame>(&self, sockets: &mut SocketSet, timestamp: Instant,
                            ip_repr: IpRepr, ip_payload: &'frame [u8]) ->
-                          Result<Packet<'frame>>
+                          Result<Option<Packet<'frame>>>
     {
         let (src_addr, dst_addr) = (ip_repr.src_addr(), ip_repr.dst_addr());
         let tcp_packet = TcpPacket::new_checked(ip_payload)?;
@@ -1398,7 +1400,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
 
             match tcp_socket.process(timestamp, &ip_repr, &tcp_repr) {
                 // The packet is valid and handled by socket.
-                Ok(reply) => return Ok(reply.map_or(Packet::None, Packet::Tcp)),
+                Ok(reply) => return Ok(reply.map(Packet::Tcp)),
                 // The packet is malformed, or doesn't match the socket state,
                 // or the socket buffer is full.
                 Err(e) => return Err(e)
@@ -1407,10 +1409,10 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
 
         if tcp_repr.control == TcpControl::Rst {
             // Never reply to a TCP RST packet with another TCP RST packet.
-            Ok(Packet::None)
+            Ok(None)
         } else {
             // The packet wasn't handled by a socket, send a TCP RST packet.
-            Ok(Packet::Tcp(TcpSocket::rst_reply(&ip_repr, &tcp_repr)))
+            Ok(Some(Packet::Tcp(TcpSocket::rst_reply(&ip_repr, &tcp_repr))))
         }
     }
 
@@ -1499,7 +1501,6 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
                                   &checksum_caps);
                 })
             }
-            Packet::None => Ok(())
         }
     }
 
@@ -1852,10 +1853,10 @@ mod test {
         // broadcast address
         #[cfg(all(feature = "proto-ipv4", not(feature = "proto-ipv6")))]
         assert_eq!(iface.inner.process_ipv4(&mut socket_set, Instant::from_millis(0), &frame),
-                   Ok(Packet::None));
+                   Ok(None));
         #[cfg(feature = "proto-ipv6")]
         assert_eq!(iface.inner.process_ipv6(&mut socket_set, Instant::from_millis(0), &frame),
-                   Ok(Packet::None));
+                   Ok(None));
     }
 
     #[test]
@@ -1913,7 +1914,7 @@ mod test {
         // Ensure that the unknown protocol triggers an error response.
         // And we correctly handle no payload.
         assert_eq!(iface.inner.process_ipv4(&mut socket_set, Instant::from_millis(0), &frame),
-                   Ok(expected_repr));
+                   Ok(Some(expected_repr)));
     }
 
     #[test]
@@ -1978,7 +1979,7 @@ mod test {
         // Ensure that the unknown protocol triggers an error response.
         // And we correctly handle no payload.
         assert_eq!(iface.inner.process_udp(&mut socket_set, ip_repr, false, data),
-                   Ok(expected_repr));
+                   Ok(Some(expected_repr)));
 
         let ip_repr = IpRepr::Ipv4(Ipv4Repr {
             src_addr:    Ipv4Address([0x7f, 0x00, 0x00, 0x02]),
@@ -1997,7 +1998,7 @@ mod test {
         // ICMP error response when the destination address is a
         // broadcast address and no socket is bound to the port.
         assert_eq!(iface.inner.process_udp(&mut socket_set, ip_repr,
-                   false, packet_broadcast.into_inner()), Ok(Packet::None));
+                   false, packet_broadcast.into_inner()), Ok(None));
     }
 
     #[test]
@@ -2061,7 +2062,7 @@ mod test {
 
         // Packet should be handled by bound UDP socket
         assert_eq!(iface.inner.process_udp(&mut socket_set, ip_repr, false, packet.into_inner()),
-                   Ok(Packet::None));
+                   Ok(None));
 
         {
             // Make sure the payload to the UDP packet processed by process_udp is
@@ -2127,7 +2128,7 @@ mod test {
         let expected_packet = Packet::Icmpv4((expected_ipv4_repr, expected_icmpv4_repr));
 
         assert_eq!(iface.inner.process_ipv4(&mut socket_set, Instant::from_millis(0), &frame),
-                   Ok(expected_packet));
+                   Ok(Some(expected_packet)));
     }
 
     #[test]
@@ -2219,10 +2220,10 @@ mod test {
         // The expected packet and the generated packet are equal
         #[cfg(all(feature = "proto-ipv4", not(feature = "proto-ipv6")))]
         assert_eq!(iface.inner.process_udp(&mut socket_set, ip_repr.into(), false, payload),
-                   Ok(Packet::Icmpv4((expected_ip_repr, expected_icmp_repr))));
+                   Ok(Some(Packet::Icmpv4((expected_ip_repr, expected_icmp_repr)))));
         #[cfg(feature = "proto-ipv6")]
         assert_eq!(iface.inner.process_udp(&mut socket_set, ip_repr.into(), false, payload),
-                   Ok(Packet::Icmpv6((expected_ip_repr, expected_icmp_repr))));
+                   Ok(Some(Packet::Icmpv6((expected_ip_repr, expected_icmp_repr)))));
     }
 
     #[test]
@@ -2256,13 +2257,13 @@ mod test {
 
         // Ensure an ARP Request for us triggers an ARP Reply
         assert_eq!(iface.inner.process_ethernet(&mut socket_set, Instant::from_millis(0), frame.into_inner()),
-                   Ok(Packet::Arp(ArpRepr::EthernetIpv4 {
+                   Ok(Some(Packet::Arp(ArpRepr::EthernetIpv4 {
                        operation: ArpOperation::Reply,
                        source_hardware_addr: local_hw_addr,
                        source_protocol_addr: local_ip_addr,
                        target_hardware_addr: remote_hw_addr,
                        target_protocol_addr: remote_ip_addr
-                   })));
+                   }))));
 
         // Ensure the address of the requestor was entered in the cache
         assert_eq!(iface.inner.lookup_hardware_addr(MockTxToken, Instant::from_secs(0),
@@ -2322,7 +2323,7 @@ mod test {
 
         // Ensure an Neighbor Solicitation triggers a Neighbor Advertisement
         assert_eq!(iface.inner.process_ethernet(&mut socket_set, Instant::from_millis(0), frame.into_inner()),
-                   Ok(Packet::Icmpv6((ipv6_expected, icmpv6_expected))));
+                   Ok(Some(Packet::Icmpv6((ipv6_expected, icmpv6_expected)))));
 
         // Ensure the address of the requestor was entered in the cache
         assert_eq!(iface.inner.lookup_hardware_addr(MockTxToken, Instant::from_secs(0),
@@ -2359,7 +2360,7 @@ mod test {
 
         // Ensure an ARP Request for someone else does not trigger an ARP Reply
         assert_eq!(iface.inner.process_ethernet(&mut socket_set, Instant::from_millis(0), frame.into_inner()),
-                   Ok(Packet::None));
+                   Ok(None));
 
         // Ensure the address of the requestor was entered in the cache
         assert_eq!(iface.inner.lookup_hardware_addr(MockTxToken, Instant::from_secs(0),
@@ -2423,7 +2424,7 @@ mod test {
             ..ipv4_repr
         };
         assert_eq!(iface.inner.process_icmpv4(&mut socket_set, ip_repr, icmp_data),
-                   Ok(Packet::Icmpv4((ipv4_reply, echo_reply))));
+                   Ok(Some(Packet::Icmpv4((ipv4_reply, echo_reply)))));
 
         {
             let mut socket = socket_set.get::<IcmpSocket>(socket_handle);
@@ -2513,7 +2514,7 @@ mod test {
         // Ensure the unknown next header causes a ICMPv6 Parameter Problem
         // error message to be sent to the sender.
         assert_eq!(iface.inner.process_ipv6(&mut socket_set, Instant::from_millis(0), &frame),
-                   Ok(Packet::Icmpv6((reply_ipv6_repr, reply_icmp_repr))));
+                   Ok(Some(Packet::Icmpv6((reply_ipv6_repr, reply_icmp_repr)))));
 
         // Ensure the address of the requestor was entered in the cache
         assert_eq!(iface.inner.lookup_hardware_addr(MockTxToken, Instant::from_secs(0),
@@ -2663,7 +2664,7 @@ mod test {
         };
 
         assert_eq!(iface.inner.process_ipv4(&mut socket_set, Instant::from_millis(0), &frame),
-                   Ok(Packet::None));
+                   Ok(None));
     }
 
     #[test]
@@ -2722,7 +2723,7 @@ mod test {
 
         // because the packet could not be handled we should send an Icmp message
         assert!(match frame {  
-            Ok(Packet::Icmpv4(_)) => true,
+            Ok(Some(Packet::Icmpv4(_))) => true,
             _ => false,
         });
     }
@@ -2795,7 +2796,7 @@ mod test {
         };
 
         assert_eq!(iface.inner.process_ipv4(&mut socket_set, Instant::from_millis(0), &frame),
-                   Ok(Packet::None));
+                   Ok(None));
 
         {
             // Make sure the UDP socket can still receive in presence of a Raw socket that handles UDP

--- a/src/iface/ethernet.rs
+++ b/src/iface/ethernet.rs
@@ -268,9 +268,25 @@ impl<'b, 'c, 'e, DeviceT> InterfaceBuilder<'b, 'c, 'e, DeviceT>
 }
 
 #[derive(Debug, PartialEq)]
-enum Packet<'a> {
+enum EthernetPacket<'a> {
     #[cfg(feature = "proto-ipv4")]
     Arp(ArpRepr),
+    Ip(IpPacket<'a>),
+}
+
+impl<'a> EthernetPacket<'a> {
+    fn neighbor_addr(&self) -> Option<IpAddress> {
+        match self {
+            #[cfg(feature = "proto-ipv4")]
+            &EthernetPacket::Arp(_) => None,
+            &EthernetPacket::Ip(ref pkt) => Some(pkt.neighbor_addr()),
+        }
+    }
+}
+
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum IpPacket<'a> {
     #[cfg(feature = "proto-ipv4")]
     Icmpv4((Ipv4Repr, Icmpv4Repr<'a>)),
     #[cfg(feature = "proto-igmp")]
@@ -285,23 +301,71 @@ enum Packet<'a> {
     Tcp((IpRepr, TcpRepr<'a>))
 }
 
-impl<'a> Packet<'a> {
-    fn neighbor_addr(&self) -> Option<IpAddress> {
+impl<'a> IpPacket<'a> {
+    pub(crate) fn neighbor_addr(&self) -> IpAddress {
+        return self.ip_repr().dst_addr()
+    }
+
+    pub(crate) fn ip_repr(&self) -> IpRepr {
+        match &self {
+            #[cfg(feature = "proto-ipv4")]
+            &IpPacket::Icmpv4((ipv4_repr, _)) => IpRepr::Ipv4(ipv4_repr.clone()),
+            #[cfg(feature = "proto-igmp")]
+            &IpPacket::Igmp((ipv4_repr, _)) => IpRepr::Ipv4(ipv4_repr.clone()),
+            #[cfg(feature = "proto-ipv6")]
+            &IpPacket::Icmpv6((ipv6_repr, _)) => IpRepr::Ipv6(ipv6_repr.clone()),
+            #[cfg(feature = "socket-raw")]
+            &IpPacket::Raw((ip_repr, _)) => ip_repr.clone(),
+            #[cfg(feature = "socket-udp")]
+            &IpPacket::Udp((ip_repr, _)) => ip_repr.clone(),
+            #[cfg(feature = "socket-tcp")]
+            &IpPacket::Tcp((ip_repr, _)) => ip_repr.clone(),
+        }
+    }
+
+    pub(crate) fn emit_payload(&self, _ip_repr: IpRepr, payload: &mut [u8], caps: &DeviceCapabilities) {
         match self {
             #[cfg(feature = "proto-ipv4")]
-            &Packet::Arp(_) => None,
-            #[cfg(feature = "proto-ipv4")]
-            &Packet::Icmpv4((ref ipv4_repr, _)) => Some(ipv4_repr.dst_addr.into()),
+            IpPacket::Icmpv4((_, icmpv4_repr)) => 
+                icmpv4_repr.emit(&mut Icmpv4Packet::new_unchecked(payload), &caps.checksum),
             #[cfg(feature = "proto-igmp")]
-            &Packet::Igmp((ref ipv4_repr, _)) => Some(ipv4_repr.dst_addr.into()),
+            IpPacket::Igmp((_, igmp_repr)) =>
+                igmp_repr.emit(&mut IgmpPacket::new_unchecked(payload)),
             #[cfg(feature = "proto-ipv6")]
-            &Packet::Icmpv6((ref ipv6_repr, _)) => Some(ipv6_repr.dst_addr.into()),
+            IpPacket::Icmpv6((_, icmpv6_repr)) =>
+                icmpv6_repr.emit(&_ip_repr.src_addr(), &_ip_repr.dst_addr(),
+                         &mut Icmpv6Packet::new_unchecked(payload), &caps.checksum),
             #[cfg(feature = "socket-raw")]
-            &Packet::Raw((ref ip_repr, _)) => Some(ip_repr.dst_addr()),
+            IpPacket::Raw((_, raw_packet)) =>
+                payload.copy_from_slice(raw_packet),
             #[cfg(feature = "socket-udp")]
-            &Packet::Udp((ref ip_repr, _)) => Some(ip_repr.dst_addr()),
+            IpPacket::Udp((_, udp_repr)) =>
+                udp_repr.emit(&mut UdpPacket::new_unchecked(payload),
+                              &_ip_repr.src_addr(), &_ip_repr.dst_addr(), &caps.checksum),
             #[cfg(feature = "socket-tcp")]
-            &Packet::Tcp((ref ip_repr, _)) => Some(ip_repr.dst_addr())
+            IpPacket::Tcp((_, mut tcp_repr)) => {
+                // This is a terrible hack to make TCP performance more acceptable on systems
+                // where the TCP buffers are significantly larger than network buffers,
+                // e.g. a 64 kB TCP receive buffer (and so, when empty, a 64k window)
+                // together with four 1500 B Ethernet receive buffers. If left untreated,
+                // this would result in our peer pushing our window and sever packet loss.
+                //
+                // I'm really not happy about this "solution" but I don't know what else to do.
+                if let Some(max_burst_size) = caps.max_burst_size {
+                    let mut max_segment_size = caps.max_transmission_unit;
+                    max_segment_size -= _ip_repr.buffer_len();
+                    max_segment_size -= tcp_repr.header_len();
+
+                    let max_window_size = max_burst_size * max_segment_size;
+                    if tcp_repr.window_len as usize > max_window_size {
+                        tcp_repr.window_len = max_window_size as u16;
+                    }
+                }
+
+                tcp_repr.emit(&mut TcpPacket::new_unchecked(payload),
+                                &_ip_repr.src_addr(), &_ip_repr.dst_addr(),
+                                &caps.checksum);
+            }
         }
     }
 }
@@ -384,7 +448,7 @@ impl<'b, 'c, 'e, DeviceT> Interface<'b, 'c, 'e, DeviceT>
                         self.inner.igmp_report_packet(IgmpVersion::Version2, addr) {
                     // Send initial membership report
                     let tx_token = self.device.transmit().ok_or(Error::Exhausted)?;
-                    self.inner.dispatch(tx_token, _timestamp, pkt)?;
+                    self.inner.dispatch(tx_token, _timestamp, EthernetPacket::Ip(pkt))?;
                     Ok(true)
                 } else {
                     Ok(false)
@@ -410,7 +474,7 @@ impl<'b, 'c, 'e, DeviceT> Interface<'b, 'c, 'e, DeviceT>
                 } else if let Some(pkt) = self.inner.igmp_leave_packet(addr) {
                     // Send group leave packet
                     let tx_token = self.device.transmit().ok_or(Error::Exhausted)?;
-                    self.inner.dispatch(tx_token, _timestamp, pkt)?;
+                    self.inner.dispatch(tx_token, _timestamp, EthernetPacket::Ip(pkt))?;
                     Ok(true)
                 } else {
                     Ok(false)
@@ -592,7 +656,7 @@ impl<'b, 'c, 'e, DeviceT> Interface<'b, 'c, 'e, DeviceT>
 
             macro_rules! respond {
                 ($response:expr) => ({
-                    let response = $response;
+                    let response = EthernetPacket::Ip($response);
                     neighbor_addr = response.neighbor_addr();
                     let tx_token = device.transmit().ok_or(Error::Exhausted)?;
                     device_result = inner.dispatch(tx_token, timestamp, response);
@@ -605,28 +669,28 @@ impl<'b, 'c, 'e, DeviceT> Interface<'b, 'c, 'e, DeviceT>
                     #[cfg(feature = "socket-raw")]
                     Socket::Raw(ref mut socket) =>
                         socket.dispatch(&caps.checksum, |response|
-                            respond!(Packet::Raw(response))),
+                            respond!(IpPacket::Raw(response))),
                     #[cfg(all(feature = "socket-icmp", any(feature = "proto-ipv4", feature = "proto-ipv6")))]
                     Socket::Icmp(ref mut socket) =>
                         socket.dispatch(&caps, |response| {
                             match response {
                                 #[cfg(feature = "proto-ipv4")]
                                 (IpRepr::Ipv4(ipv4_repr), IcmpRepr::Ipv4(icmpv4_repr)) =>
-                                    respond!(Packet::Icmpv4((ipv4_repr, icmpv4_repr))),
+                                    respond!(IpPacket::Icmpv4((ipv4_repr, icmpv4_repr))),
                                 #[cfg(feature = "proto-ipv6")]
                                 (IpRepr::Ipv6(ipv6_repr), IcmpRepr::Ipv6(icmpv6_repr)) =>
-                                    respond!(Packet::Icmpv6((ipv6_repr, icmpv6_repr))),
+                                    respond!(IpPacket::Icmpv6((ipv6_repr, icmpv6_repr))),
                                 _ => Err(Error::Unaddressable)
                             }
                         }),
                     #[cfg(feature = "socket-udp")]
                     Socket::Udp(ref mut socket) =>
                         socket.dispatch(|response|
-                            respond!(Packet::Udp(response))),
+                            respond!(IpPacket::Udp(response))),
                     #[cfg(feature = "socket-tcp")]
                     Socket::Tcp(ref mut socket) =>
                         socket.dispatch(timestamp, &caps, |response|
-                            respond!(Packet::Tcp(response))),
+                            respond!(IpPacket::Tcp(response))),
                     Socket::__Nonexhaustive(_) => unreachable!()
                 };
 
@@ -663,7 +727,7 @@ impl<'b, 'c, 'e, DeviceT> Interface<'b, 'c, 'e, DeviceT>
                 if let Some(pkt) = self.inner.igmp_report_packet(version, group) {
                     // Send initial membership report
                     let tx_token = self.device.transmit().ok_or(Error::Exhausted)?;
-                    self.inner.dispatch(tx_token, timestamp, pkt)?;
+                    self.inner.dispatch(tx_token, timestamp, EthernetPacket::Ip(pkt))?;
                 }
 
                 self.inner.igmp_report_state = IgmpReportState::Inactive;
@@ -681,7 +745,7 @@ impl<'b, 'c, 'e, DeviceT> Interface<'b, 'c, 'e, DeviceT>
                         if let Some(pkt) = self.inner.igmp_report_packet(version, addr) {
                             // Send initial membership report
                             let tx_token = self.device.transmit().ok_or(Error::Exhausted)?;
-                            self.inner.dispatch(tx_token, timestamp, pkt)?;
+                            self.inner.dispatch(tx_token, timestamp, EthernetPacket::Ip(pkt))?;
                         }
 
                         let next_timeout = (timeout + interval).max(timestamp);
@@ -771,7 +835,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
 
     fn process_ethernet<'frame, T: AsRef<[u8]>>
                        (&mut self, sockets: &mut SocketSet, timestamp: Instant, frame: &'frame T) ->
-                       Result<Option<Packet<'frame>>>
+                       Result<Option<EthernetPacket<'frame>>>
     {
         let eth_frame = EthernetFrame::new_checked(frame)?;
 
@@ -789,10 +853,10 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
                 self.process_arp(timestamp, &eth_frame),
             #[cfg(feature = "proto-ipv4")]
             EthernetProtocol::Ipv4 =>
-                self.process_ipv4(sockets, timestamp, &eth_frame),
+                self.process_ipv4(sockets, timestamp, &eth_frame).map(|o| o.map(EthernetPacket::Ip)),
             #[cfg(feature = "proto-ipv6")]
             EthernetProtocol::Ipv6 =>
-                self.process_ipv6(sockets, timestamp, &eth_frame),
+                self.process_ipv6(sockets, timestamp, &eth_frame).map(|o| o.map(EthernetPacket::Ip)),
             // Drop all other traffic.
             _ => Err(Error::Unrecognized),
         }
@@ -801,7 +865,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
     #[cfg(feature = "proto-ipv4")]
     fn process_arp<'frame, T: AsRef<[u8]>>
                   (&mut self, timestamp: Instant, eth_frame: &EthernetFrame<&'frame T>) ->
-                  Result<Option<Packet<'frame>>>
+                  Result<Option<EthernetPacket<'frame>>>
     {
         let arp_packet = ArpPacket::new_checked(eth_frame.payload())?;
         let arp_repr = ArpRepr::parse(&arp_packet)?;
@@ -824,7 +888,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
                 }
 
                 if operation == ArpOperation::Request && self.has_ip_addr(target_protocol_addr) {
-                    Ok(Some(Packet::Arp(ArpRepr::EthernetIpv4 {
+                    Ok(Some(EthernetPacket::Arp(ArpRepr::EthernetIpv4 {
                         operation: ArpOperation::Reply,
                         source_hardware_addr: self.ethernet_addr,
                         source_protocol_addr: target_protocol_addr,
@@ -866,7 +930,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
     fn process_ipv6<'frame, T: AsRef<[u8]>>
                    (&mut self, sockets: &mut SocketSet, timestamp: Instant,
                     eth_frame: &EthernetFrame<&'frame T>) ->
-                   Result<Option<Packet<'frame>>>
+                   Result<Option<IpPacket<'frame>>>
     {
         let ipv6_packet = Ipv6Packet::new_checked(eth_frame.payload())?;
         let ipv6_repr = Ipv6Repr::parse(&ipv6_packet)?;
@@ -903,7 +967,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
     fn process_nxt_hdr<'frame>
                    (&mut self, sockets: &mut SocketSet, timestamp: Instant, ipv6_repr: Ipv6Repr,
                     nxt_hdr: IpProtocol, handled_by_raw_socket: bool, ip_payload: &'frame [u8])
-                   -> Result<Option<Packet<'frame>>>
+                   -> Result<Option<IpPacket<'frame>>>
     {
         match nxt_hdr {
             IpProtocol::Icmpv6 =>
@@ -944,7 +1008,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
     fn process_ipv4<'frame, T: AsRef<[u8]>>
                    (&mut self, sockets: &mut SocketSet, timestamp: Instant,
                     eth_frame: &EthernetFrame<&'frame T>) ->
-                   Result<Option<Packet<'frame>>>
+                   Result<Option<IpPacket<'frame>>>
     {
         let ipv4_packet = Ipv4Packet::new_checked(eth_frame.payload())?;
         let checksum_caps = self.device_capabilities.checksum.clone();
@@ -1027,7 +1091,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
     /// after a query is broadcasted by a router; this is not currently done.
     #[cfg(feature = "proto-igmp")]
     fn process_igmp<'frame>(&mut self, timestamp: Instant, ipv4_repr: Ipv4Repr,
-                            ip_payload: &'frame [u8]) -> Result<Option<Packet<'frame>>> {
+                            ip_payload: &'frame [u8]) -> Result<Option<IpPacket<'frame>>> {
         let igmp_packet = IgmpPacket::new_checked(ip_payload)?;
         let igmp_repr = IgmpRepr::parse(&igmp_packet)?;
 
@@ -1076,7 +1140,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
 
     #[cfg(feature = "proto-ipv6")]
     fn process_icmpv6<'frame>(&mut self, _sockets: &mut SocketSet, timestamp: Instant,
-                              ip_repr: IpRepr, ip_payload: &'frame [u8]) -> Result<Option<Packet<'frame>>>
+                              ip_repr: IpRepr, ip_payload: &'frame [u8]) -> Result<Option<IpPacket<'frame>>>
     {
         let icmp_packet = Icmpv6Packet::new_checked(ip_payload)?;
         let checksum_caps = self.device_capabilities.checksum.clone();
@@ -1137,7 +1201,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
 
     #[cfg(feature = "proto-ipv6")]
     fn process_ndisc<'frame>(&mut self, timestamp: Instant, ip_repr: Ipv6Repr,
-                             repr: NdiscRepr<'frame>) -> Result<Option<Packet<'frame>>> {
+                             repr: NdiscRepr<'frame>) -> Result<Option<IpPacket<'frame>>> {
         match repr {
             NdiscRepr::NeighborAdvert { lladdr, target_addr, flags } => {
                 let ip_addr = ip_repr.src_addr.into();
@@ -1175,7 +1239,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
                         hop_limit: 0xff,
                         payload_len: advert.buffer_len()
                     };
-                    Ok(Some(Packet::Icmpv6((ip_repr, advert))))
+                    Ok(Some(IpPacket::Icmpv6((ip_repr, advert))))
                 } else {
                     Ok(None)
                 }
@@ -1187,7 +1251,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
     #[cfg(feature = "proto-ipv6")]
     fn process_hopbyhop<'frame>(&mut self, sockets: &mut SocketSet, timestamp: Instant,
                                 ipv6_repr: Ipv6Repr, handled_by_raw_socket: bool,
-                                ip_payload: &'frame [u8]) -> Result<Option<Packet<'frame>>>
+                                ip_payload: &'frame [u8]) -> Result<Option<IpPacket<'frame>>>
     {
         let hbh_pkt = Ipv6HopByHopHeader::new_checked(ip_payload)?;
         let hbh_repr = Ipv6HopByHopRepr::parse(&hbh_pkt)?;
@@ -1217,7 +1281,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
 
     #[cfg(feature = "proto-ipv4")]
     fn process_icmpv4<'frame>(&self, _sockets: &mut SocketSet, ip_repr: IpRepr,
-                              ip_payload: &'frame [u8]) -> Result<Option<Packet<'frame>>>
+                              ip_payload: &'frame [u8]) -> Result<Option<IpPacket<'frame>>>
     {
         let icmp_packet = Icmpv4Packet::new_checked(ip_payload)?;
         let checksum_caps = self.device_capabilities.checksum.clone();
@@ -1271,7 +1335,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
     #[cfg(feature = "proto-ipv4")]
     fn icmpv4_reply<'frame, 'icmp: 'frame>
                    (&self, ipv4_repr: Ipv4Repr, icmp_repr: Icmpv4Repr<'icmp>) ->
-                   Option<Packet<'frame>>
+                   Option<IpPacket<'frame>>
     {
         if !ipv4_repr.src_addr.is_unicast() {
             // Do not send ICMP replies to non-unicast sources
@@ -1285,7 +1349,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
                 payload_len: icmp_repr.buffer_len(),
                 hop_limit:   64
             };
-            Some(Packet::Icmpv4((ipv4_reply_repr, icmp_repr)))
+            Some(IpPacket::Icmpv4((ipv4_reply_repr, icmp_repr)))
         } else if ipv4_repr.dst_addr.is_broadcast() {
             // Only reply to broadcasts for echo replies and not other ICMP messages
             match icmp_repr {
@@ -1298,7 +1362,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
                             payload_len: icmp_repr.buffer_len(),
                             hop_limit:   64
                         };
-                        Some(Packet::Icmpv4((ipv4_reply_repr, icmp_repr)))
+                        Some(IpPacket::Icmpv4((ipv4_reply_repr, icmp_repr)))
                     },
                     None => None,
                 },
@@ -1312,7 +1376,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
     #[cfg(feature = "proto-ipv6")]
     fn icmpv6_reply<'frame, 'icmp: 'frame>
                    (&self, ipv6_repr: Ipv6Repr, icmp_repr: Icmpv6Repr<'icmp>) ->
-                   Option<Packet<'frame>>
+                   Option<IpPacket<'frame>>
     {
         if ipv6_repr.dst_addr.is_unicast() {
             let ipv6_reply_repr = Ipv6Repr {
@@ -1322,7 +1386,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
                 payload_len: icmp_repr.buffer_len(),
                 hop_limit:   64
             };
-            Some(Packet::Icmpv6((ipv6_reply_repr, icmp_repr)))
+            Some(IpPacket::Icmpv6((ipv6_reply_repr, icmp_repr)))
         } else {
             // Do not send any ICMP replies to a broadcast destination address.
             None
@@ -1332,7 +1396,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
     #[cfg(feature = "socket-udp")]
     fn process_udp<'frame>(&self, sockets: &mut SocketSet,
                            ip_repr: IpRepr, handled_by_raw_socket: bool, ip_payload: &'frame [u8]) ->
-                          Result<Option<Packet<'frame>>>
+                          Result<Option<IpPacket<'frame>>>
     {
         let (src_addr, dst_addr) = (ip_repr.src_addr(), ip_repr.dst_addr());
         let udp_packet = UdpPacket::new_checked(ip_payload)?;
@@ -1388,7 +1452,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
     #[cfg(feature = "socket-tcp")]
     fn process_tcp<'frame>(&self, sockets: &mut SocketSet, timestamp: Instant,
                            ip_repr: IpRepr, ip_payload: &'frame [u8]) ->
-                          Result<Option<Packet<'frame>>>
+                          Result<Option<IpPacket<'frame>>>
     {
         let (src_addr, dst_addr) = (ip_repr.src_addr(), ip_repr.dst_addr());
         let tcp_packet = TcpPacket::new_checked(ip_payload)?;
@@ -1400,7 +1464,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
 
             match tcp_socket.process(timestamp, &ip_repr, &tcp_repr) {
                 // The packet is valid and handled by socket.
-                Ok(reply) => return Ok(reply.map(Packet::Tcp)),
+                Ok(reply) => return Ok(reply.map(|x| IpPacket::Tcp(x))),
                 // The packet is malformed, or doesn't match the socket state,
                 // or the socket buffer is full.
                 Err(e) => return Err(e)
@@ -1412,18 +1476,17 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
             Ok(None)
         } else {
             // The packet wasn't handled by a socket, send a TCP RST packet.
-            Ok(Some(Packet::Tcp(TcpSocket::rst_reply(&ip_repr, &tcp_repr))))
+            Ok(Some(IpPacket::Tcp(TcpSocket::rst_reply(&ip_repr, &tcp_repr))))
         }
     }
 
     fn dispatch<Tx>(&mut self, tx_token: Tx, timestamp: Instant,
-                    packet: Packet) -> Result<()>
+                    packet: EthernetPacket) -> Result<()>
         where Tx: TxToken
     {
-        let checksum_caps = self.device_capabilities.checksum.clone();
         match packet {
             #[cfg(feature = "proto-ipv4")]
-            Packet::Arp(arp_repr) => {
+            EthernetPacket::Arp(arp_repr) => {
                 let dst_hardware_addr =
                     match arp_repr {
                         ArpRepr::EthernetIpv4 { target_hardware_addr, .. } => target_hardware_addr,
@@ -1438,69 +1501,9 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
                     arp_repr.emit(&mut packet);
                 })
             },
-            #[cfg(feature = "proto-ipv4")]
-            Packet::Icmpv4((ipv4_repr, icmpv4_repr)) => {
-                self.dispatch_ip(tx_token, timestamp, IpRepr::Ipv4(ipv4_repr),
-                                 |_ip_repr, payload| {
-                    icmpv4_repr.emit(&mut Icmpv4Packet::new_unchecked(payload), &checksum_caps);
-                })
-            }
-            #[cfg(feature = "proto-igmp")]
-            Packet::Igmp((ipv4_repr, igmp_repr)) => {
-                self.dispatch_ip(tx_token, timestamp, IpRepr::Ipv4(ipv4_repr), |_ip_repr, payload| {
-                    igmp_repr.emit(&mut IgmpPacket::new_unchecked(payload));
-                })
-            }
-            #[cfg(feature = "proto-ipv6")]
-            Packet::Icmpv6((ipv6_repr, icmpv6_repr)) => {
-                self.dispatch_ip(tx_token, timestamp, IpRepr::Ipv6(ipv6_repr),
-                                 |ip_repr, payload| {
-                    icmpv6_repr.emit(&ip_repr.src_addr(), &ip_repr.dst_addr(),
-                                     &mut Icmpv6Packet::new_unchecked(payload), &checksum_caps);
-                })
-            }
-            #[cfg(feature = "socket-raw")]
-            Packet::Raw((ip_repr, raw_packet)) => {
-                self.dispatch_ip(tx_token, timestamp, ip_repr, |_ip_repr, payload| {
-                    payload.copy_from_slice(raw_packet);
-                })
-            }
-            #[cfg(feature = "socket-udp")]
-            Packet::Udp((ip_repr, udp_repr)) => {
-                self.dispatch_ip(tx_token, timestamp, ip_repr, |ip_repr, payload| {
-                    udp_repr.emit(&mut UdpPacket::new_unchecked(payload),
-                                  &ip_repr.src_addr(), &ip_repr.dst_addr(),
-                                  &checksum_caps);
-                })
-            }
-            #[cfg(feature = "socket-tcp")]
-            Packet::Tcp((ip_repr, mut tcp_repr)) => {
-                let caps = self.device_capabilities.clone();
-                self.dispatch_ip(tx_token, timestamp, ip_repr, |ip_repr, payload| {
-                    // This is a terrible hack to make TCP performance more acceptable on systems
-                    // where the TCP buffers are significantly larger than network buffers,
-                    // e.g. a 64 kB TCP receive buffer (and so, when empty, a 64k window)
-                    // together with four 1500 B Ethernet receive buffers. If left untreated,
-                    // this would result in our peer pushing our window and sever packet loss.
-                    //
-                    // I'm really not happy about this "solution" but I don't know what else to do.
-                    if let Some(max_burst_size) = caps.max_burst_size {
-                        let mut max_segment_size = caps.max_transmission_unit;
-                        max_segment_size -= EthernetFrame::<&[u8]>::header_len();
-                        max_segment_size -= ip_repr.buffer_len();
-                        max_segment_size -= tcp_repr.header_len();
-
-                        let max_window_size = max_burst_size * max_segment_size;
-                        if tcp_repr.window_len as usize > max_window_size {
-                            tcp_repr.window_len = max_window_size as u16;
-                        }
-                    }
-
-                    tcp_repr.emit(&mut TcpPacket::new_unchecked(payload),
-                                  &ip_repr.src_addr(), &ip_repr.dst_addr(),
-                                  &checksum_caps);
-                })
-            }
+            EthernetPacket::Ip(packet) => {
+                self.dispatch_ip(tx_token, timestamp, packet)
+            },
         }
     }
 
@@ -1626,25 +1629,23 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
                 net_debug!("address {} not in neighbor cache, sending Neighbor Solicitation",
                            dst_addr);
 
-                let checksum_caps = self.device_capabilities.checksum.clone();
-
                 let solicit = Icmpv6Repr::Ndisc(NdiscRepr::NeighborSolicit {
                     target_addr: src_addr,
                     lladdr: Some(self.ethernet_addr),
                 });
 
-                let ip_repr = IpRepr::Ipv6(Ipv6Repr {
-                    src_addr: src_addr,
-                    dst_addr: dst_addr.solicited_node(),
-                    next_header: IpProtocol::Icmpv6,
-                    payload_len: solicit.buffer_len(),
-                    hop_limit: 0xff
-                });
+                let packet = IpPacket::Icmpv6((
+                    Ipv6Repr {
+                        src_addr: src_addr,
+                        dst_addr: dst_addr.solicited_node(),
+                        next_header: IpProtocol::Icmpv6,
+                        payload_len: solicit.buffer_len(),
+                        hop_limit: 0xff
+                    },
+                    solicit,
+                ));
 
-                self.dispatch_ip(tx_token, timestamp, ip_repr, |ip_repr, payload| {
-                    solicit.emit(&ip_repr.src_addr(), &ip_repr.dst_addr(),
-                                 &mut Icmpv6Packet::new_unchecked(payload), &checksum_caps);
-                })?;
+                self.dispatch_ip(tx_token, timestamp, packet)?;
             }
 
             _ => ()
@@ -1654,12 +1655,10 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
         Err(Error::Unaddressable)
     }
 
-    fn dispatch_ip<Tx, F>(&mut self, tx_token: Tx, timestamp: Instant,
-                          ip_repr: IpRepr, f: F) -> Result<()>
-        where Tx: TxToken, F: FnOnce(IpRepr, &mut [u8])
-    {
-        let ip_repr = ip_repr.lower(&self.ip_addrs)?;
-        let checksum_caps = self.device_capabilities.checksum.clone();
+    fn dispatch_ip<Tx: TxToken>(&mut self, tx_token: Tx, timestamp: Instant,
+                          packet: IpPacket) -> Result<()> {
+        let ip_repr = packet.ip_repr().lower(&self.ip_addrs)?;
+        let caps = self.device_capabilities.clone();
 
         let (dst_hardware_addr, tx_token) =
             self.lookup_hardware_addr(tx_token, timestamp,
@@ -1675,21 +1674,21 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
                 _ => return
             }
 
-            ip_repr.emit(frame.payload_mut(), &checksum_caps);
+            ip_repr.emit(frame.payload_mut(), &caps.checksum);
 
             let payload = &mut frame.payload_mut()[ip_repr.buffer_len()..];
-            f(ip_repr, payload)
+            packet.emit_payload(ip_repr, payload, &caps);
         })
     }
 
     #[cfg(feature = "proto-igmp")]
-    fn igmp_report_packet<'any>(&self, version: IgmpVersion, group_addr: Ipv4Address) -> Option<Packet<'any>> {
+    fn igmp_report_packet<'any>(&self, version: IgmpVersion, group_addr: Ipv4Address) -> Option<IpPacket<'any>> {
         let iface_addr = self.ipv4_address()?;
         let igmp_repr = IgmpRepr::MembershipReport {
             group_addr,
             version,
         };
-        let pkt = Packet::Igmp((Ipv4Repr {
+        let pkt = IpPacket::Igmp((Ipv4Repr {
             src_addr:    iface_addr,
             // Send to the group being reported
             dst_addr:    group_addr,
@@ -1703,10 +1702,10 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
     }
 
     #[cfg(feature = "proto-igmp")]
-    fn igmp_leave_packet<'any>(&self, group_addr: Ipv4Address) -> Option<Packet<'any>> {
+    fn igmp_leave_packet<'any>(&self, group_addr: Ipv4Address) -> Option<IpPacket<'any>> {
         self.ipv4_address().map(|iface_addr| {
             let igmp_repr = IgmpRepr::LeaveGroup { group_addr };
-            let pkt = Packet::Igmp((Ipv4Repr {
+            let pkt = IpPacket::Igmp((Ipv4Repr {
                 src_addr:    iface_addr,
                 dst_addr:    Ipv4Address::MULTICAST_ALL_ROUTERS,
                 protocol:    IpProtocol::Igmp,
@@ -1755,7 +1754,7 @@ mod test {
     #[cfg(feature = "proto-ipv6")]
     use wire::{Ipv6HopByHopHeader, Ipv6Option, Ipv6OptionRepr};
 
-    use super::Packet;
+    use super::{EthernetPacket, IpPacket};
 
     fn create_loopback<'a, 'b, 'c>() -> (EthernetInterface<'static, 'b, 'c, Loopback>,
                                          SocketSet<'static, 'a, 'b>) {
@@ -1900,7 +1899,7 @@ mod test {
             data: &NO_BYTES
         };
 
-        let expected_repr = Packet::Icmpv4((
+        let expected_repr = IpPacket::Icmpv4((
             Ipv4Repr {
                 src_addr: Ipv4Address([0x7f, 0x00, 0x00, 0x01]),
                 dst_addr: Ipv4Address([0x7f, 0x00, 0x00, 0x02]),
@@ -1965,7 +1964,7 @@ mod test {
             },
             data: &data
         };
-        let expected_repr = Packet::Icmpv4((
+        let expected_repr = IpPacket::Icmpv4((
             Ipv4Repr {
                 src_addr: Ipv4Address([0x7f, 0x00, 0x00, 0x01]),
                 dst_addr: Ipv4Address([0x7f, 0x00, 0x00, 0x02]),
@@ -2125,7 +2124,7 @@ mod test {
             hop_limit: 64,
             payload_len: expected_icmpv4_repr.buffer_len(),
         };
-        let expected_packet = Packet::Icmpv4((expected_ipv4_repr, expected_icmpv4_repr));
+        let expected_packet = IpPacket::Icmpv4((expected_ipv4_repr, expected_icmpv4_repr));
 
         assert_eq!(iface.inner.process_ipv4(&mut socket_set, Instant::from_millis(0), &frame),
                    Ok(Some(expected_packet)));
@@ -2220,10 +2219,10 @@ mod test {
         // The expected packet and the generated packet are equal
         #[cfg(all(feature = "proto-ipv4", not(feature = "proto-ipv6")))]
         assert_eq!(iface.inner.process_udp(&mut socket_set, ip_repr.into(), false, payload),
-                   Ok(Some(Packet::Icmpv4((expected_ip_repr, expected_icmp_repr)))));
+                   Ok(Some(IpPacket::Icmpv4((expected_ip_repr, expected_icmp_repr)))));
         #[cfg(feature = "proto-ipv6")]
         assert_eq!(iface.inner.process_udp(&mut socket_set, ip_repr.into(), false, payload),
-                   Ok(Some(Packet::Icmpv6((expected_ip_repr, expected_icmp_repr)))));
+                   Ok(Some(IpPacket::Icmpv6((expected_ip_repr, expected_icmp_repr)))));
     }
 
     #[test]
@@ -2257,7 +2256,7 @@ mod test {
 
         // Ensure an ARP Request for us triggers an ARP Reply
         assert_eq!(iface.inner.process_ethernet(&mut socket_set, Instant::from_millis(0), frame.into_inner()),
-                   Ok(Some(Packet::Arp(ArpRepr::EthernetIpv4 {
+                   Ok(Some(EthernetPacket::Arp(ArpRepr::EthernetIpv4 {
                        operation: ArpOperation::Reply,
                        source_hardware_addr: local_hw_addr,
                        source_protocol_addr: local_ip_addr,
@@ -2323,7 +2322,7 @@ mod test {
 
         // Ensure an Neighbor Solicitation triggers a Neighbor Advertisement
         assert_eq!(iface.inner.process_ethernet(&mut socket_set, Instant::from_millis(0), frame.into_inner()),
-                   Ok(Some(Packet::Icmpv6((ipv6_expected, icmpv6_expected)))));
+                   Ok(Some(EthernetPacket::Ip(IpPacket::Icmpv6((ipv6_expected, icmpv6_expected))))));
 
         // Ensure the address of the requestor was entered in the cache
         assert_eq!(iface.inner.lookup_hardware_addr(MockTxToken, Instant::from_secs(0),
@@ -2424,7 +2423,7 @@ mod test {
             ..ipv4_repr
         };
         assert_eq!(iface.inner.process_icmpv4(&mut socket_set, ip_repr, icmp_data),
-                   Ok(Some(Packet::Icmpv4((ipv4_reply, echo_reply)))));
+                   Ok(Some(IpPacket::Icmpv4((ipv4_reply, echo_reply)))));
 
         {
             let mut socket = socket_set.get::<IcmpSocket>(socket_handle);
@@ -2514,7 +2513,7 @@ mod test {
         // Ensure the unknown next header causes a ICMPv6 Parameter Problem
         // error message to be sent to the sender.
         assert_eq!(iface.inner.process_ipv6(&mut socket_set, Instant::from_millis(0), &frame),
-                   Ok(Some(Packet::Icmpv6((reply_ipv6_repr, reply_icmp_repr)))));
+                   Ok(Some(IpPacket::Icmpv6((reply_ipv6_repr, reply_icmp_repr)))));
 
         // Ensure the address of the requestor was entered in the cache
         assert_eq!(iface.inner.lookup_hardware_addr(MockTxToken, Instant::from_secs(0),
@@ -2723,7 +2722,7 @@ mod test {
 
         // because the packet could not be handled we should send an Icmp message
         assert!(match frame {  
-            Ok(Some(Packet::Icmpv4(_))) => true,
+            Ok(Some(IpPacket::Icmpv4(_))) => true,
             _ => false,
         });
     }

--- a/src/iface/interface.rs
+++ b/src/iface/interface.rs
@@ -4,22 +4,24 @@
 
 use core::cmp;
 use managed::{ManagedSlice, ManagedMap};
-#[cfg(not(all(feature = "ethernet", feature = "proto-igmp")))]
+#[cfg(not(all(feature = "medium-ethernet", feature = "proto-igmp")))]
 use core::marker::PhantomData;
 
 use {Error, Result};
 use phy::{Device, DeviceCapabilities, RxToken, TxToken, Medium};
 use time::{Duration, Instant};
-#[cfg(feature = "ethernet")]
+#[cfg(feature = "medium-ethernet")]
 use wire::pretty_print::PrettyPrinter;
-#[cfg(feature = "ethernet")]
+#[cfg(feature = "medium-ethernet")]
 use wire::{EthernetAddress, EthernetProtocol, EthernetFrame};
-use wire::{IpAddress, IpProtocol, IpRepr, IpCidr, IpVersion};
+use wire::{IpAddress, IpProtocol, IpRepr, IpCidr};
+#[cfg(feature = "medium-ip")]
+use wire::IpVersion;
 #[cfg(feature = "proto-ipv6")]
 use wire::{Ipv6Address, Ipv6Packet, Ipv6Repr, IPV6_MIN_MTU};
 #[cfg(feature = "proto-ipv4")]
 use wire::{Ipv4Address, Ipv4Packet, Ipv4Repr, IPV4_MIN_MTU};
-#[cfg(all(feature = "ethernet", feature = "proto-ipv4"))]
+#[cfg(all(feature = "medium-ethernet", feature = "proto-ipv4"))]
 use wire::{ArpPacket, ArpRepr, ArpOperation};
 #[cfg(feature = "proto-ipv4")]
 use wire::{Icmpv4Packet, Icmpv4Repr, Icmpv4DstUnreachable};
@@ -33,7 +35,7 @@ use wire::IcmpRepr;
 use wire::{Ipv6HopByHopHeader, Ipv6HopByHopRepr};
 #[cfg(feature = "proto-ipv6")]
 use wire::{Ipv6OptionRepr, Ipv6OptionFailureType};
-#[cfg(all(feature = "ethernet", feature = "proto-ipv6"))]
+#[cfg(all(feature = "medium-ethernet", feature = "proto-ipv6"))]
 use wire::{NdiscNeighborFlags, NdiscRepr};
 #[cfg(all(feature = "proto-ipv6", feature = "socket-udp"))]
 use wire::Icmpv6DstUnreachable;
@@ -51,7 +53,7 @@ use socket::IcmpSocket;
 use socket::UdpSocket;
 #[cfg(feature = "socket-tcp")]
 use socket::TcpSocket;
-#[cfg(feature = "ethernet")]
+#[cfg(feature = "medium-ethernet")]
 use super::{NeighborCache, NeighborAnswer};
 use super::Routes;
 
@@ -73,11 +75,11 @@ pub struct Interface<'b, 'c, 'e, DeviceT: for<'d> Device<'d>> {
 /// methods on the `Interface` in this time (since its `device` field is borrowed
 /// exclusively). However, it is still possible to call methods on its `inner` field.
 struct InterfaceInner<'b, 'c, 'e> {
-    #[cfg(feature = "ethernet")]
+    #[cfg(feature = "medium-ethernet")]
     neighbor_cache:         Option<NeighborCache<'b>>,
-    #[cfg(not(feature = "ethernet"))]
+    #[cfg(not(feature = "medium-ethernet"))]
     _neighbor_cache:        PhantomData<&'b ()>,
-    #[cfg(feature = "ethernet")]
+    #[cfg(feature = "medium-ethernet")]
     ethernet_addr:          Option<EthernetAddress>,
     ip_addrs:               ManagedSlice<'c, IpCidr>,
     #[cfg(feature = "proto-ipv4")]
@@ -96,11 +98,11 @@ struct InterfaceInner<'b, 'c, 'e> {
 /// A builder structure used for creating a network interface.
 pub struct InterfaceBuilder <'b, 'c, 'e, DeviceT: for<'d> Device<'d>> {
     device:                 DeviceT,
-    #[cfg(feature = "ethernet")]
+    #[cfg(feature = "medium-ethernet")]
     ethernet_addr:          Option<EthernetAddress>,
-    #[cfg(feature = "ethernet")]
+    #[cfg(feature = "medium-ethernet")]
     neighbor_cache:         Option<NeighborCache<'b>>,
-    #[cfg(not(feature = "ethernet"))]
+    #[cfg(not(feature = "medium-ethernet"))]
     _neighbor_cache:        PhantomData<&'b ()>,
     ip_addrs:               ManagedSlice<'c, IpCidr>,
     #[cfg(feature = "proto-ipv4")]
@@ -117,7 +119,7 @@ impl<'b, 'c, 'e, DeviceT> InterfaceBuilder<'b, 'c, 'e, DeviceT>
         where DeviceT: for<'d> Device<'d> {
     /// Create a builder used for creating a network interface using the
     /// given device and address.
-    #[cfg_attr(feature = "ethernet", doc = r##"
+    #[cfg_attr(feature = "medium-ethernet", doc = r##"
     # Examples
     
     ```
@@ -144,11 +146,11 @@ impl<'b, 'c, 'e, DeviceT> InterfaceBuilder<'b, 'c, 'e, DeviceT>
     pub fn new(device: DeviceT) -> Self {
         InterfaceBuilder {
             device:              device,
-            #[cfg(feature = "ethernet")]
+            #[cfg(feature = "medium-ethernet")]
             ethernet_addr:       None,
-            #[cfg(feature = "ethernet")]
+            #[cfg(feature = "medium-ethernet")]
             neighbor_cache:      None,
-            #[cfg(not(feature = "ethernet"))]
+            #[cfg(not(feature = "medium-ethernet"))]
             _neighbor_cache:     PhantomData,
             ip_addrs:            ManagedSlice::Borrowed(&mut []),
             #[cfg(feature = "proto-ipv4")]
@@ -168,7 +170,7 @@ impl<'b, 'c, 'e, DeviceT> InterfaceBuilder<'b, 'c, 'e, DeviceT>
     /// This function panics if the address is not unicast.
     ///
     /// [ethernet_addr]: struct.Interface.html#method.ethernet_addr
-    #[cfg(feature = "ethernet")]
+    #[cfg(feature = "medium-ethernet")]
     pub fn ethernet_addr(mut self, addr: EthernetAddress) -> Self {
         InterfaceInner::check_ethernet_addr(&addr);
         self.ethernet_addr = Some(addr);
@@ -240,7 +242,7 @@ impl<'b, 'c, 'e, DeviceT> InterfaceBuilder<'b, 'c, 'e, DeviceT>
     }
 
     /// Set the Neighbor Cache the interface will use.
-    #[cfg(feature = "ethernet")]
+    #[cfg(feature = "medium-ethernet")]
     pub fn neighbor_cache(mut self, neighbor_cache: NeighborCache<'b>) -> Self {
         self.neighbor_cache = Some(neighbor_cache);
         self
@@ -260,37 +262,33 @@ impl<'b, 'c, 'e, DeviceT> InterfaceBuilder<'b, 'c, 'e, DeviceT>
     pub fn finalize(self) -> Interface<'b, 'c, 'e, DeviceT> {
         let device_capabilities = self.device.capabilities();
 
-        #[cfg(feature = "ethernet")]
-        let mut ethernet_addr = None;
-        #[cfg(feature = "ethernet")]
-        let mut neighbor_cache = None;
-        match device_capabilities.medium {
-            #[cfg(feature = "ethernet")]
-            Medium::Ethernet => {
-                ethernet_addr = Some(self.ethernet_addr.expect("ethernet_addr required option was not set"));
-                neighbor_cache = Some(self.neighbor_cache.expect("neighbor_cache required option was not set"));
-            }
+        #[cfg(feature = "medium-ethernet")]
+        let (ethernet_addr, neighbor_cache) = match device_capabilities.medium {
+            Medium::Ethernet => (
+                Some(self.ethernet_addr.expect("ethernet_addr required option was not set")),
+                Some(self.neighbor_cache.expect("neighbor_cache required option was not set"))
+            ),
+            #[cfg(feature = "medium-ip")]
             Medium::Ip => {
-                #[cfg(feature = "ethernet")]
                 assert!(self.ethernet_addr.is_none(), "ethernet_addr is set, but device medium is IP");
-                #[cfg(feature = "ethernet")]
                 assert!(self.neighbor_cache.is_none(), "neighbor_cache is set, but device medium is IP");
+                (None, None)
             }
-        }
+        };
 
         Interface {
             device: self.device,
             inner: InterfaceInner {
-                #[cfg(feature = "ethernet")]
+                #[cfg(feature = "medium-ethernet")]
                 ethernet_addr,
                 ip_addrs: self.ip_addrs,
                 #[cfg(feature = "proto-ipv4")]
                 any_ip: self.any_ip,
                 routes: self.routes,
                 device_capabilities,
-                #[cfg(feature = "ethernet")]
+                #[cfg(feature = "medium-ethernet")]
                 neighbor_cache,
-                #[cfg(not(feature = "ethernet"))]
+                #[cfg(not(feature = "medium-ethernet"))]
                 _neighbor_cache: PhantomData,
                 #[cfg(feature = "proto-igmp")]
                 ipv4_multicast_groups: self.ipv4_multicast_groups,
@@ -304,7 +302,7 @@ impl<'b, 'c, 'e, DeviceT> InterfaceBuilder<'b, 'c, 'e, DeviceT>
 }
 
 #[derive(Debug, PartialEq)]
-#[cfg(feature = "ethernet")]
+#[cfg(feature = "medium-ethernet")]
 enum EthernetPacket<'a> {
     #[cfg(feature = "proto-ipv4")]
     Arp(ArpRepr),
@@ -432,7 +430,7 @@ impl<'b, 'c, 'e, DeviceT> Interface<'b, 'c, 'e, DeviceT>
     /// # Panics
     /// This function panics if if the interface's medium is not Ethernet.
 
-    #[cfg(feature = "ethernet")]
+    #[cfg(feature = "medium-ethernet")]
     pub fn ethernet_addr(&self) -> EthernetAddress {
         self.inner.ethernet_addr.unwrap()
     }
@@ -442,7 +440,7 @@ impl<'b, 'c, 'e, DeviceT> Interface<'b, 'c, 'e, DeviceT>
     /// # Panics
     /// This function panics if the address is not unicast, or if the
     /// interface's medium is not Ethernet.
-    #[cfg(feature = "ethernet")]
+    #[cfg(feature = "medium-ethernet")]
     pub fn set_ethernet_addr(&mut self, addr: EthernetAddress) {
         assert!(self.device.capabilities().medium == Medium::Ethernet);
         InterfaceInner::check_ethernet_addr(&addr);
@@ -652,7 +650,7 @@ impl<'b, 'c, 'e, DeviceT> Interface<'b, 'c, 'e, DeviceT>
             };
             rx_token.consume(timestamp, |frame| {
                 match inner.device_capabilities.medium {
-                    #[cfg(feature = "ethernet")]
+                    #[cfg(feature = "medium-ethernet")]
                     Medium::Ethernet => {
                         inner.process_ethernet(sockets, timestamp, &frame).map_err(|err| {
                             net_debug!("cannot process ingress packet: {}", err);
@@ -672,6 +670,7 @@ impl<'b, 'c, 'e, DeviceT> Interface<'b, 'c, 'e, DeviceT>
                             }
                         })
                     }
+                    #[cfg(feature = "medium-ip")]
                     Medium::Ip => {
                         inner.process_ip(sockets, timestamp, &frame).map_err(|err| {
                             net_debug!("cannot process ingress packet: {}", err);
@@ -700,10 +699,10 @@ impl<'b, 'c, 'e, DeviceT> Interface<'b, 'c, 'e, DeviceT>
     fn socket_egress(&mut self, sockets: &mut SocketSet, timestamp: Instant) -> Result<bool> {
         let mut caps = self.device.capabilities();
         match caps.medium {
-            #[cfg(feature = "ethernet")]
-            Medium::Ethernet => 
-                caps.max_transmission_unit -= EthernetFrame::<&[u8]>::header_len(),
-            _ => {}
+            #[cfg(feature = "medium-ethernet")]
+            Medium::Ethernet => caps.max_transmission_unit -= EthernetFrame::<&[u8]>::header_len(),
+            #[cfg(feature = "medium-ip")]
+            Medium::Ip => {}
         }
 
         let mut emitted_any = false;
@@ -735,7 +734,7 @@ impl<'b, 'c, 'e, DeviceT> Interface<'b, 'c, 'e, DeviceT>
                             respond!(IpPacket::Raw(response))),
                     #[cfg(all(feature = "socket-icmp", any(feature = "proto-ipv4", feature = "proto-ipv6")))]
                     Socket::Icmp(ref mut socket) =>
-                        socket.dispatch(&caps, |response| {
+                        socket.dispatch(|response| {
                             match response {
                                 #[cfg(feature = "proto-ipv4")]
                                 (IpRepr::Ipv4(ipv4_repr), IcmpRepr::Ipv4(icmpv4_repr)) =>
@@ -752,7 +751,7 @@ impl<'b, 'c, 'e, DeviceT> Interface<'b, 'c, 'e, DeviceT>
                             respond!(IpPacket::Udp(response))),
                     #[cfg(feature = "socket-tcp")]
                     Socket::Tcp(ref mut socket) =>
-                        socket.dispatch(timestamp, &caps, |response|
+                        socket.dispatch(timestamp, caps.max_transmission_unit, |response|
                             respond!(IpPacket::Tcp(response))),
                     Socket::__Nonexhaustive(_) => unreachable!()
                 };
@@ -830,7 +829,7 @@ impl<'b, 'c, 'e, DeviceT> Interface<'b, 'c, 'e, DeviceT>
 }
 
 impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
-    #[cfg(feature = "ethernet")]
+    #[cfg(feature = "medium-ethernet")]
     fn check_ethernet_addr(addr: &EthernetAddress) {
         if addr.is_multicast() {
             panic!("Ethernet address {} is not unicast", addr)
@@ -897,7 +896,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
         }
     }
 
-    #[cfg(feature = "ethernet")]
+    #[cfg(feature = "medium-ethernet")]
     fn process_ethernet<'frame, T: AsRef<[u8]>>
                        (&mut self, sockets: &mut SocketSet, timestamp: Instant, frame: &'frame T) ->
                        Result<Option<EthernetPacket<'frame>>>
@@ -948,6 +947,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
         }
     }
 
+    #[cfg(feature = "medium-ip")]
     fn process_ip<'frame, T: AsRef<[u8]>>
                   (&mut self, sockets: &mut SocketSet, timestamp: Instant, ip_payload: &'frame T) ->
                   Result<Option<IpPacket<'frame>>>
@@ -968,7 +968,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
         }
     }
 
-    #[cfg(all(feature = "ethernet", feature = "proto-ipv4"))]
+    #[cfg(all(feature = "medium-ethernet", feature = "proto-ipv4"))]
     fn process_arp<'frame, T: AsRef<[u8]>>
                   (&mut self, timestamp: Instant, eth_frame: &EthernetFrame<&'frame T>) ->
                   Result<Option<EthernetPacket<'frame>>>
@@ -1270,7 +1270,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
             Icmpv6Repr::EchoReply { .. } => Ok(None),
 
             // Forward any NDISC packets to the ndisc packet handler
-            #[cfg(feature = "ethernet")]
+            #[cfg(feature = "medium-ethernet")]
             Icmpv6Repr::Ndisc(repr) if ip_repr.hop_limit() == 0xff => match ip_repr {
                 IpRepr::Ipv6(ipv6_repr) => self.process_ndisc(_timestamp, ipv6_repr, repr),
                 _ => Ok(None)
@@ -1286,7 +1286,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
         }
     }
 
-    #[cfg(all(feature = "ethernet", feature = "proto-ipv6"))]
+    #[cfg(all(feature = "medium-ethernet", feature = "proto-ipv6"))]
     fn process_ndisc<'frame>(&mut self, timestamp: Instant, ip_repr: Ipv6Repr,
                              repr: NdiscRepr<'frame>) -> Result<Option<IpPacket<'frame>>> {
         match repr {
@@ -1567,7 +1567,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
         }
     }
 
-    #[cfg(feature = "ethernet")]
+    #[cfg(feature = "medium-ethernet")]
     fn dispatch<Tx>(&mut self, tx_token: Tx, timestamp: Instant,
                     packet: EthernetPacket) -> Result<()>
         where Tx: TxToken
@@ -1595,7 +1595,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
         }
     }
 
-    #[cfg(feature = "ethernet")]
+    #[cfg(feature = "medium-ethernet")]
     fn dispatch_ethernet<Tx, F>(&mut self, tx_token: Tx, timestamp: Instant,
                                 buffer_len: usize, f: F) -> Result<()>
         where Tx: TxToken, F: FnOnce(EthernetFrame<&mut [u8]>)
@@ -1636,10 +1636,11 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
         match self.route(addr, timestamp) {
             Ok(_routed_addr) => {
                 match self.device_capabilities.medium {
-                    #[cfg(feature = "ethernet")]
+                    #[cfg(feature = "medium-ethernet")]
                     Medium::Ethernet => self.neighbor_cache.as_ref().unwrap()
                         .lookup(&_routed_addr, timestamp)
                         .found(),
+                    #[cfg(feature = "medium-ip")]
                     Medium::Ip => true,
                 }
             }
@@ -1647,7 +1648,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
         }
     }
 
-    #[cfg(feature = "ethernet")]
+    #[cfg(feature = "medium-ethernet")]
     fn lookup_hardware_addr<Tx>(&mut self, tx_token: Tx, timestamp: Instant,
                                 src_addr: &IpAddress, dst_addr: &IpAddress) ->
                                Result<(EthernetAddress, Tx)>
@@ -1755,7 +1756,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
         let caps = self.device_capabilities.clone();
 
         match self.device_capabilities.medium {
-            #[cfg(feature = "ethernet")]
+            #[cfg(feature = "medium-ethernet")]
             Medium::Ethernet => {
                 let (dst_hardware_addr, tx_token) =
                     self.lookup_hardware_addr(tx_token, timestamp,
@@ -1777,6 +1778,7 @@ impl<'b, 'c, 'e> InterfaceInner<'b, 'c, 'e> {
                     packet.emit_payload(ip_repr, payload, &caps);
                 })
             }
+            #[cfg(feature = "medium-ip")]
             Medium::Ip => {
                 let tx_len = ip_repr.total_len();
                 tx_token.consume(timestamp, tx_len, |mut tx_buffer| {
@@ -1837,7 +1839,7 @@ mod test {
     use {Result, Error};
 
     use super::InterfaceBuilder;
-    #[cfg(feature = "ethernet")]
+    #[cfg(feature = "medium-ethernet")]
     use iface::NeighborCache;
     use iface::Interface;
     use phy::{self, Loopback, ChecksumCapabilities};
@@ -1846,9 +1848,9 @@ mod test {
     use phy::{Device, RxToken, TxToken};
     use time::Instant;
     use socket::SocketSet;
-    #[cfg(all(feature = "ethernet", feature = "proto-ipv4"))]
+    #[cfg(all(feature = "medium-ethernet", feature = "proto-ipv4"))]
     use wire::{ArpOperation, ArpPacket, ArpRepr};
-    #[cfg(all(feature = "ethernet"))]
+    #[cfg(all(feature = "medium-ethernet"))]
     use wire::{EthernetAddress, EthernetFrame, EthernetProtocol};
     use wire::{IpAddress, IpCidr, IpProtocol, IpRepr};
     #[cfg(feature = "proto-ipv4")]
@@ -1863,17 +1865,27 @@ mod test {
     use wire::{Ipv6Address, Ipv6Repr, Ipv6Packet};
     #[cfg(feature = "proto-ipv6")]
     use wire::{Icmpv6Packet, Icmpv6Repr, Icmpv6ParamProblem};
-    #[cfg(all(feature = "ethernet", feature = "proto-ipv6"))]
+    #[cfg(all(feature = "medium-ethernet", feature = "proto-ipv6"))]
     use wire::{NdiscNeighborFlags, NdiscRepr};
     #[cfg(feature = "proto-ipv6")]
     use wire::{Ipv6HopByHopHeader, Ipv6Option, Ipv6OptionRepr};
 
-    #[cfg(feature = "ethernet")]
+    #[cfg(feature = "medium-ethernet")]
     use super::EthernetPacket;
     use super::IpPacket;
 
     fn create_loopback<'a, 'b, 'c>() -> (Interface<'static, 'b, 'c, Loopback>,
                                          SocketSet<'static, 'a, 'b>) {
+        #[cfg(feature = "medium-ethernet")]
+        return create_loopback_ethernet();
+        #[cfg(not(feature = "medium-ethernet"))]
+        return create_loopback_ip();
+    }
+
+    #[cfg(all(feature = "medium-ip"))]
+    #[allow(unused)]
+    fn create_loopback_ip<'a, 'b, 'c>() -> (Interface<'static, 'b, 'c, Loopback>,
+                                           SocketSet<'static, 'a, 'b>) {
         // Create a basic device
         let device = Loopback::new(Medium::Ip);
         let ip_addrs = [
@@ -1896,7 +1908,7 @@ mod test {
         (iface, SocketSet::new(vec![]))
     }
 
-    #[cfg(all(feature = "ethernet"))]
+    #[cfg(all(feature = "medium-ethernet"))]
     fn create_loopback_ethernet<'a, 'b, 'c>() -> (Interface<'static, 'b, 'c, Loopback>,
                                                   SocketSet<'static, 'a, 'b>) {
         // Create a basic device
@@ -1947,7 +1959,7 @@ mod test {
 
     #[test]
     #[should_panic(expected = "ethernet_addr required option was not set")]
-    #[cfg(all(feature = "ethernet"))]
+    #[cfg(all(feature = "medium-ethernet"))]
     fn test_builder_initialization_panic() {
         InterfaceBuilder::new(Loopback::new(Medium::Ethernet)).finalize();
     }
@@ -2368,7 +2380,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(all(feature = "ethernet", feature = "proto-ipv4"))]
+    #[cfg(all(feature = "medium-ethernet", feature = "proto-ipv4"))]
     fn test_handle_valid_arp_request() {
         let (mut iface, mut socket_set) = create_loopback_ethernet();
 
@@ -2413,7 +2425,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(all(feature = "ethernet", feature = "proto-ipv6"))]
+    #[cfg(all(feature = "medium-ethernet", feature = "proto-ipv6"))]
     fn test_handle_valid_ndisc_request() {
         let (mut iface, mut socket_set) = create_loopback_ethernet();
 
@@ -2473,7 +2485,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(all(feature = "ethernet", feature = "proto-ipv4"))]
+    #[cfg(all(feature = "medium-ethernet", feature = "proto-ipv4"))]
     fn test_handle_other_arp_request() {
         let (mut iface, mut socket_set) = create_loopback_ethernet();
 
@@ -2657,11 +2669,21 @@ mod test {
     #[cfg(feature = "proto-igmp")]
     fn test_handle_igmp() {
         fn recv_igmp<'b>(mut iface: &mut Interface<'static, 'b, 'static, Loopback>, timestamp: Instant) -> Vec<(Ipv4Repr, IgmpRepr)> {
-            let checksum_caps = &iface.device.capabilities().checksum;
+            let caps = iface.device.capabilities();
+            let checksum_caps = &caps.checksum;
             recv_all(&mut iface, timestamp)
                 .iter()
                 .filter_map(|frame| {
-                    let ipv4_packet = Ipv4Packet::new_checked(frame).ok()?;
+                    
+                    let ipv4_packet = match caps.medium {
+                        #[cfg(feature = "medium-ethernet")]
+                        Medium::Ethernet => {
+                            let eth_frame = EthernetFrame::new_checked(frame).ok()?;
+                            Ipv4Packet::new_checked(eth_frame.payload()).ok()?
+                        }
+                        #[cfg(feature = "medium-ip")]
+                        Medium::Ip => Ipv4Packet::new_checked(&frame[..]).ok()?
+                    };
                     let ipv4_repr = Ipv4Repr::parse(&ipv4_packet, &checksum_caps).ok()?;
                     let ip_payload = ipv4_packet.payload();
                     let igmp_packet = IgmpPacket::new_checked(ip_payload).ok()?;

--- a/src/iface/mod.rs
+++ b/src/iface/mod.rs
@@ -7,8 +7,7 @@ provides lookup and caching of hardware addresses, and handles management packet
 #[cfg(feature = "ethernet")]
 mod neighbor;
 mod route;
-#[cfg(feature = "ethernet")]
-mod ethernet;
+mod interface;
 
 #[cfg(feature = "ethernet")]
 pub use self::neighbor::Neighbor as Neighbor;
@@ -17,6 +16,5 @@ pub(crate) use self::neighbor::Answer as NeighborAnswer;
 #[cfg(feature = "ethernet")]
 pub use self::neighbor::Cache as NeighborCache;
 pub use self::route::{Route, Routes};
-#[cfg(feature = "ethernet")]
-pub use self::ethernet::{Interface as EthernetInterface,
-                         InterfaceBuilder as EthernetInterfaceBuilder};
+
+pub use self::interface::{Interface, InterfaceBuilder};

--- a/src/iface/mod.rs
+++ b/src/iface/mod.rs
@@ -4,17 +4,19 @@ The `iface` module deals with the *network interfaces*. It filters incoming fram
 provides lookup and caching of hardware addresses, and handles management packets.
 */
 
-#[cfg(feature = "ethernet")]
+#[cfg(feature = "medium-ethernet")]
 mod neighbor;
 mod route;
+#[cfg(any(feature = "medium-ethernet", feature = "medium-ip"))]
 mod interface;
 
-#[cfg(feature = "ethernet")]
+#[cfg(feature = "medium-ethernet")]
 pub use self::neighbor::Neighbor as Neighbor;
-#[cfg(feature = "ethernet")]
+#[cfg(feature = "medium-ethernet")]
 pub(crate) use self::neighbor::Answer as NeighborAnswer;
-#[cfg(feature = "ethernet")]
+#[cfg(feature = "medium-ethernet")]
 pub use self::neighbor::Cache as NeighborCache;
 pub use self::route::{Route, Routes};
 
+#[cfg(any(feature = "medium-ethernet", feature = "medium-ip"))]
 pub use self::interface::{Interface, InterfaceBuilder};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(feature = "alloc", feature(alloc))]
 #![no_std]
 #![deny(unsafe_code)]
-#![cfg_attr(all(any(feature = "proto-ipv4", feature = "proto-ipv6"), feature = "ethernet"), deny(unused))]
+#![cfg_attr(all(any(feature = "proto-ipv4", feature = "proto-ipv6"), feature = "medium-ethernet"), deny(unused))]
 
 //! The _smoltcp_ library is built in a layered structure, with the layers corresponding
 //! to the levels of API abstraction. Only the highest layers would be used by a typical
@@ -91,7 +91,7 @@ compile_error!("at least one socket needs to be enabled"); */
 // FIXME(dlrobertson): clippy fails with this lint
 #![cfg_attr(feature = "cargo-clippy", allow(if_same_then_else))]
 
-#[cfg(all(feature = "proto-ipv6", feature = "ethernet"))]
+#[cfg(all(feature = "proto-ipv6", feature = "medium-ethernet"))]
 #[macro_use]
 extern crate bitflags;
 extern crate byteorder;

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -3,7 +3,7 @@
 use core::str::FromStr;
 use core::result;
 
-#[cfg(feature = "ethernet")]
+#[cfg(feature = "medium-ethernet")]
 use wire::EthernetAddress;
 use wire::{IpAddress, IpCidr, IpEndpoint};
 #[cfg(feature = "proto-ipv4")]
@@ -118,7 +118,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    #[cfg(feature = "ethernet")]
+    #[cfg(feature = "medium-ethernet")]
     fn accept_mac_joined_with(&mut self, separator: u8) -> Result<EthernetAddress> {
         let mut octets = [0u8; 6];
         for n in 0..6 {
@@ -130,7 +130,7 @@ impl<'a> Parser<'a> {
         Ok(EthernetAddress(octets))
     }
 
-    #[cfg(feature = "ethernet")]
+    #[cfg(feature = "medium-ethernet")]
     fn accept_mac(&mut self) -> Result<EthernetAddress> {
         if let Some(mac) = self.try(|p| p.accept_mac_joined_with(b'-')) {
             return Ok(mac)
@@ -348,7 +348,7 @@ impl<'a> Parser<'a> {
     }
 }
 
-#[cfg(feature = "ethernet")]
+#[cfg(feature = "medium-ethernet")]
 impl FromStr for EthernetAddress {
     type Err = ();
 
@@ -467,7 +467,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(all(feature = "proto-ipv4", feature = "ethernet"))]
+    #[cfg(all(feature = "proto-ipv4", feature = "medium-ethernet"))]
     fn test_mac() {
         assert_eq!(EthernetAddress::from_str(""), Err(()));
         assert_eq!(EthernetAddress::from_str("02:00:00:00:00:00"),

--- a/src/phy/loopback.rs
+++ b/src/phy/loopback.rs
@@ -10,13 +10,14 @@ use alloc::collections::VecDeque;
 use alloc::VecDeque;
 
 use Result;
-use phy::{self, Device, DeviceCapabilities};
+use phy::{self, Device, DeviceCapabilities, Medium};
 use time::Instant;
 
 /// A loopback device.
 #[derive(Debug)]
 pub struct Loopback {
     queue: VecDeque<Vec<u8>>,
+    medium: Medium,
 }
 
 impl Loopback {
@@ -24,9 +25,10 @@ impl Loopback {
     ///
     /// Every packet transmitted through this device will be received through it
     /// in FIFO order.
-    pub fn new() -> Loopback {
+    pub fn new(medium: Medium) -> Loopback {
         Loopback {
             queue: VecDeque::new(),
+            medium,
         }
     }
 }
@@ -38,6 +40,7 @@ impl<'a> Device<'a> for Loopback {
     fn capabilities(&self) -> DeviceCapabilities {
         DeviceCapabilities {
             max_transmission_unit: 65535,
+            medium: self.medium,
             ..DeviceCapabilities::default()
         }
     }

--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -10,7 +10,8 @@ and implementations of it:
   * _adapters_ [RawSocket](struct.RawSocket.html) and
     [TapInterface](struct.TapInterface.html), to transmit and receive frames
     on the host OS.
-
+*/
+#![cfg_attr(feature = "ethernet", doc = r##"
 # Examples
 
 An implementation of the [Device](trait.Device.html) trait for a simple hardware
@@ -18,7 +19,7 @@ Ethernet controller could look as follows:
 
 ```rust
 use smoltcp::Result;
-use smoltcp::phy::{self, DeviceCapabilities, Device};
+use smoltcp::phy::{self, DeviceCapabilities, Device, Medium};
 use smoltcp::time::Instant;
 
 struct StmPhy {
@@ -52,6 +53,7 @@ impl<'a> phy::Device<'a> for StmPhy {
         let mut caps = DeviceCapabilities::default();
         caps.max_transmission_unit = 1536;
         caps.max_burst_size = Some(1);
+        caps.medium = Medium::Ethernet;
         caps
     }
 }
@@ -82,7 +84,7 @@ impl<'a> phy::TxToken for StmPhyTxToken<'a> {
     }
 }
 ```
-*/
+"##)]
 
 use Result;
 use time::Instant;
@@ -192,6 +194,13 @@ impl ChecksumCapabilities {
 /// the bandwidth or packet size limitations.
 #[derive(Debug, Clone, Default)]
 pub struct DeviceCapabilities {
+    /// Medium of the device.
+    ///
+    /// This indicates what kind of packet the sent/received bytes are, and determines
+    /// some behaviors of Interface. For example, ARP/NDISC address resolution is only done
+    /// for Ethernet mediums.
+    pub medium: Medium,
+
     /// Maximum transmission unit.
     ///
     /// The network device is unable to send or receive frames larger than the value returned
@@ -218,6 +227,33 @@ pub struct DeviceCapabilities {
     /// Only present to prevent people from trying to initialize every field of DeviceLimits,
     /// which would not let us add new fields in the future.
     dummy: ()
+}
+
+/// Type of medium of a device.
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub enum Medium {
+    /// Ethernet medium. Devices of this type send and receive Ethernet frames,
+    /// and interfaces using it must do neighbor discovery via ARP or NDISC.
+    ///
+    /// Examples of devices of this type are Ethernet, WiFi (802.11), Linux `tap`, and VPNs in tap (layer 2) mode.
+    #[cfg(feature = "ethernet")]
+    Ethernet,
+
+    /// IP medium. Devices of this type send and receive IP frames, without an
+    /// Ethernet header. MAC addresses are not used, and no neighbor discovery (ARP, NDISC) is done.
+    ///
+    /// Examples of devices of this type are the Linux `tun`, PPP interfaces, VPNs in tun (layer 3) mode.
+    Ip,
+}
+
+
+impl Default for Medium {
+    fn default() -> Medium {
+        #[cfg(feature = "ethernet")]
+        return Medium::Ethernet;
+        #[cfg(not(feature = "ethernet"))]
+        return Medium::Ip;
+    }
 }
 
 /// An interface for sending and receiving raw network frames.

--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -11,7 +11,7 @@ and implementations of it:
     [TapInterface](struct.TapInterface.html), to transmit and receive frames
     on the host OS.
 */
-#![cfg_attr(feature = "ethernet", doc = r##"
+#![cfg_attr(feature = "medium-ethernet", doc = r##"
 # Examples
 
 An implementation of the [Device](trait.Device.html) trait for a simple hardware
@@ -122,7 +122,7 @@ pub use self::tap_interface::TapInterface;
 pub use self::tun_interface::TunInterface;
 
 
-#[cfg(feature = "ethernet")]
+#[cfg(feature = "medium-ethernet")]
 /// A tracer device for Ethernet frames.
 pub type EthernetTracer<T> = Tracer<T, super::wire::EthernetFrame<&'static [u8]>>;
 
@@ -241,23 +241,26 @@ pub enum Medium {
     /// and interfaces using it must do neighbor discovery via ARP or NDISC.
     ///
     /// Examples of devices of this type are Ethernet, WiFi (802.11), Linux `tap`, and VPNs in tap (layer 2) mode.
-    #[cfg(feature = "ethernet")]
+    #[cfg(feature = "medium-ethernet")]
     Ethernet,
 
     /// IP medium. Devices of this type send and receive IP frames, without an
     /// Ethernet header. MAC addresses are not used, and no neighbor discovery (ARP, NDISC) is done.
     ///
     /// Examples of devices of this type are the Linux `tun`, PPP interfaces, VPNs in tun (layer 3) mode.
+    #[cfg(feature = "medium-ip")]
     Ip,
 }
 
 
 impl Default for Medium {
     fn default() -> Medium {
-        #[cfg(feature = "ethernet")]
+        #[cfg(feature = "medium-ethernet")]
         return Medium::Ethernet;
-        #[cfg(not(feature = "ethernet"))]
+        #[cfg(all(feature = "medium-ip", not(feature = "medium-ethernet")))]
         return Medium::Ip;
+        #[cfg(all(not(feature = "medium-ip"), not(feature = "medium-ethernet")))]
+        panic!("No medium enabled");
     }
 }
 

--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -102,6 +102,8 @@ mod loopback;
 mod raw_socket;
 #[cfg(all(feature = "phy-tap_interface", target_os = "linux"))]
 mod tap_interface;
+#[cfg(all(feature = "phy-tun_interface", target_os = "linux"))]
+mod tun_interface;
 
 #[cfg(all(any(feature = "phy-raw_socket", feature = "phy-tap_interface"), unix))]
 pub use self::sys::wait;
@@ -116,6 +118,9 @@ pub use self::loopback::Loopback;
 pub use self::raw_socket::RawSocket;
 #[cfg(all(feature = "phy-tap_interface", target_os = "linux"))]
 pub use self::tap_interface::TapInterface;
+#[cfg(all(feature = "phy-tun_interface", target_os = "linux"))]
+pub use self::tun_interface::TunInterface;
+
 
 #[cfg(feature = "ethernet")]
 /// A tracer device for Ethernet frames.

--- a/src/phy/raw_socket.rs
+++ b/src/phy/raw_socket.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::os::unix::io::{RawFd, AsRawFd};
 
 use Result;
-use phy::{self, sys, DeviceCapabilities, Device};
+use phy::{self, sys, DeviceCapabilities, Device, Medium};
 use time::Instant;
 
 /// A socket that captures or transmits the complete frame.
@@ -44,6 +44,7 @@ impl<'a> Device<'a> for RawSocket {
     fn capabilities(&self) -> DeviceCapabilities {
         DeviceCapabilities {
             max_transmission_unit: self.mtu,
+            medium: Medium::Ethernet,
             ..DeviceCapabilities::default()
         }
     }

--- a/src/phy/sys/linux.rs
+++ b/src/phy/sys/linux.rs
@@ -10,6 +10,8 @@ pub const ETH_P_ALL:    libc::c_short = 0x0003;
 
 #[cfg(feature = "phy-tap_interface")]
 pub const TUNSETIFF:    libc::c_ulong = 0x400454CA;
+#[cfg(feature = "phy-tun_interface")]
+pub const IFF_TUN:      libc::c_int   = 0x0001;
 #[cfg(feature = "phy-tap_interface")]
 pub const IFF_TAP:      libc::c_int   = 0x0002;
 #[cfg(feature = "phy-tap_interface")]

--- a/src/phy/sys/mod.rs
+++ b/src/phy/sys/mod.rs
@@ -15,6 +15,8 @@ pub mod raw_socket;
 pub mod bpf;
 #[cfg(all(feature = "phy-tap_interface", target_os = "linux"))]
 pub mod tap_interface;
+#[cfg(all(feature = "phy-tun_interface", target_os = "linux"))]
+pub mod tun_interface;
 
 #[cfg(all(feature = "phy-raw_socket", target_os = "linux"))]
 pub use self::raw_socket::RawSocketDesc;
@@ -22,6 +24,8 @@ pub use self::raw_socket::RawSocketDesc;
 pub use self::bpf::BpfDevice as RawSocketDesc;
 #[cfg(all(feature = "phy-tap_interface", target_os = "linux"))]
 pub use self::tap_interface::TapInterfaceDesc;
+#[cfg(all(feature = "phy-tun_interface", target_os = "linux"))]
+pub use self::tun_interface::TunInterfaceDesc;
 
 /// Wait until given file descriptor becomes readable, but no longer than given timeout.
 pub fn wait(fd: RawFd, duration: Option<Duration>) -> io::Result<()> {

--- a/src/phy/sys/tun_interface.rs
+++ b/src/phy/sys/tun_interface.rs
@@ -1,0 +1,75 @@
+use std::io;
+use std::os::unix::io::{RawFd, AsRawFd};
+use libc;
+use super::*;
+
+#[derive(Debug)]
+pub struct TunInterfaceDesc {
+    lower: libc::c_int,
+    ifreq: ifreq
+}
+
+impl AsRawFd for TunInterfaceDesc {
+    fn as_raw_fd(&self) -> RawFd {
+        self.lower
+    }
+}
+
+impl TunInterfaceDesc {
+    pub fn new(name: &str) -> io::Result<TunInterfaceDesc> {
+        let lower = unsafe {
+            let lower = libc::open("/dev/net/tun\0".as_ptr() as *const libc::c_char,
+                                   libc::O_RDWR | libc::O_NONBLOCK);
+            if lower == -1 { return Err(io::Error::last_os_error()) }
+            lower
+        };
+
+        Ok(TunInterfaceDesc {
+            lower: lower,
+            ifreq: ifreq_for(name)
+        })
+    }
+
+    pub fn attach_interface(&mut self) -> io::Result<()> {
+        self.ifreq.ifr_data = imp::IFF_TUN | imp::IFF_NO_PI;
+        ifreq_ioctl(self.lower, &mut self.ifreq, imp::TUNSETIFF).map(|_| ())
+    }
+
+    pub fn interface_mtu(&mut self) -> io::Result<usize> {
+        let lower = unsafe {
+            let lower = libc::socket(libc::AF_INET, libc::SOCK_DGRAM, libc::IPPROTO_IP);
+            if lower == -1 { return Err(io::Error::last_os_error()) }
+            lower
+        };
+
+        let mtu = ifreq_ioctl(lower, &mut self.ifreq, imp::SIOCGIFMTU).map(|mtu| mtu as usize);
+
+        unsafe { libc::close(lower); }
+
+        mtu
+    }
+
+    pub fn recv(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        unsafe {
+            let len = libc::read(self.lower, buffer.as_mut_ptr() as *mut libc::c_void,
+                                 buffer.len());
+            if len == -1 { return Err(io::Error::last_os_error()) }
+            Ok(len as usize)
+        }
+    }
+
+    pub fn send(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        unsafe {
+            let len = libc::write(self.lower, buffer.as_ptr() as *const libc::c_void,
+                                  buffer.len());
+            if len == -1 { Err(io::Error::last_os_error()).unwrap() }
+            Ok(len as usize)
+        }
+    }
+}
+
+impl Drop for TunInterfaceDesc {
+    fn drop(&mut self) {
+        unsafe { libc::close(self.lower); }
+    }
+}

--- a/src/phy/tap_interface.rs
+++ b/src/phy/tap_interface.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::os::unix::io::{RawFd, AsRawFd};
 
 use Result;
-use phy::{self, sys, DeviceCapabilities, Device};
+use phy::{self, sys, DeviceCapabilities, Device, Medium};
 use time::Instant;
 
 /// A virtual Ethernet interface.
@@ -45,6 +45,7 @@ impl<'a> Device<'a> for TapInterface {
     fn capabilities(&self) -> DeviceCapabilities {
         DeviceCapabilities {
             max_transmission_unit: self.mtu,
+            medium: Medium::Ethernet,
             ..DeviceCapabilities::default()
         }
     }

--- a/src/phy/tun_interface.rs
+++ b/src/phy/tun_interface.rs
@@ -1,0 +1,105 @@
+use std::cell::RefCell;
+use std::vec::Vec;
+use std::rc::Rc;
+use std::io;
+use std::os::unix::io::{RawFd, AsRawFd};
+
+use Result;
+use phy::{self, sys, DeviceCapabilities, Device, Medium};
+use time::Instant;
+
+/// A Tun interface.
+#[derive(Debug)]
+pub struct TunInterface {
+    lower:  Rc<RefCell<sys::TunInterfaceDesc>>,
+    mtu:    usize
+}
+
+impl AsRawFd for TunInterface {
+    fn as_raw_fd(&self) -> RawFd {
+        self.lower.borrow().as_raw_fd()
+    }
+}
+
+impl TunInterface {
+    /// Attaches to a TUN interface called `name`, or creates it if it does not exist.
+    ///
+    /// If `name` is a persistent interface configured with UID of the current user,
+    /// no special privileges are needed. Otherwise, this requires superuser privileges
+    /// or a corresponding capability set on the executable.
+    pub fn new(name: &str) -> io::Result<TunInterface> {
+        let mut lower = sys::TunInterfaceDesc::new(name)?;
+        lower.attach_interface()?;
+        let mtu = lower.interface_mtu()?;
+        Ok(TunInterface {
+            lower: Rc::new(RefCell::new(lower)),
+            mtu:   mtu
+        })
+    }
+}
+
+impl<'a> Device<'a> for TunInterface {
+    type RxToken = RxToken;
+    type TxToken = TxToken;
+
+    fn capabilities(&self) -> DeviceCapabilities {
+        DeviceCapabilities {
+            max_transmission_unit: self.mtu,
+            medium: Medium::Ip,
+            ..DeviceCapabilities::default()
+        }
+    }
+
+    fn receive(&'a mut self) -> Option<(Self::RxToken, Self::TxToken)> {
+        let mut lower = self.lower.borrow_mut();
+        let mut buffer = vec![0; self.mtu];
+        match lower.recv(&mut buffer[..]) {
+            Ok(size) => {
+                buffer.resize(size, 0);
+                let rx = RxToken { buffer };
+                let tx = TxToken { lower: self.lower.clone() };
+                Some((rx, tx))
+            }
+            Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => {
+                None
+            }
+            Err(err) => panic!("{}", err)
+        }
+    }
+
+    fn transmit(&'a mut self) -> Option<Self::TxToken> {
+        Some(TxToken {
+            lower: self.lower.clone(),
+        })
+    }
+}
+
+#[doc(hidden)]
+pub struct RxToken {
+    buffer: Vec<u8>
+}
+
+impl phy::RxToken for RxToken {
+    fn consume<R, F>(mut self, _timestamp: Instant, f: F) -> Result<R>
+        where F: FnOnce(&mut [u8]) -> Result<R>
+    {
+        f(&mut self.buffer[..])
+    }
+}
+
+#[doc(hidden)]
+pub struct TxToken {
+    lower: Rc<RefCell<sys::TunInterfaceDesc>>,
+}
+
+impl phy::TxToken for TxToken {
+    fn consume<R, F>(self, _timestamp: Instant, len: usize, f: F) -> Result<R>
+        where F: FnOnce(&mut [u8]) -> Result<R>
+    {
+        let mut lower = self.lower.borrow_mut();
+        let mut buffer = vec![0; len];
+        let result = f(&mut buffer);
+        lower.send(&buffer[..]).unwrap();
+        result
+    }
+}

--- a/src/wire/icmpv6.rs
+++ b/src/wire/icmpv6.rs
@@ -6,7 +6,7 @@ use phy::ChecksumCapabilities;
 use super::ip::checksum;
 use super::{IpAddress, IpProtocol, Ipv6Packet, Ipv6Repr};
 use super::MldRepr;
-#[cfg(feature = "ethernet")]
+#[cfg(feature = "medium-ethernet")]
 use super::NdiscRepr;
 
 enum_with_unknown! {
@@ -539,7 +539,7 @@ pub enum Repr<'a> {
         seq_no: u16,
         data:   &'a [u8]
     },
-    #[cfg(feature = "ethernet")]
+    #[cfg(feature = "medium-ethernet")]
     Ndisc(NdiscRepr<'a>),
     Mld(MldRepr<'a>),
     #[doc(hidden)]
@@ -622,7 +622,7 @@ impl<'a> Repr<'a> {
                     data:   packet.payload()
                 })
             },
-            #[cfg(feature = "ethernet")]
+            #[cfg(feature = "medium-ethernet")]
             (msg_type, 0) if msg_type.is_ndisc() => {
                 NdiscRepr::parse(packet).map(|repr| Repr::Ndisc(repr))
             },
@@ -644,7 +644,7 @@ impl<'a> Repr<'a> {
             &Repr::EchoReply { data, .. } => {
                 field::ECHO_SEQNO.end + data.len()
             },
-            #[cfg(feature = "ethernet")]
+            #[cfg(feature = "medium-ethernet")]
             &Repr::Ndisc(ndisc) => {
                 ndisc.buffer_len()
             },
@@ -716,7 +716,7 @@ impl<'a> Repr<'a> {
                 packet.payload_mut()[..data_len].copy_from_slice(&data[..data_len])
             },
 
-            #[cfg(feature = "ethernet")]
+            #[cfg(feature = "medium-ethernet")]
             &Repr::Ndisc(ndisc) => {
                 ndisc.emit(packet)
             },

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -77,9 +77,9 @@ mod field {
 
 pub mod pretty_print;
 
-#[cfg(feature = "ethernet")]
+#[cfg(feature = "medium-ethernet")]
 mod ethernet;
-#[cfg(all(feature = "proto-ipv4", feature = "ethernet"))]
+#[cfg(all(feature = "proto-ipv4", feature = "medium-ethernet"))]
 mod arp;
 pub(crate) mod ip;
 #[cfg(feature = "proto-ipv4")]
@@ -102,9 +102,9 @@ mod icmpv6;
 mod icmp;
 #[cfg(feature = "proto-igmp")]
 mod igmp;
-#[cfg(all(feature = "proto-ipv6", feature = "ethernet"))]
+#[cfg(all(feature = "proto-ipv6", feature = "medium-ethernet"))]
 mod ndisc;
-#[cfg(all(feature = "proto-ipv6", feature = "ethernet"))]
+#[cfg(all(feature = "proto-ipv6", feature = "medium-ethernet"))]
 mod ndiscoption;
 #[cfg(feature = "proto-ipv6")]
 mod mld;
@@ -115,13 +115,13 @@ pub(crate) mod dhcpv4;
 
 pub use self::pretty_print::PrettyPrinter;
 
-#[cfg(feature = "ethernet")]
+#[cfg(feature = "medium-ethernet")]
 pub use self::ethernet::{EtherType as EthernetProtocol,
                          Address as EthernetAddress,
                          Frame as EthernetFrame,
                          Repr as EthernetRepr};
 
-#[cfg(all(feature = "proto-ipv4", feature = "ethernet"))]
+#[cfg(all(feature = "proto-ipv4", feature = "medium-ethernet"))]
 pub use self::arp::{Hardware as ArpHardware,
                     Operation as ArpOperation,
                     Packet as ArpPacket,
@@ -192,12 +192,12 @@ pub use self::icmpv6::{Message as Icmpv6Message,
 pub use self::icmp::Repr as IcmpRepr;
 
 
-#[cfg(all(feature = "proto-ipv6", feature = "ethernet"))]
+#[cfg(all(feature = "proto-ipv6", feature = "medium-ethernet"))]
 pub use self::ndisc::{Repr as NdiscRepr,
                       RouterFlags as NdiscRouterFlags,
                       NeighborFlags as NdiscNeighborFlags};
 
-#[cfg(all(feature = "proto-ipv6", feature = "ethernet"))]
+#[cfg(all(feature = "proto-ipv6", feature = "medium-ethernet"))]
 pub use self::ndiscoption::{NdiscOption,
                             Repr as NdiscOptionRepr,
                             Type as NdiscOptionType,


### PR DESCRIPTION
This is a new attempt at implementing #334, addressing the shortcomings found in the first version (#336) detailed in https://github.com/smoltcp-rs/smoltcp/pull/336#issuecomment-638520316.

So far I'm quite pleased by how it turned out. The only big structural change in `Interface` is checking for `Device.medium()` in send and receive paths and adjusting the behavior accordingly. The rest of the changes are mostly boilerplate and updating the tests.

This includes the Linux tun work by @lucaszanella from Dirbaio/smoltcp#1, squashed and updated for the v2 changes.

Things that need fixing:
- [ ] The prettyprinter is broken (it doesn't take `medium` into account, always interprets as Ethernet)

Possible future work:
- [X] Adding a `medium_ip` feature DONE
- [X] Renaming `ethernet` feature to `medium_ethernet` for consistency? DONE
- [ ] Doing a PoC of instantiating an `Interface` with dynamic dispatch to the device, check how much improvement in binary size is there vs static dispatch.