### PR TITLE
tcp: allow sending ACKs in FinWait2 state.

### DIFF
--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1574,8 +1574,9 @@ impl<'a> TcpSocket<'a> {
                 }
             }
 
-            // We do not transmit anything in the FIN-WAIT-2 state.
-            State::FinWait2 => return Err(Error::Exhausted),
+            // We do not transmit data in the FIN-WAIT-2 state, but we may transmit
+            // ACKs for incoming data.
+            State::FinWait2 => {}
 
             // We do not transmit data or control flags in the CLOSING or TIME-WAIT states,
             // but we may retransmit an ACK.
@@ -3093,6 +3094,11 @@ mod test {
             assert_eq!(data, b"abc");
             (3, ())
         }).unwrap();
+        recv!(s, [TcpRepr {
+            seq_number: LOCAL_SEQ + 1 + 1,
+            ack_number: Some(REMOTE_SEQ + 1 + 3),
+            ..RECV_TEMPL
+        }]);
     }
 
     #[test]


### PR DESCRIPTION
in FinWait2 the connection is "half-closed": we may no longer send data, but we still can receive data. This data has to be ACKed.

The current code forbids anything to be sent in FinWait2, this has 2 problems:
- ACKs are not sent.
- A polling infinite busy loop happens, because `poll_at` still returns PollAt::Now (because `ack_to_transmit` returns `true`), but dispatch doesn't actually do anything.

This extends a test to cover the failure, then fixes it.