### PR TITLE
Allow for ARP retry during egress

### DIFF
--- a/src/iface/ethernet.rs
+++ b/src/iface/ethernet.rs
@@ -578,7 +578,7 @@ impl<'b, 'c, 'e, DeviceT> Interface<'b, 'c, 'e, DeviceT>
 
         let mut emitted_any = false;
         for mut socket in sockets.iter_mut() {
-            if !socket.meta_mut().egress_permitted(|ip_addr|
+            if !socket.meta_mut().egress_permitted(timestamp, |ip_addr|
                     self.inner.has_neighbor(&ip_addr, timestamp)) {
                 continue
             }

--- a/src/socket/meta.rs
+++ b/src/socket/meta.rs
@@ -71,7 +71,7 @@ impl Meta {
                     self.neighbor_state = NeighborState::Active;
                     true
                 } else if timestamp > silent_until {
-                    net_trace!("{}: Retrying egress for neighbor {}", self.handle, neighbor);
+                    net_trace!("{}: neighbor {} silence timer expired, rediscovering", self.handle, neighbor);
                     true
                 } else {
                     false

--- a/src/socket/meta.rs
+++ b/src/socket/meta.rs
@@ -58,17 +58,20 @@ impl Meta {
         }
     }
 
-    pub(crate) fn egress_permitted<F>(&mut self, has_neighbor: F) -> bool
+    pub(crate) fn egress_permitted<F>(&mut self, timestamp: Instant, has_neighbor: F) -> bool
         where F: Fn(IpAddress) -> bool
     {
         match self.neighbor_state {
             NeighborState::Active =>
                 true,
-            NeighborState::Waiting { neighbor, .. } => {
+            NeighborState::Waiting { neighbor, silent_until } => {
                 if has_neighbor(neighbor) {
                     net_trace!("{}: neighbor {} discovered, unsilencing",
                                self.handle, neighbor);
                     self.neighbor_state = NeighborState::Active;
+                    true
+                } else if timestamp > silent_until {
+                    net_trace!("{}: Retrying egress for neighbor {}", self.handle, neighbor);
                     true
                 } else {
                     false


### PR DESCRIPTION
The stack would send an ARP and put the `Neighbor` into the waiting state if it couldn't find a valid (non expired) hardware address, but it wouldn't allow for retries, stalling the socket indefinitely if we didn't get a response. These changes allow for retries after a `silent timer` has expired.

Closes https://github.com/smoltcp-rs/smoltcp/issues/319

CC @birkenfeld