### PR TITLE
Adjusting TCP connection 3-way handshake state management

### DIFF
--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -2500,6 +2500,18 @@ mod test {
     }
 
     #[test]
+    fn test_syn_sent_bad_ack() {
+        let mut s = socket_syn_sent();
+        send!(s, TcpRepr {
+            control: TcpControl::None,
+            seq_number: REMOTE_SEQ,
+            ack_number: Some(TcpSeqNumber(1)),
+            ..SEND_TEMPL
+        }, Err(Error::Dropped));
+        assert_eq!(s.state, State::Closed);
+    }
+
+    #[test]
     fn test_syn_sent_close() {
         let mut s = socket();
         s.close();

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -999,7 +999,7 @@ impl<'a> TcpSocket<'a> {
             (State::SynSent, &TcpRepr {
                 control: TcpControl::None, ack_number: Some(_), ..
             }) => {
-                net_debug!("{}:{}:{}: expecting a SYN,ACK",
+                net_debug!("{}:{}:{}: expecting a SYN|ACK",
                            self.meta.handle, self.local_endpoint, self.remote_endpoint);
                 self.abort();
                 return Err(Error::Dropped)

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -995,6 +995,15 @@ impl<'a> TcpSocket<'a> {
                            self.meta.handle, self.local_endpoint, self.remote_endpoint);
                 return Err(Error::Dropped)
             }
+            // Any ACK in the SYN-SENT state must have the SYN flag set.
+            (State::SynSent, &TcpRepr {
+                control: TcpControl::None, ack_number: Some(_), ..
+            }) => {
+                net_debug!("{}:{}:{}: expecting a SYN,ACK",
+                           self.meta.handle, self.local_endpoint, self.remote_endpoint);
+                self.abort();
+                return Err(Error::Dropped)
+            }
             // Every acknowledgement must be for transmitted but unacknowledged data.
             (_, &TcpRepr { ack_number: Some(ack_number), .. }) => {
                 let unacknowledged = self.tx_buffer.len() + control_len;

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -2504,7 +2504,6 @@ mod test {
         let mut s = socket_syn_sent();
         send!(s, TcpRepr {
             control: TcpControl::None,
-            seq_number: REMOTE_SEQ,
             ack_number: Some(TcpSeqNumber(1)),
             ..SEND_TEMPL
         }, Err(Error::Dropped));


### PR DESCRIPTION
This PR fixes #366 by adding an `abort()` if an `ACK` is received without the `SYN` flag set when in `SYN-SENT`.

The implications of this are that the user will have to re-`connect` the TCP socket after this occurrence. 