### PR TITLE
Various cleanup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,8 +87,6 @@
                feature = "socket-tcp")))]
 compile_error!("at least one socket needs to be enabled"); */
 
-// FIXME(dlrobertson): clippy fails with this lint
-#![allow(clippy::if_same_then_else)]
 #![allow(clippy::match_like_matches_macro)]
 #![allow(clippy::redundant_field_names)]
 #![allow(clippy::identity_op)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,6 @@ compile_error!("at least one socket needs to be enabled"); */
 
 // FIXME(dlrobertson): clippy fails with this lint
 #![allow(clippy::if_same_then_else)]
-#![allow(clippy::manual_non_exhaustive)]
 #![allow(clippy::match_like_matches_macro)]
 #![allow(clippy::redundant_field_names)]
 #![allow(clippy::identity_op)]

--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -158,6 +158,7 @@ impl Checksum {
 
 /// A description of checksum behavior for every supported protocol.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct ChecksumCapabilities {
     pub ipv4: Checksum,
     pub udp: Checksum,
@@ -166,7 +167,6 @@ pub struct ChecksumCapabilities {
     pub icmpv4: Checksum,
     #[cfg(feature = "proto-ipv6")]
     pub icmpv6: Checksum,
-    dummy: (),
 }
 
 impl ChecksumCapabilities {
@@ -181,7 +181,6 @@ impl ChecksumCapabilities {
             icmpv4: Checksum::None,
             #[cfg(feature = "proto-ipv6")]
             icmpv6: Checksum::None,
-            ..Self::default()
         }
     }
 }
@@ -191,6 +190,7 @@ impl ChecksumCapabilities {
 /// Higher-level protocols may achieve higher throughput or lower latency if they consider
 /// the bandwidth or packet size limitations.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct DeviceCapabilities {
     /// Maximum transmission unit.
     ///
@@ -214,10 +214,6 @@ pub struct DeviceCapabilities {
     /// If the network device is capable of verifying or computing checksums for some protocols,
     /// it can request that the stack not do so in software to improve performance.
     pub checksum: ChecksumCapabilities,
-
-    /// Only present to prevent people from trying to initialize every field of DeviceLimits,
-    /// which would not let us add new fields in the future.
-    pub(crate) dummy: ()
 }
 
 /// An interface for sending and receiving raw network frames.

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1905,6 +1905,7 @@ impl<'a> TcpSocket<'a> {
         Ok(())
     }
 
+    #[allow(clippy::if_same_then_else)]
     pub(crate) fn poll_at(&self) -> PollAt {
         // The logic here mirrors the beginning of dispatch() closely.
         if !self.remote_endpoint.is_specified() {

--- a/src/wire/arp.rs
+++ b/src/wire/arp.rs
@@ -86,6 +86,7 @@ impl<T: AsRef<[u8]>> Packet<T> {
     ///
     /// [set_hardware_len]: #method.set_hardware_len
     /// [set_protocol_len]: #method.set_protocol_len
+    #[allow(clippy::if_same_then_else)]
     pub fn check_len(&self) -> Result<()> {
         let len = self.buffer.as_ref().len();
         if len < field::OPER.end {

--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -271,6 +271,7 @@ impl<T: AsRef<[u8]>> Packet<T> {
     ///
     /// [set_header_len]: #method.set_header_len
     /// [set_total_len]: #method.set_total_len
+    #[allow(clippy::if_same_then_else)]
     pub fn check_len(&self) -> Result<()> {
         let len = self.buffer.as_ref().len();
         if len < field::DST_ADDR.end {


### PR DESCRIPTION
This builds on 633e7c25 (#409), adding the `#[non_exhaustive]` attribute to applicable struct definitions and de-duplicates and (hopefully) simplifies a few if-else blocks. I've also verified that these changes don't result in larger binaries.