### PR TITLE
tcp: Add RTT estimation.

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -50,19 +50,19 @@ impl Instant {
 
     /// The fractional number of milliseconds that have passed
     /// since the beginning of time.
-    pub fn millis(&self) -> i64 {
+    pub const fn millis(&self) -> i64 {
         self.millis % 1000
     }
 
     /// The number of whole seconds that have passed since the
     /// beginning of time.
-    pub fn secs(&self) -> i64 {
+    pub const fn secs(&self) -> i64 {
         self.millis / 1000
     }
 
     /// The total number of milliseconds that have passed since
     /// the biginning of time.
-    pub fn total_millis(&self) -> i64 {
+    pub const fn total_millis(&self) -> i64 {
         self.millis
     }
 }
@@ -141,27 +141,27 @@ pub struct Duration {
 
 impl Duration {
     /// Create a new `Duration` from a number of milliseconds.
-    pub fn from_millis(millis: u64) -> Duration {
+    pub const fn from_millis(millis: u64) -> Duration {
         Duration { millis }
     }
 
     /// Create a new `Instant` from a number of seconds.
-    pub fn from_secs(secs: u64) -> Duration {
+    pub const fn from_secs(secs: u64) -> Duration {
         Duration { millis: secs * 1000 }
     }
 
     /// The fractional number of milliseconds in this `Duration`.
-    pub fn millis(&self) -> u64 {
+    pub const fn millis(&self) -> u64 {
         self.millis % 1000
     }
 
     /// The number of whole seconds in this `Duration`.
-    pub fn secs(&self) -> u64 {
+    pub const fn secs(&self) -> u64 {
         self.millis / 1000
     }
 
     /// The total number of milliseconds in this `Duration`.
-    pub fn total_millis(&self) -> u64 {
+    pub const fn total_millis(&self) -> u64 {
         self.millis
     }
 }


### PR DESCRIPTION
- Add a RTT estimator implementing the algorithm from Van Jacobson's original paper
- Use its output as the retransmission timeout, instead of the previous hardcoded 100ms.

This massively improves performance in slow networks such as 3G/4G/LTE. 

Tested against a Linux stack, simulating latency with `netem`. For example, to add a delay of 100ms with 40ms of jitter:

    sudo tc qdisc replace dev tap0 root netem delay 100ms 40ms

Testing shows this eliminates all the unnecessary retransmissions:

```
Before:

3303	2758.061630482	192.168.69.1	192.168.69.100	TCP	1514	1234 → 36492 [PSH, ACK] Seq=81921 Ack=1 Win=2048 Len=1460
3304	2758.061769051	192.168.69.100	192.168.69.1	TCP	54	36492 → 1234 [ACK] Seq=1 Ack=81921 Win=107904 Len=0
3305	2758.061888699	192.168.69.1	192.168.69.100	TCP	642	1234 → 36492 [PSH, ACK] Seq=83381 Ack=1 Win=2048 Len=588
3306	2758.162142016	192.168.69.1	192.168.69.100	TCP	1514	[TCP Out-Of-Order] 1234 → 36492 [ACK] Seq=81921 Ack=1 Win=2048 Len=1460
3307	2758.162170291	192.168.69.1	192.168.69.100	TCP	642	[TCP Retransmission] 1234 → 36492 [PSH, ACK] Seq=83381 Ack=1 Win=2048 Len=588
3308	2758.177570006	192.168.69.100	192.168.69.1	TCP	66	[TCP Dup ACK 3304#1] 36492 → 1234 [ACK] Seq=1 Ack=81921 Win=107904 Len=0 SLE=79873 SRE=81333
3309	2758.189322198	192.168.69.100	192.168.69.1	TCP	66	[TCP Dup ACK 3304#2] 36492 → 1234 [ACK] Seq=1 Ack=81921 Win=107904 Len=0 SLE=81333 SRE=81921
3310	2758.219241882	192.168.69.100	192.168.69.1	TCP	66	[TCP Dup ACK 3304#3] 36492 → 1234 [ACK] Seq=1 Ack=81921 Win=107904 Len=0 SLE=79873 SRE=81333
3311	2758.219306221	192.168.69.1	192.168.69.100	TCP	1514	[TCP Fast Retransmission] 1234 → 36492 [ACK] Seq=81921 Ack=1 Win=2048 Len=1460
3312	2758.219313302	192.168.69.1	192.168.69.100	TCP	642	[TCP Retransmission] 1234 → 36492 [PSH, ACK] Seq=83381 Ack=1 Win=2048 Len=588
3313	2758.238660869	192.168.69.100	192.168.69.1	TCP	66	[TCP Dup ACK 3304#4] 36492 → 1234 [ACK] Seq=1 Ack=81921 Win=107904 Len=0 SLE=81333 SRE=81921
3314	2758.244392088	192.168.69.100	192.168.69.1	TCP	54	36492 → 1234 [ACK] Seq=1 Ack=83381 Win=110848 Len=0
3315	2758.244469607	192.168.69.1	192.168.69.100	TCP	1514	1234 → 36492 [PSH, ACK] Seq=83969 Ack=1 Win=2048 Len=1460
3316	2758.297758461	192.168.69.100	192.168.69.1	TCP	54	36492 → 1234 [ACK] Seq=1 Ack=83969 Win=113792 Len=0
3317	2758.297899404	192.168.69.1	192.168.69.100	TCP	642	1234 → 36492 [PSH, ACK] Seq=85429 Ack=1 Win=2048 Len=588
3318	2758.375412811	192.168.69.100	192.168.69.1	TCP	66	[TCP Dup ACK 3316#1] 36492 → 1234 [ACK] Seq=1 Ack=83969 Win=113792 Len=0 SLE=81921 SRE=83381
3319	2758.394315585	192.168.69.100	192.168.69.1	TCP	66	[TCP Dup ACK 3316#2] 36492 → 1234 [ACK] Seq=1 Ack=83969 Win=113792 Len=0 SLE=83381 SRE=83969
3320	2758.398778234	192.168.69.1	192.168.69.100	TCP	1514	[TCP Fast Retransmission] 1234 → 36492 [ACK] Seq=83969 Ack=1 Win=2048 Len=1460
3321	2758.398808674	192.168.69.1	192.168.69.100	TCP	642	[TCP Retransmission] 1234 → 36492 [PSH, ACK] Seq=85429 Ack=1 Win=2048 Len=588
3322	2758.493322989	192.168.69.100	192.168.69.1	TCP	66	[TCP Dup ACK 3316#3] 36492 → 1234 [ACK] Seq=1 Ack=83969 Win=113792 Len=0 SLE=81921 SRE=83381

After: 

2498	2712.377287021	192.168.69.1	192.168.69.100	TCP	642	1234 → 36480 [PSH, ACK] Seq=73141 Ack=1 Win=2048 Len=588
2499	2712.593987771	192.168.69.100	192.168.69.1	TCP	54	36480 → 1234 [ACK] Seq=1 Ack=73141 Win=81664 Len=0
2500	2712.594025393	192.168.69.1	192.168.69.100	TCP	1514	1234 → 36480 [PSH, ACK] Seq=73729 Ack=1 Win=2048 Len=1460
2501	2712.594416483	192.168.69.100	192.168.69.1	TCP	54	36480 → 1234 [ACK] Seq=1 Ack=73729 Win=84608 Len=0
2502	2712.594431805	192.168.69.1	192.168.69.100	TCP	642	1234 → 36480 [PSH, ACK] Seq=75189 Ack=1 Win=2048 Len=588
2503	2712.811480972	192.168.69.100	192.168.69.1	TCP	54	36480 → 1234 [ACK] Seq=1 Ack=75189 Win=87552 Len=0
2504	2712.811611744	192.168.69.1	192.168.69.100	TCP	1514	1234 → 36480 [PSH, ACK] Seq=75777 Ack=1 Win=2048 Len=1460
2505	2712.830381768	192.168.69.100	192.168.69.1	TCP	54	36480 → 1234 [ACK] Seq=1 Ack=75777 Win=90368 Len=0
2506	2712.830516297	192.168.69.1	192.168.69.100	TCP	642	1234 → 36480 [PSH, ACK] Seq=77237 Ack=1 Win=2048 Len=588
2507	2713.009748718	192.168.69.100	192.168.69.1	TCP	54	36480 → 1234 [ACK] Seq=1 Ack=77237 Win=93312 Len=0
```