### PR TITLE
Fixes unused MTU settings at TcpSocket dispatch

### DIFF
--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1559,7 +1559,7 @@ impl<'a> TcpSocket<'a> {
                 // from the transmit buffer.
                 let offset = self.remote_last_seq - self.local_seq_no;
                 let size = cmp::min(cmp::min(self.remote_win_len, self.remote_mss),
-                     caps.max_transmission_unit);
+                     caps.max_transmission_unit - ip_repr.buffer_len() - repr.mss_header_len());
                 repr.payload = self.tx_buffer.get_allocated(offset, size);
                 // If we've sent everything we had in the buffer, follow it with the PSH or FIN
                 // flags, depending on whether the transmit half of the connection is open.

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1558,7 +1558,8 @@ impl<'a> TcpSocket<'a> {
                 // Extract as much data as the remote side can receive in this packet
                 // from the transmit buffer.
                 let offset = self.remote_last_seq - self.local_seq_no;
-                let size = cmp::min(self.remote_win_len, self.remote_mss);
+                let size = cmp::min(cmp::min(self.remote_win_len, self.remote_mss),
+                     caps.max_transmission_unit);
                 repr.payload = self.tx_buffer.get_allocated(offset, size);
                 // If we've sent everything we had in the buffer, follow it with the PSH or FIN
                 // flags, depending on whether the transmit half of the connection is open.


### PR DESCRIPTION
This commit fixes a small bug, where the TcpSocket computed the maximum
size per payload in a tx_buffer without taking into account the MTU
defined by the underlying network device.