### PR TITLE
Changed Dhcpv4Client to use device checksum capabilities

### DIFF
--- a/src/dhcp/clientv4.rs
+++ b/src/dhcp/clientv4.rs
@@ -130,7 +130,7 @@ impl Client {
     where
         DeviceT: for<'d> Device<'d>,
     {
-        let checksum_caps = ChecksumCapabilities::default();  // ?
+        let checksum_caps = iface.device().capabilities().checksum;
         let mut raw_socket = sockets.get::<RawSocket>(self.raw_handle);
 
         // Process incoming


### PR DESCRIPTION
Fixes #371 by fetching the checksum capabilities from the `Device`.

Previously, the checksum capabilities were always set to `ChecksumCapabilities::default()`, which could mess with the checksum generation.