### PR TITLE
Add SocketHandle::inner

### DIFF
--- a/src/socket/set.rs
+++ b/src/socket/set.rs
@@ -25,6 +25,13 @@ impl fmt::Display for Handle {
     }
 }
 
+impl Handle {
+    /// Return a numeric value of the handle.
+    pub fn inner(&self) -> usize {
+        self.0
+    }
+}
+
 /// An extensible set of sockets.
 ///
 /// The lifetimes `'b` and `'c` are used when storing a `Socket<'b, 'c>`.


### PR DESCRIPTION
Since `Hash` and `Display` are already implemented for `smoltcp::socket::set::Handle`, the numeric value of the handle is obtainable through these indirect means. I think it makes sense to expose a method to get this value explicitly.