### PR TITLE
add null terminator to c-string passed to 'libc::open'

### DIFF
--- a/src/phy/sys/bpf.rs
+++ b/src/phy/sys/bpf.rs
@@ -43,7 +43,7 @@ impl AsRawFd for BpfDevice {
 fn open_device() -> io::Result<libc::c_int> {
     unsafe {
         for i in 0..256 {
-            let dev = format!("/dev/bpf{}", i).as_ptr() as *const libc::c_char;
+            let dev = format!("/dev/bpf{}\0", i).as_ptr() as *const libc::c_char;
             match libc::open(dev, libc::O_RDWR) {
                 -1 => continue,
                 fd => return Ok(fd),


### PR DESCRIPTION
Hello :crab: , this PR appends a null-terminator(`\0`) to c-string fed to `libc::open`.

Function signature of `libc::open` is as follows.
`open(path: *const c_char, oflag: c_int, ...) -> c_int`

**Buffer-over-read** could happen when the `libc` implementation relies on `path` terminating with a null byte.

In `src/phy/sys/tap_interface.rs`, a string fed to `libc::open` is appended with a null terminator.
This PR is to do the same thing in `src/phy/sys/bpf.rs`.
https://github.com/smoltcp-rs/smoltcp/blob/bdfa44270e9c59b3095b555cdf14601f7dc27794/src/phy/sys/tap_interface.rs#L21

Thank you for reviewing this PR :smiley_cat: 