### PR TITLE
Make wire/ipv4 functions const where easy.

### DIFF
--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -39,7 +39,7 @@ impl Address {
     pub const MULTICAST_ALL_ROUTERS: Address = Address([224, 0, 0, 2]);
 
     /// Construct an IPv4 address from parts.
-    pub fn new(a0: u8, a1: u8, a2: u8, a3: u8) -> Address {
+    pub const fn new(a0: u8, a1: u8, a2: u8, a3: u8) -> Address {
         Address([a0, a1, a2, a3])
     }
 
@@ -54,7 +54,7 @@ impl Address {
     }
 
     /// Return an IPv4 address as a sequence of octets, in big-endian.
-    pub fn as_bytes(&self) -> &[u8] {
+    pub const fn as_bytes(&self) -> &[u8] {
         &self.0
     }
 
@@ -71,12 +71,12 @@ impl Address {
     }
 
     /// Query whether the address is a multicast address.
-    pub fn is_multicast(&self) -> bool {
+    pub const fn is_multicast(&self) -> bool {
         self.0[0] & 0xf0 == 224
     }
 
     /// Query whether the address falls into the "unspecified" range.
-    pub fn is_unspecified(&self) -> bool {
+    pub const fn is_unspecified(&self) -> bool {
         self.0[0] == 0
     }
 
@@ -86,7 +86,7 @@ impl Address {
     }
 
     /// Query whether the address falls into the "loopback" range.
-    pub fn is_loopback(&self) -> bool {
+    pub const fn is_loopback(&self) -> bool {
         self.0[0] == 127
     }
 }
@@ -125,8 +125,10 @@ impl Cidr {
     ///
     /// # Panics
     /// This function panics if the prefix length is larger than 32.
-    pub fn new(address: Address, prefix_len: u8) -> Cidr {
-        assert!(prefix_len <= 32);
+    pub const fn new(address: Address, prefix_len: u8) -> Cidr {
+        // Replace with const panic (or assert) when stabilized
+        // see: https://github.com/rust-lang/rust/issues/51999
+        ["Prefix length should be <= 32"][(prefix_len > 32) as usize];
         Cidr { address, prefix_len }
     }
 
@@ -141,17 +143,17 @@ impl Cidr {
     }
 
     /// Return the address of this IPv4 CIDR block.
-    pub fn address(&self) -> Address {
+    pub const fn address(&self) -> Address {
         self.address
     }
 
     /// Return the prefix length of this IPv4 CIDR block.
-    pub fn prefix_len(&self) -> u8 {
+    pub const fn prefix_len(&self) -> u8 {
         self.prefix_len
     }
 
     /// Return the network mask of this IPv4 CIDR.
-    pub fn netmask(&self) -> Address {
+    pub const fn netmask(&self) -> Address {
         if self.prefix_len == 0 {
             return Address([0, 0, 0, 0]);
         }
@@ -188,7 +190,7 @@ impl Cidr {
     }
 
     /// Return the network block of this IPv4 CIDR.
-    pub fn network(&self) -> Cidr {
+    pub const fn network(&self) -> Cidr {
         let mask = self.netmask().0;
         let network = [
             self.address.0[0] & mask[0],

--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -54,7 +54,7 @@ impl Address {
     }
 
     /// Return an IPv4 address as a sequence of octets, in big-endian.
-    pub const fn as_bytes(&self) -> &[u8] {
+    pub fn as_bytes(&self) -> &[u8] {
         &self.0
     }
 
@@ -125,6 +125,7 @@ impl Cidr {
     ///
     /// # Panics
     /// This function panics if the prefix length is larger than 32.
+    #[allow(clippy::no_effect)]
     pub const fn new(address: Address, prefix_len: u8) -> Cidr {
         // Replace with const panic (or assert) when stabilized
         // see: https://github.com/rust-lang/rust/issues/51999
@@ -153,7 +154,7 @@ impl Cidr {
     }
 
     /// Return the network mask of this IPv4 CIDR.
-    pub const fn netmask(&self) -> Address {
+    pub fn netmask(&self) -> Address {
         if self.prefix_len == 0 {
             return Address([0, 0, 0, 0]);
         }
@@ -190,7 +191,7 @@ impl Cidr {
     }
 
     /// Return the network block of this IPv4 CIDR.
-    pub const fn network(&self) -> Cidr {
+    pub fn network(&self) -> Cidr {
         let mask = self.netmask().0;
         let network = [
             self.address.0[0] & mask[0],


### PR DESCRIPTION
This is a small PR that makes functions in `src/wire/ipv4.rs` const. Specifically targeting `Address::new` and `Cidr::new`, but also updating other functions where there is no impact to the function body.

`const fn` was [stabilized in 1.31](https://doc.rust-lang.org/edition-guide/rust-next/const-fn.html), so I believe this is zero impact to existing code (given current minimum required rust version of 1.40)

The motivation for this change is to simplify static initialization on embedded platforms. E.g. initialize an arbitrary IP address, or empty storage for a CIDR.

Let me know if this is misaligned with project goals/direction! It's useful to my projects, but I'm very open to feedback!