### PR TITLE
Simplify more lifetimes

### DIFF
--- a/src/dhcp/clientv4.rs
+++ b/src/dhcp/clientv4.rs
@@ -94,7 +94,7 @@ impl Client {
     ///     Instant::now()
     /// );
     /// ```
-    pub fn new<'a, 'b>(sockets: &mut SocketSet<'a, 'b>, rx_buffer: RawSocketBuffer<'b>, tx_buffer: RawSocketBuffer<'b>, now: Instant) -> Self
+    pub fn new<'a>(sockets: &mut SocketSet<'a>, rx_buffer: RawSocketBuffer<'a>, tx_buffer: RawSocketBuffer<'a>, now: Instant) -> Self
     {
         let raw_socket = RawSocket::new(IpVersion::Ipv4, IpProtocol::Udp, rx_buffer, tx_buffer);
         let raw_handle = sockets.add(raw_socket);

--- a/src/iface/ethernet.rs
+++ b/src/iface/ethernet.rs
@@ -1731,7 +1731,7 @@ mod test {
     use super::{EthernetPacket, IpPacket};
 
     fn create_loopback<'a, 'b, 'c>() -> (EthernetInterface<'static, 'b, 'c, Loopback>,
-                                         SocketSet<'static, 'a>) {
+                                         SocketSet<'a>) {
         // Create a basic device
         let device = Loopback::new();
         let ip_addrs = [


### PR DESCRIPTION
Follow-up to #410 

I'd like to get this in before the 0.7 release (#412) for consistency: if we do breaking changes simplifying some lifetimes we might as well simplify them all.