### PR TITLE
replace deprecated item 'mem::uninitialized'

### DIFF
--- a/src/phy/sys/mod.rs
+++ b/src/phy/sys/mod.rs
@@ -26,15 +26,24 @@ pub use self::tap_interface::TapInterfaceDesc;
 /// Wait until given file descriptor becomes readable, but no longer than given timeout.
 pub fn wait(fd: RawFd, duration: Option<Duration>) -> io::Result<()> {
     unsafe {
-        let mut readfds = mem::uninitialized::<libc::fd_set>();
-        libc::FD_ZERO(&mut readfds);
-        libc::FD_SET(fd, &mut readfds);
+        let mut readfds = {
+            let mut readfds = mem::MaybeUninit::<libc::fd_set>::uninit();
+            libc::FD_ZERO(readfds.as_mut_ptr());
+            libc::FD_SET(fd, readfds.as_mut_ptr());
+            readfds.assume_init()
+        };
 
-        let mut writefds = mem::uninitialized::<libc::fd_set>();
-        libc::FD_ZERO(&mut writefds);
+        let mut writefds = {
+            let mut writefds = mem::MaybeUninit::<libc::fd_set>::uninit();
+            libc::FD_ZERO(writefds.as_mut_ptr());
+            writefds.assume_init()
+        };
 
-        let mut exceptfds = mem::uninitialized::<libc::fd_set>();
-        libc::FD_ZERO(&mut exceptfds);
+        let mut exceptfds = {
+            let mut exceptfds = mem::MaybeUninit::<libc::fd_set>::uninit();
+            libc::FD_ZERO(exceptfds.as_mut_ptr());
+            exceptfds.assume_init()
+        };
 
         let mut timeout = libc::timeval { tv_sec: 0, tv_usec: 0 };
         let timeout_ptr =


### PR DESCRIPTION
This PR replaces the use of deprecated item `mem::uninitialized` with `mem::MaybeUninit`.

Thank you for reviewing 🦸‍♀️ 