### PR TITLE
Fix bpf ffi and add OpenBSD bpf cfg

### DIFF
--- a/src/phy/sys/bpf.rs
+++ b/src/phy/sys/bpf.rs
@@ -6,16 +6,16 @@ use libc;
 use super::{ifreq, ifreq_for};
 
 /// set interface
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "openbsd"))]
 const BIOCSETIF: libc::c_ulong = 0x8020426c;
 /// get buffer length
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "openbsd"))]
 const BIOCGBLEN: libc::c_ulong = 0x40044266;
 /// set immediate/nonblocking read
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "openbsd"))]
 const BIOCIMMEDIATE: libc::c_ulong = 0x80044270;
 // TODO: check if this is same for OSes other than macos
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "openbsd"))]
 const BPF_HDRLEN: usize = 18;
 
 macro_rules! try_ioctl {
@@ -43,8 +43,8 @@ impl AsRawFd for BpfDevice {
 fn open_device() -> io::Result<libc::c_int> {
     unsafe {
         for i in 0..256 {
-            let dev = format!("/dev/bpf{}\0", i).as_ptr() as *const libc::c_char;
-            match libc::open(dev, libc::O_RDWR) {
+            let dev = format!("/dev/bpf{}\0", i);
+            match libc::open(dev.as_ptr() as *const libc::c_char, libc::O_RDWR) {
                 -1 => continue,
                 fd => return Ok(fd),
             };


### PR DESCRIPTION
This fixes the `as_ptr` call which currently is causing a dealloc before the FFI call to libc open. This resulted in a permanent "file not found" when opening any device.

OpenBSD 6.8 amd64. Rust 1.46.0. smoltcp 15f3bc5cd09b50354c5156b7e43e1ef30faa30c0.
```
core::ptr::slice_from_raw_parts_mut::h6b6d2aa746578da4 (data=0xc5035c4c420 "/dev/bpf0\000", len=10)
alloc::alloc::dealloc::h4e59c1527d840d21 (ptr=0xc5035c4c420 "/dev/bpf0\000", layout=...)
alloc::alloc::dealloc::h4e59c1527d840d21 (ptr=0xc5035c4c420 '\337' <repeats 32 times>, "\000",
smoltcp::phy::sys::bpf::open_device::h9e20766127888bdc ()
_libc_open_cancel (path=0xc5035c4c420 '\337' <repeats 32 times>, flags=2)
```

This also adds OpenBSD support by adjusting the existing cfg options in `bpf.rs`.

Thanks for your work! `smoltcp` is awesome.