### PR TITLE
Simplify Socket lifetimes

### DIFF
--- a/src/dhcp/clientv4.rs
+++ b/src/dhcp/clientv4.rs
@@ -94,8 +94,7 @@ impl Client {
     ///     Instant::now()
     /// );
     /// ```
-    pub fn new<'a, 'b, 'c>(sockets: &mut SocketSet<'a, 'b, 'c>, rx_buffer: RawSocketBuffer<'b, 'c>, tx_buffer: RawSocketBuffer<'b, 'c>, now: Instant) -> Self
-    where 'b: 'c,
+    pub fn new<'a, 'b>(sockets: &mut SocketSet<'a, 'b>, rx_buffer: RawSocketBuffer<'b>, tx_buffer: RawSocketBuffer<'b>, now: Instant) -> Self
     {
         let raw_socket = RawSocket::new(IpVersion::Ipv4, IpProtocol::Udp, rx_buffer, tx_buffer);
         let raw_handle = sockets.add(raw_socket);

--- a/src/iface/ethernet.rs
+++ b/src/iface/ethernet.rs
@@ -1727,7 +1727,7 @@ mod test {
     use super::{EthernetPacket, IpPacket};
 
     fn create_loopback<'a, 'b, 'c>() -> (EthernetInterface<'static, 'b, 'c, Loopback>,
-                                         SocketSet<'static, 'a, 'b>) {
+                                         SocketSet<'static, 'a>) {
         // Create a basic device
         let device = Loopback::new();
         let ip_addrs = [

--- a/src/socket/icmp.rs
+++ b/src/socket/icmp.rs
@@ -46,7 +46,7 @@ impl Default for Endpoint {
 pub type IcmpPacketMetadata = PacketMetadata<IpAddress>;
 
 /// An ICMP packet ring buffer.
-pub type IcmpSocketBuffer<'a, 'b> = PacketBuffer<'a, 'b, IpAddress>;
+pub type IcmpSocketBuffer<'a> = PacketBuffer<'a, IpAddress>;
 
 /// A ICMP socket
 ///
@@ -58,10 +58,10 @@ pub type IcmpSocketBuffer<'a, 'b> = PacketBuffer<'a, 'b, IpAddress>;
 /// [IcmpEndpoint]: enum.IcmpEndpoint.html
 /// [bind]: #method.bind
 #[derive(Debug)]
-pub struct IcmpSocket<'a, 'b: 'a> {
+pub struct IcmpSocket<'a> {
     pub(crate) meta: SocketMeta,
-    rx_buffer: IcmpSocketBuffer<'a, 'b>,
-    tx_buffer: IcmpSocketBuffer<'a, 'b>,
+    rx_buffer: IcmpSocketBuffer<'a>,
+    tx_buffer: IcmpSocketBuffer<'a>,
     /// The endpoint this socket is communicating with
     endpoint:  Endpoint,
     /// The time-to-live (IPv4) or hop limit (IPv6) value used in outgoing packets.
@@ -72,10 +72,10 @@ pub struct IcmpSocket<'a, 'b: 'a> {
     tx_waker: WakerRegistration,
 }
 
-impl<'a, 'b> IcmpSocket<'a, 'b> {
+impl<'a> IcmpSocket<'a> {
     /// Create an ICMP socket with the given buffers.
-    pub fn new(rx_buffer: IcmpSocketBuffer<'a, 'b>,
-               tx_buffer: IcmpSocketBuffer<'a, 'b>) -> IcmpSocket<'a, 'b> {
+    pub fn new(rx_buffer: IcmpSocketBuffer<'a>,
+               tx_buffer: IcmpSocketBuffer<'a>) -> IcmpSocket<'a> {
         IcmpSocket {
             meta:      SocketMeta::default(),
             rx_buffer: rx_buffer,
@@ -455,8 +455,8 @@ impl<'a, 'b> IcmpSocket<'a, 'b> {
     }
 }
 
-impl<'a, 'b> Into<Socket<'a, 'b>> for IcmpSocket<'a, 'b> {
-    fn into(self) -> Socket<'a, 'b> {
+impl<'a> Into<Socket<'a>> for IcmpSocket<'a> {
+    fn into(self) -> Socket<'a> {
         Socket::Icmp(self)
     }
 }
@@ -467,12 +467,12 @@ mod tests_common {
     pub use crate::wire::IpAddress;
     pub use super::*;
 
-    pub fn buffer(packets: usize) -> IcmpSocketBuffer<'static, 'static> {
+    pub fn buffer(packets: usize) -> IcmpSocketBuffer<'static> {
         IcmpSocketBuffer::new(vec![IcmpPacketMetadata::EMPTY; packets], vec![0; 66 * packets])
     }
 
-    pub fn socket(rx_buffer: IcmpSocketBuffer<'static, 'static>,
-              tx_buffer: IcmpSocketBuffer<'static, 'static>) -> IcmpSocket<'static, 'static> {
+    pub fn socket(rx_buffer: IcmpSocketBuffer<'static>,
+              tx_buffer: IcmpSocketBuffer<'static>) -> IcmpSocket<'static> {
         IcmpSocket::new(rx_buffer, tx_buffer)
     }
 

--- a/src/socket/raw.rs
+++ b/src/socket/raw.rs
@@ -19,31 +19,31 @@ use crate::wire::{Ipv6Repr, Ipv6Packet};
 pub type RawPacketMetadata = PacketMetadata<()>;
 
 /// A UDP packet ring buffer.
-pub type RawSocketBuffer<'a, 'b> = PacketBuffer<'a, 'b, ()>;
+pub type RawSocketBuffer<'a> = PacketBuffer<'a, ()>;
 
 /// A raw IP socket.
 ///
 /// A raw socket is bound to a specific IP protocol, and owns
 /// transmit and receive packet buffers.
 #[derive(Debug)]
-pub struct RawSocket<'a, 'b: 'a> {
+pub struct RawSocket<'a> {
     pub(crate) meta: SocketMeta,
     ip_version:  IpVersion,
     ip_protocol: IpProtocol,
-    rx_buffer:   RawSocketBuffer<'a, 'b>,
-    tx_buffer:   RawSocketBuffer<'a, 'b>,
+    rx_buffer:   RawSocketBuffer<'a>,
+    tx_buffer:   RawSocketBuffer<'a>,
     #[cfg(feature = "async")]
     rx_waker: WakerRegistration,
     #[cfg(feature = "async")]
     tx_waker: WakerRegistration,
 }
 
-impl<'a, 'b> RawSocket<'a, 'b> {
+impl<'a> RawSocket<'a> {
     /// Create a raw IP socket bound to the given IP version and datagram protocol,
     /// with the given buffers.
     pub fn new(ip_version: IpVersion, ip_protocol: IpProtocol,
-               rx_buffer: RawSocketBuffer<'a, 'b>,
-               tx_buffer: RawSocketBuffer<'a, 'b>) -> RawSocket<'a, 'b> {
+               rx_buffer: RawSocketBuffer<'a>,
+               tx_buffer: RawSocketBuffer<'a>) -> RawSocket<'a> {
         RawSocket {
             meta: SocketMeta::default(),
             ip_version,
@@ -297,8 +297,8 @@ impl<'a, 'b> RawSocket<'a, 'b> {
     }
 }
 
-impl<'a, 'b> Into<Socket<'a, 'b>> for RawSocket<'a, 'b> {
-    fn into(self) -> Socket<'a, 'b> {
+impl<'a> Into<Socket<'a>> for RawSocket<'a> {
+    fn into(self) -> Socket<'a> {
         Socket::Raw(self)
     }
 }
@@ -312,7 +312,7 @@ mod test {
     use crate::wire::{Ipv6Address, Ipv6Repr};
     use super::*;
 
-    fn buffer(packets: usize) -> RawSocketBuffer<'static, 'static> {
+    fn buffer(packets: usize) -> RawSocketBuffer<'static> {
         RawSocketBuffer::new(vec![RawPacketMetadata::EMPTY; packets], vec![0; 48 * packets])
     }
 
@@ -320,9 +320,9 @@ mod test {
     mod ipv4_locals {
         use super::*;
 
-        pub fn socket(rx_buffer: RawSocketBuffer<'static, 'static>,
-                      tx_buffer: RawSocketBuffer<'static, 'static>)
-                     -> RawSocket<'static, 'static> {
+        pub fn socket(rx_buffer: RawSocketBuffer<'static>,
+                      tx_buffer: RawSocketBuffer<'static>)
+                     -> RawSocket<'static> {
             RawSocket::new(IpVersion::Ipv4, IpProtocol::Unknown(IP_PROTO),
                            rx_buffer, tx_buffer)
         }
@@ -352,9 +352,9 @@ mod test {
     mod ipv6_locals {
         use super::*;
 
-        pub fn socket(rx_buffer: RawSocketBuffer<'static, 'static>,
-                      tx_buffer: RawSocketBuffer<'static, 'static>)
-                     -> RawSocket<'static, 'static> {
+        pub fn socket(rx_buffer: RawSocketBuffer<'static>,
+                      tx_buffer: RawSocketBuffer<'static>)
+                     -> RawSocket<'static> {
             RawSocket::new(IpVersion::Ipv6, IpProtocol::Unknown(IP_PROTO),
                            rx_buffer, tx_buffer)
         }

--- a/src/socket/ref_.rs
+++ b/src/socket/ref_.rs
@@ -20,11 +20,11 @@ pub trait Session {
 }
 
 #[cfg(feature = "socket-raw")]
-impl<'a, 'b> Session for RawSocket<'a, 'b> {}
+impl<'a> Session for RawSocket<'a> {}
 #[cfg(all(feature = "socket-icmp", any(feature = "proto-ipv4", feature = "proto-ipv6")))]
-impl<'a, 'b> Session for IcmpSocket<'a, 'b> {}
+impl<'a> Session for IcmpSocket<'a> {}
 #[cfg(feature = "socket-udp")]
-impl<'a, 'b> Session for UdpSocket<'a, 'b> {}
+impl<'a> Session for UdpSocket<'a> {}
 #[cfg(feature = "socket-tcp")]
 impl<'a> Session for TcpSocket<'a> {}
 

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1943,8 +1943,8 @@ impl<'a> TcpSocket<'a> {
     }
 }
 
-impl<'a, 'b> Into<Socket<'a, 'b>> for TcpSocket<'a> {
-    fn into(self) -> Socket<'a, 'b> {
+impl<'a> Into<Socket<'a>> for TcpSocket<'a> {
+    fn into(self) -> Socket<'a> {
         Socket::Tcp(self)
     }
 }

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -13,18 +13,18 @@ use crate::socket::WakerRegistration;
 pub type UdpPacketMetadata = PacketMetadata<IpEndpoint>;
 
 /// A UDP packet ring buffer.
-pub type UdpSocketBuffer<'a, 'b> = PacketBuffer<'a, 'b, IpEndpoint>;
+pub type UdpSocketBuffer<'a> = PacketBuffer<'a, IpEndpoint>;
 
 /// A User Datagram Protocol socket.
 ///
 /// A UDP socket is bound to a specific endpoint, and owns transmit and receive
 /// packet buffers.
 #[derive(Debug)]
-pub struct UdpSocket<'a, 'b: 'a> {
+pub struct UdpSocket<'a> {
     pub(crate) meta: SocketMeta,
     endpoint:  IpEndpoint,
-    rx_buffer: UdpSocketBuffer<'a, 'b>,
-    tx_buffer: UdpSocketBuffer<'a, 'b>,
+    rx_buffer: UdpSocketBuffer<'a>,
+    tx_buffer: UdpSocketBuffer<'a>,
     /// The time-to-live (IPv4) or hop limit (IPv6) value used in outgoing packets.
     hop_limit: Option<u8>,
     #[cfg(feature = "async")]
@@ -33,10 +33,10 @@ pub struct UdpSocket<'a, 'b: 'a> {
     tx_waker: WakerRegistration,
 }
 
-impl<'a, 'b> UdpSocket<'a, 'b> {
+impl<'a> UdpSocket<'a> {
     /// Create an UDP socket with the given buffers.
-    pub fn new(rx_buffer: UdpSocketBuffer<'a, 'b>,
-               tx_buffer: UdpSocketBuffer<'a, 'b>) -> UdpSocket<'a, 'b> {
+    pub fn new(rx_buffer: UdpSocketBuffer<'a>,
+               tx_buffer: UdpSocketBuffer<'a>) -> UdpSocket<'a> {
         UdpSocket {
             meta:      SocketMeta::default(),
             endpoint:  IpEndpoint::default(),
@@ -336,8 +336,8 @@ impl<'a, 'b> UdpSocket<'a, 'b> {
     }
 }
 
-impl<'a, 'b> Into<Socket<'a, 'b>> for UdpSocket<'a, 'b> {
-    fn into(self) -> Socket<'a, 'b> {
+impl<'a> Into<Socket<'a>> for UdpSocket<'a> {
+    fn into(self) -> Socket<'a> {
         Socket::Udp(self)
     }
 }
@@ -352,13 +352,13 @@ mod test {
     use crate::wire::ip::test::{MOCK_IP_ADDR_1, MOCK_IP_ADDR_2, MOCK_IP_ADDR_3};
     use super::*;
 
-    fn buffer(packets: usize) -> UdpSocketBuffer<'static, 'static> {
+    fn buffer(packets: usize) -> UdpSocketBuffer<'static> {
         UdpSocketBuffer::new(vec![UdpPacketMetadata::EMPTY; packets], vec![0; 16 * packets])
     }
 
-    fn socket(rx_buffer: UdpSocketBuffer<'static, 'static>,
-              tx_buffer: UdpSocketBuffer<'static, 'static>)
-            -> UdpSocket<'static, 'static> {
+    fn socket(rx_buffer: UdpSocketBuffer<'static>,
+              tx_buffer: UdpSocketBuffer<'static>)
+            -> UdpSocket<'static> {
         UdpSocket::new(rx_buffer, tx_buffer)
     }
 

--- a/src/storage/packet_buffer.rs
+++ b/src/storage/packet_buffer.rs
@@ -35,19 +35,19 @@ impl<H> PacketMetadata<H> {
 
 /// An UDP packet ring buffer.
 #[derive(Debug)]
-pub struct PacketBuffer<'a, 'b, H: 'a> {
+pub struct PacketBuffer<'a,  H: 'a> {
     metadata_ring: RingBuffer<'a, PacketMetadata<H>>,
-    payload_ring:  RingBuffer<'b, u8>,
+    payload_ring:  RingBuffer<'a, u8>,
 }
 
-impl<'a, 'b, H> PacketBuffer<'a, 'b, H> {
+impl<'a, H> PacketBuffer<'a, H> {
     /// Create a new packet buffer with the provided metadata and payload storage.
     ///
     /// Metadata storage limits the maximum _number_ of packets in the buffer and payload
     /// storage limits the maximum _total size_ of packets.
-    pub fn new<MS, PS>(metadata_storage: MS, payload_storage: PS) -> PacketBuffer<'a, 'b, H>
+    pub fn new<MS, PS>(metadata_storage: MS, payload_storage: PS) -> PacketBuffer<'a, H>
         where MS: Into<ManagedSlice<'a, PacketMetadata<H>>>,
-              PS: Into<ManagedSlice<'b, u8>>,
+              PS: Into<ManagedSlice<'a, u8>>,
     {
         PacketBuffer {
             metadata_ring: RingBuffer::new(metadata_storage),
@@ -184,7 +184,7 @@ impl<'a, 'b, H> PacketBuffer<'a, 'b, H> {
 mod test {
     use super::*;
 
-    fn buffer() -> PacketBuffer<'static, 'static, ()> {
+    fn buffer() -> PacketBuffer<'static, ()> {
         PacketBuffer::new(vec![PacketMetadata::EMPTY; 4],
                           vec![0u8; 16])
     }


### PR DESCRIPTION
`PacketBuffer` currently requires 2 different lifetimes for metadata and payload buffers. This causes a lot of cascading complexity causing Sockets to require 2 lifetimes and SocketSet to require 3 (!) lifetimes.

I can't think of any usage requiring 2 separate lifetimes in `PacketBuffer`. (ie something you *could* do with separate lifetimes but *can't* do with just 1). 

This PR removes it, yielding a nice simplification of lifetimes everywhere :) 

