### PR TITLE
Pin clippy check to 1.49.0

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -23,4 +23,4 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: -- -D warnings
+          args: --tests --examples -- -D warnings

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.49.0
           override: true
           components: clippy
       - uses: actions-rs/clippy-check@v1

--- a/examples/dhcp_client.rs
+++ b/examples/dhcp_client.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::option_map_unit_fn)]
 mod utils;
 
 use std::collections::BTreeMap;
@@ -57,10 +58,10 @@ fn main() {
             });
         config.map(|config| {
             println!("DHCP config: {:?}", config);
-            match config.address {
-                Some(cidr) => if cidr != prev_cidr {
+            if let Some(cidr) = config.address {
+                if cidr != prev_cidr {
                     iface.update_ip_addrs(|addrs| {
-                        addrs.iter_mut().nth(0)
+                        addrs.iter_mut().next()
                             .map(|addr| {
                                 *addr = IpCidr::Ipv4(cidr);
                             });
@@ -68,11 +69,10 @@ fn main() {
                     prev_cidr = cidr;
                     println!("Assigned a new IPv4 address: {}", cidr);
                 }
-                _ => {}
             }
 
             config.router.map(|router| iface.routes_mut()
-                              .add_default_ipv4_route(router.into())
+                              .add_default_ipv4_route(router)
                               .unwrap()
             );
             iface.routes_mut()

--- a/examples/loopback.rs
+++ b/examples/loopback.rs
@@ -76,9 +76,7 @@ fn main() {
         utils::add_middleware_options(&mut opts, &mut free);
 
         let mut matches = utils::parse_options(&opts, free);
-        let device = utils::parse_middleware_options(&mut matches, device, /*loopback=*/true);
-
-        device
+        utils::parse_middleware_options(&mut matches, device, /*loopback=*/true)
     };
 
     let mut neighbor_cache_entries = [None; 8];

--- a/examples/multicast.rs
+++ b/examples/multicast.rs
@@ -83,7 +83,7 @@ fn main() {
                 // For display purposes only - normally we wouldn't process incoming IGMP packets
                 // in the application layer
                 socket.recv()
-                    .and_then(|payload| Ipv4Packet::new_checked(payload))
+                    .and_then(Ipv4Packet::new_checked)
                     .and_then(|ipv4_packet| IgmpPacket::new_checked(ipv4_packet.payload()))
                     .and_then(|igmp_packet| IgmpRepr::parse(&igmp_packet))
                     .map(|igmp_repr| println!("IGMP packet: {:?}", igmp_repr))

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -74,7 +74,7 @@ fn main() {
     let count    = matches.opt_str("count").map(|s| usize::from_str(&s).unwrap()).unwrap_or(4);
     let interval = matches.opt_str("interval")
         .map(|s| Duration::from_secs(u64::from_str(&s).unwrap()))
-        .unwrap_or(Duration::from_secs(1));
+        .unwrap_or_else(|| Duration::from_secs(1));
     let timeout  = Duration::from_secs(
         matches.opt_str("timeout").map(|s| u64::from_str(&s).unwrap()).unwrap_or(5)
     );

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -109,7 +109,7 @@ fn main() {
 
             if socket.can_send() {
                 debug!("tcp:6969 send greeting");
-                write!(socket, "hello\n").unwrap();
+                writeln!(socket, "hello").unwrap();
                 debug!("tcp:6969 close");
                 socket.close();
             }

--- a/examples/utils.rs
+++ b/examples/utils.rs
@@ -42,7 +42,7 @@ pub fn setup_logging_with_clock<F>(filter: &str, since_startup: F)
         })
         .filter(None, LevelFilter::Trace)
         .parse(filter)
-        .parse(&env::var("RUST_LOG").unwrap_or("".to_owned()))
+        .parse(&env::var("RUST_LOG").unwrap_or_else(|_| "".to_owned()))
         .init();
 }
 
@@ -68,7 +68,7 @@ pub fn parse_options(options: &Options, free: Vec<&str>) -> Matches {
         Ok(matches) => {
             if matches.opt_present("h") || matches.free.len() != free.len() {
                 let brief = format!("Usage: {} [OPTION]... {}",
-                                    env::args().nth(0).unwrap(), free.join(" "));
+                                    env::args().next().unwrap(), free.join(" "));
                 print!("{}", options.usage(&brief));
                 process::exit(if matches.free.len() != free.len() { 1 } else { 0 })
             }

--- a/src/iface/ethernet.rs
+++ b/src/iface/ethernet.rs
@@ -1757,7 +1757,7 @@ mod test {
         let mut pkts = Vec::new();
         while let Some((rx, _tx)) = iface.device.receive() {
             rx.consume(timestamp, |pkt| {
-                pkts.push(pkt.iter().cloned().collect());
+                pkts.push(pkt.to_vec());
                 Ok(())
             }).unwrap();
         }
@@ -2567,7 +2567,7 @@ mod test {
         // Leave multicast groups
         let timestamp = Instant::now();
         for group in &groups {
-            iface.leave_multicast_group(group.clone(), timestamp)
+            iface.leave_multicast_group(*group, timestamp)
                 .unwrap();
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ compile_error!("at least one socket needs to be enabled"); */
 #![allow(clippy::redundant_field_names)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::option_map_unit_fn)]
+#![allow(clippy::unit_arg)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -217,7 +217,7 @@ pub struct DeviceCapabilities {
 
     /// Only present to prevent people from trying to initialize every field of DeviceLimits,
     /// which would not let us add new fields in the future.
-    dummy: ()
+    pub(crate) dummy: ()
 }
 
 /// An interface for sending and receiving raw network frames.

--- a/src/socket/raw.rs
+++ b/src/socket/raw.rs
@@ -473,14 +473,14 @@ mod test {
         {
             let mut socket = ipv4_locals::socket(buffer(0), buffer(2));
 
-            let mut wrong_version = ipv4_locals::PACKET_BYTES.clone();
+            let mut wrong_version = ipv4_locals::PACKET_BYTES;
             Ipv4Packet::new_unchecked(&mut wrong_version).set_version(6);
 
             assert_eq!(socket.send_slice(&wrong_version[..]), Ok(()));
             assert_eq!(socket.dispatch(&checksum_caps, |_| unreachable!()),
                        Ok(()));
 
-            let mut wrong_protocol = ipv4_locals::PACKET_BYTES.clone();
+            let mut wrong_protocol = ipv4_locals::PACKET_BYTES;
             Ipv4Packet::new_unchecked(&mut wrong_protocol).set_protocol(IpProtocol::Tcp);
 
             assert_eq!(socket.send_slice(&wrong_protocol[..]), Ok(()));
@@ -491,14 +491,14 @@ mod test {
         {
             let mut socket = ipv6_locals::socket(buffer(0), buffer(2));
 
-            let mut wrong_version = ipv6_locals::PACKET_BYTES.clone();
+            let mut wrong_version = ipv6_locals::PACKET_BYTES;
             Ipv6Packet::new_unchecked(&mut wrong_version[..]).set_version(4);
 
             assert_eq!(socket.send_slice(&wrong_version[..]), Ok(()));
             assert_eq!(socket.dispatch(&checksum_caps, |_| unreachable!()),
                        Ok(()));
 
-            let mut wrong_protocol = ipv6_locals::PACKET_BYTES.clone();
+            let mut wrong_protocol = ipv6_locals::PACKET_BYTES;
             Ipv6Packet::new_unchecked(&mut wrong_protocol[..]).set_next_header(IpProtocol::Tcp);
 
             assert_eq!(socket.send_slice(&wrong_protocol[..]), Ok(()));
@@ -514,7 +514,7 @@ mod test {
             let mut socket = ipv4_locals::socket(buffer(1), buffer(0));
             assert!(!socket.can_recv());
 
-            let mut cksumd_packet = ipv4_locals::PACKET_BYTES.clone();
+            let mut cksumd_packet = ipv4_locals::PACKET_BYTES;
             Ipv4Packet::new_unchecked(&mut cksumd_packet).fill_checksum();
 
             assert_eq!(socket.recv(), Err(Error::Exhausted));

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1972,8 +1972,10 @@ mod test {
 
     fn recv<F>(socket: &mut TcpSocket, timestamp: Instant, mut f: F)
             where F: FnMut(Result<TcpRepr>) {
-        let mut caps = DeviceCapabilities::default();
-        caps.max_transmission_unit = 1520;
+        let caps = DeviceCapabilities {
+            max_transmission_unit: 1520,
+            ..Default::default()
+        };
         let result = socket.dispatch(timestamp, &caps, |(ip_repr, tcp_repr)| {
             let ip_repr = ip_repr.lower(&[IpCidr::new(LOCAL_END.addr, 24)]).unwrap();
 
@@ -4821,8 +4823,10 @@ mod test {
     #[test]
     fn test_set_hop_limit() {
         let mut s = socket_syn_received();
-        let mut caps = DeviceCapabilities::default();
-        caps.max_transmission_unit = 1520;
+        let caps = DeviceCapabilities {
+            max_transmission_unit: 1520,
+            ..Default::default()
+        };
 
         s.set_hop_limit(Some(0x2a));
         assert_eq!(s.dispatch(Instant::from_millis(0), &caps, |(ip_repr, _)| {

--- a/src/storage/ring_buffer.rs
+++ b/src/storage/ring_buffer.rs
@@ -405,7 +405,7 @@ mod test {
         assert_eq!(ring.dequeue_one_with(|_| unreachable!()) as Result<()>,
                    Err(Error::Exhausted));
 
-        ring.enqueue_one_with(|e| Ok(e)).unwrap();
+        ring.enqueue_one_with(Ok).unwrap();
         assert!(!ring.is_empty());
         assert!(!ring.is_full());
 


### PR DESCRIPTION
This also includes a handful of other clippy-inspired cleanups.