### PR TITLE
Fix MTU of RawSocket and TapInterface.

### DIFF
--- a/src/phy/sys/raw_socket.rs
+++ b/src/phy/sys/raw_socket.rs
@@ -2,6 +2,7 @@ use std::{mem, io};
 use std::os::unix::io::{RawFd, AsRawFd};
 use libc;
 use super::*;
+use crate::wire::EthernetFrame;
 
 #[derive(Debug)]
 pub struct RawSocketDesc {
@@ -31,7 +32,10 @@ impl RawSocketDesc {
     }
 
     pub fn interface_mtu(&mut self) -> io::Result<usize> {
-        ifreq_ioctl(self.lower, &mut self.ifreq, imp::SIOCGIFMTU).map(|mtu| mtu as usize)
+        // SIOCGIFMTU returns the IP MTU (typically 1500 bytes.)
+        // smoltcp counts the entire Ethernet packet in the MTU, so add the Ethernet header size to it.
+        let ip_mtu = ifreq_ioctl(self.lower, &mut self.ifreq, imp::SIOCGIFMTU).map(|mtu| mtu as usize)?;
+        Ok(ip_mtu + EthernetFrame::<&[u8]>::header_len())
     }
 
     pub fn bind_interface(&mut self) -> io::Result<()> {


### PR DESCRIPTION
Linux's MTU is the IP MTU, while smoltcp's is the Ethernet MTU. Therefore we have to add the ethernet header size to it.