### PR TITLE
Async/await waker support.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           - std ethernet proto-ipv6 socket-icmp socket-tcp
 
           # Test features chosen to be as aggressive as possible.
-          - std ethernet proto-ipv4 proto-ipv6 socket-raw socket-udp socket-tcp socket-icmp
+          - std ethernet proto-ipv4 proto-ipv6 socket-raw socket-udp socket-tcp socket-icmp async
 
         include:
           # Test alloc feature which requires nightly.
@@ -66,7 +66,7 @@ jobs:
 
         features:
           # These feature sets cannot run tests, so we only check they build.
-          - ethernet proto-ipv6 proto-ipv6 proto-igmp proto-dhcpv4 socket-raw socket-udp socket-tcp socket-icmp
+          - ethernet proto-ipv6 proto-ipv6 proto-igmp proto-dhcpv4 socket-raw socket-udp socket-tcp socket-icmp async
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,14 @@ ethernet = []
 "socket-udp" = []
 "socket-tcp" = []
 "socket-icmp" = []
+"async" = []
 default = [
   "std", "log", # needed for `cargo test --no-default-features --features default` :/
   "ethernet",
   "phy-raw_socket", "phy-tap_interface",
   "proto-ipv4", "proto-igmp", "proto-dhcpv4", "proto-ipv6",
-  "socket-raw", "socket-icmp", "socket-udp", "socket-tcp"
+  "socket-raw", "socket-icmp", "socket-udp", "socket-tcp",
+  "async"
 ]
 
 # experimental; do not use; no guarantees provided that this feature will be kept

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -26,7 +26,12 @@ mod tcp;
 mod set;
 mod ref_;
 
+#[cfg(feature = "async")]
+mod waker;
+
 pub(crate) use self::meta::Meta as SocketMeta;
+#[cfg(feature = "async")]
+pub(crate) use self::waker::WakerRegistration;
 
 #[cfg(feature = "socket-raw")]
 pub use self::raw::{RawPacketMetadata,

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -4,6 +4,10 @@ use {Error, Result};
 use socket::{Socket, SocketMeta, SocketHandle, PollAt};
 use storage::{PacketBuffer, PacketMetadata};
 use wire::{IpProtocol, IpRepr, IpEndpoint, UdpRepr};
+#[cfg(feature = "async")]
+use socket::WakerRegistration;
+#[cfg(feature = "async")]
+use core::task::Waker;
 
 /// A UDP packet metadata.
 pub type UdpPacketMetadata = PacketMetadata<IpEndpoint>;
@@ -22,7 +26,11 @@ pub struct UdpSocket<'a, 'b: 'a> {
     rx_buffer: UdpSocketBuffer<'a, 'b>,
     tx_buffer: UdpSocketBuffer<'a, 'b>,
     /// The time-to-live (IPv4) or hop limit (IPv6) value used in outgoing packets.
-    hop_limit: Option<u8>
+    hop_limit: Option<u8>,
+    #[cfg(feature = "async")]
+    rx_waker: WakerRegistration,
+    #[cfg(feature = "async")]
+    tx_waker: WakerRegistration,
 }
 
 impl<'a, 'b> UdpSocket<'a, 'b> {
@@ -34,8 +42,47 @@ impl<'a, 'b> UdpSocket<'a, 'b> {
             endpoint:  IpEndpoint::default(),
             rx_buffer: rx_buffer,
             tx_buffer: tx_buffer,
-            hop_limit: None
+            hop_limit: None,
+            #[cfg(feature = "async")]
+            rx_waker: WakerRegistration::new(),
+            #[cfg(feature = "async")]
+            tx_waker: WakerRegistration::new(),
         }
+    }
+
+    /// Register a waker for receive operations.
+    ///
+    /// The waker is woken on state changes that might affect the return value
+    /// of `recv` method calls, such as receiving data, or the socket closing.
+    /// 
+    /// Notes:
+    ///
+    /// - Only one waker can be registered at a time. If another waker was previously registered,
+    ///   it is overwritten and will no longer be woken.
+    /// - The Waker is woken only once. Once woken, you must register it again to receive more wakes. 
+    /// - "Spurious wakes" are allowed: a wake doesn't guarantee the result of `recv` has
+    ///   necessarily changed.
+    #[cfg(feature = "async")]
+    pub fn register_recv_waker(&mut self, waker: &Waker) {
+        self.rx_waker.register(waker)
+    }
+
+    /// Register a waker for send operations.
+    ///
+    /// The waker is woken on state changes that might affect the return value
+    /// of `send` method calls, such as space becoming available in the transmit
+    /// buffer, or the socket closing.
+    /// 
+    /// Notes:
+    ///
+    /// - Only one waker can be registered at a time. If another waker was previously registered,
+    ///   it is overwritten and will no longer be woken.
+    /// - The Waker is woken only once. Once woken, you must register it again to receive more wakes. 
+    /// - "Spurious wakes" are allowed: a wake doesn't guarantee the result of `send` has
+    ///   necessarily changed.
+    #[cfg(feature = "async")]
+    pub fn register_send_waker(&mut self, waker: &Waker) {
+        self.tx_waker.register(waker)
     }
 
     /// Return the socket handle.
@@ -89,6 +136,13 @@ impl<'a, 'b> UdpSocket<'a, 'b> {
         if self.is_open() { return Err(Error::Illegal) }
 
         self.endpoint = endpoint;
+
+        #[cfg(feature = "async")]
+        {
+            self.rx_waker.wake();
+            self.tx_waker.wake();
+        }
+
         Ok(())
     }
 
@@ -234,6 +288,10 @@ impl<'a, 'b> UdpSocket<'a, 'b> {
         net_trace!("{}:{}:{}: receiving {} octets",
                    self.meta.handle, self.endpoint,
                    endpoint, size);
+
+        #[cfg(feature = "async")]
+        self.rx_waker.wake();
+
         Ok(())
     }
 
@@ -261,7 +319,12 @@ impl<'a, 'b> UdpSocket<'a, 'b> {
                 hop_limit:   hop_limit,
             };
             emit((ip_repr, repr))
-        })
+        })?;
+
+        #[cfg(feature = "async")]
+        self.tx_waker.wake();
+
+        Ok(())
     }
 
     pub(crate) fn poll_at(&self) -> PollAt {

--- a/src/socket/waker.rs
+++ b/src/socket/waker.rs
@@ -1,0 +1,33 @@
+use core::task::Waker;
+
+/// Utility struct to register and wake a waker.
+#[derive(Debug)]
+pub struct WakerRegistration {
+    waker: Option<Waker>,
+}
+
+impl WakerRegistration {
+    pub const fn new() -> Self {
+        Self { waker: None }
+    }
+
+    /// Register a waker. Overwrites the previous waker, if any.
+    pub fn register(&mut self, w: &Waker) {
+        match self.waker {
+            // Optimization: If both the old and new Wakers wake the same task, we can simply
+            // keep the old waker, skipping the clone. (In most executor implementations,
+            // cloning a waker is somewhat expensive, comparable to cloning an Arc).
+            Some(ref w2) if (w2.will_wake(w)) => {}
+            // In all other cases
+            // - we have no waker registered
+            // - we have a waker registered but it's for a different task.
+            // then clone the new waker and store it
+            _ => self.waker = Some(w.clone()),
+        }
+    }
+
+    /// Wake the registered waker, if any.
+    pub fn wake(&mut self) {
+        self.waker.take().map(|w| w.wake());
+    }
+}


### PR DESCRIPTION
This adds `register_recv_waker` and `register_send_waker` methods to all socket types. 

This is the minimum required changes to smoltcp to support being used in async/await code. This opens the door for higher-level crates that expose wrappers implementing async traits like AsyncRead/AsyncWrite, Future, Stream...

I believe this is the best way to go, because:

- It is not clear which traits should smoltcp implement:
  - The `std` ecosystem has multiple competing incompatible traits, mainly `tokio` and `futures`.
  - The `no_std` ecosystem hasn't converged on any standard io traits yet. The `tokio` and `futures` traits aren't `no_std` compatible. 
- There are non-trivial tradeoffs when implementing async support: how are sockets allocated, is there a single global tcp/ip stack or multiple, how are lifetimes handled. 

By delegating these choices to external crates, smoltcp can stay un-opinionated.

There's an example of using this to implement AsyncBufRead and AsyncWrite in `embassy` [here](https://github.com/embassy-rs/embassy/blob/master/embassy-net/src/tcp_socket.rs). Wrappers for the `tokio` or `futures` traits would look very similar. The use of `unsafe` there is not necessary in theory, AsyncRead and AsyncWrite can be implemented in 100% safe Rust. AsyncBufRead probably will require unsafe in most cases, unfortunately.

Previously discussed on #382 and #267 .