### PR TITLE
Simplify enum_with_unknown! macro

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -23,21 +23,8 @@ macro_rules! enum_with_unknown {
     (
         $( #[$enum_attr:meta] )*
         pub enum $name:ident($ty:ty) {
-            $( $variant:ident = $value:expr ),+ $(,)*
-        }
-    ) => {
-        enum_with_unknown! {
-            $( #[$enum_attr] )*
-            pub doc enum $name($ty) {
-                $( #[doc(shown)] $variant = $value ),+
-            }
-        }
-    };
-    (
-        $( #[$enum_attr:meta] )*
-        pub doc enum $name:ident($ty:ty) {
             $(
-              $( #[$variant_attr:meta] )+
+              $( #[$variant_attr:meta] )*
               $variant:ident = $value:expr $(,)*
             ),+
         }

--- a/src/phy/pcap_writer.rs
+++ b/src/phy/pcap_writer.rs
@@ -10,7 +10,7 @@ use crate::time::Instant;
 
 enum_with_unknown! {
     /// Captured packet header type.
-    pub doc enum PcapLinkType(u32) {
+    pub enum PcapLinkType(u32) {
         /// Ethernet frames
         Ethernet =   1,
         /// IPv4 or IPv6 packets (depending on the version field)

--- a/src/wire/icmpv4.rs
+++ b/src/wire/icmpv4.rs
@@ -8,7 +8,7 @@ use crate::wire::{Ipv4Packet, Ipv4Repr};
 
 enum_with_unknown! {
     /// Internet protocol control message type.
-    pub doc enum Message(u8) {
+    pub enum Message(u8) {
         /// Echo reply
         EchoReply      =  0,
         /// Destination unreachable
@@ -52,7 +52,7 @@ impl fmt::Display for Message {
 
 enum_with_unknown! {
     /// Internet protocol control message subtype for type "Destination Unreachable".
-    pub doc enum DstUnreachable(u8) {
+    pub enum DstUnreachable(u8) {
         /// Destination network unreachable
         NetUnreachable   =  0,
         /// Destination host unreachable
@@ -131,7 +131,7 @@ impl fmt::Display for DstUnreachable {
 
 enum_with_unknown! {
     /// Internet protocol control message subtype for type "Redirect Message".
-    pub doc enum Redirect(u8) {
+    pub enum Redirect(u8) {
         /// Redirect Datagram for the Network
         Net     = 0,
         /// Redirect Datagram for the Host
@@ -145,7 +145,7 @@ enum_with_unknown! {
 
 enum_with_unknown! {
     /// Internet protocol control message subtype for type "Time Exceeded".
-    pub doc enum TimeExceeded(u8) {
+    pub enum TimeExceeded(u8) {
         /// TTL expired in transit
         TtlExpired  = 0,
         /// Fragment reassembly time exceeded
@@ -155,7 +155,7 @@ enum_with_unknown! {
 
 enum_with_unknown! {
     /// Internet protocol control message subtype for type "Parameter Problem".
-    pub doc enum ParamProblem(u8) {
+    pub enum ParamProblem(u8) {
         /// Pointer indicates the error
         AtPointer     = 0,
         /// Missing a required option

--- a/src/wire/icmpv6.rs
+++ b/src/wire/icmpv6.rs
@@ -11,7 +11,7 @@ use crate::wire::NdiscRepr;
 
 enum_with_unknown! {
     /// Internet protocol control message type.
-    pub doc enum Message(u8) {
+    pub enum Message(u8) {
         /// Destination Unreachable.
         DstUnreachable  = 0x01,
         /// Packet Too Big.
@@ -98,7 +98,7 @@ impl fmt::Display for Message {
 
 enum_with_unknown! {
     /// Internet protocol control message subtype for type "Destination Unreachable".
-    pub doc enum DstUnreachable(u8) {
+    pub enum DstUnreachable(u8) {
         /// No Route to destination.
         NoRoute         = 0,
         /// Communication with destination administratively prohibited.
@@ -141,7 +141,7 @@ impl fmt::Display for DstUnreachable {
 
 enum_with_unknown! {
     /// Internet protocol control message subtype for the type "Parameter Problem".
-    pub doc enum ParamProblem(u8) {
+    pub enum ParamProblem(u8) {
         /// Erroneous header field encountered.
         ErroneousHdrField  = 0,
         /// Unrecognized Next Header type encountered.
@@ -168,7 +168,7 @@ impl fmt::Display for ParamProblem {
 
 enum_with_unknown! {
     /// Internet protocol control message subtype for the type "Time Exceeded".
-    pub doc enum TimeExceeded(u8) {
+    pub enum TimeExceeded(u8) {
         /// Hop limit exceeded in transit.
         HopLimitExceeded    = 0,
         /// Fragment reassembly time exceeded.

--- a/src/wire/igmp.rs
+++ b/src/wire/igmp.rs
@@ -9,7 +9,7 @@ use crate::wire::Ipv4Address;
 
 enum_with_unknown! {
     /// Internet Group Management Protocol v1/v2 message version/type.
-    pub doc enum Message(u8) {
+    pub enum Message(u8) {
         /// Membership Query
         MembershipQuery = 0x11,
         /// Version 2 Membership Report

--- a/src/wire/ipv6option.rs
+++ b/src/wire/ipv6option.rs
@@ -3,7 +3,7 @@ use crate::{Error, Result};
 
 enum_with_unknown! {
     /// IPv6 Extension Header Option Type
-    pub doc enum Type(u8) {
+    pub enum Type(u8) {
         /// 1 byte of padding
         Pad1 =  0,
         /// Multiple bytes of padding
@@ -24,7 +24,7 @@ impl fmt::Display for Type {
 enum_with_unknown! {
     /// Action required when parsing the given IPv6 Extension
     /// Header Option Type fails
-    pub doc enum FailureType(u8) {
+    pub enum FailureType(u8) {
         /// Skip this option and continue processing the packet
         Skip               = 0b00000000,
         /// Discard the containing packet

--- a/src/wire/ipv6routing.rs
+++ b/src/wire/ipv6routing.rs
@@ -6,7 +6,7 @@ use crate::wire::Ipv6Address as Address;
 
 enum_with_unknown! {
     /// IPv6 Extension Routing Header Routing Type
-    pub doc enum Type(u8) {
+    pub enum Type(u8) {
         /// Source Route (DEPRECATED)
         ///
         /// See https://tools.ietf.org/html/rfc5095 for details.

--- a/src/wire/mld.rs
+++ b/src/wire/mld.rs
@@ -15,7 +15,7 @@ enum_with_unknown! {
     /// more details.
     ///
     /// [RFC 3810 § 5.2.12]: https://tools.ietf.org/html/rfc3010#section-5.2.12
-    pub doc enum RecordType(u8) {
+    pub enum RecordType(u8) {
         /// Interface has a filter mode of INCLUDE for the specified multicast address.
         ModeIsInclude   = 0x01,
         /// Interface has a filter mode of EXCLUDE for the specified multicast address.

--- a/src/wire/ndiscoption.rs
+++ b/src/wire/ndiscoption.rs
@@ -8,7 +8,7 @@ use crate::wire::{EthernetAddress, Ipv6Address, Ipv6Packet, Ipv6Repr};
 
 enum_with_unknown! {
     /// NDISC Option Type
-    pub doc enum Type(u8) {
+    pub enum Type(u8) {
         /// Source Link-layer Address
         SourceLinkLayerAddr = 0x1,
         /// Target Link-layer Address


### PR DESCRIPTION
For some reason (no idea why even though I wrote that) it's using an invalid attribute:
```
warning: unknown `doc` attribute `shown`
  --> src/macros.rs:32:26
   |
32 |                   $( #[doc(shown)] $variant = $value ),+
   |                            ^^^^^
   | 
  ::: src/wire/dhcpv4.rs:11:1
   |
11 | / enum_with_unknown! {
12 | |     /// The possible opcodes of a DHCP packet.
13 | |     pub enum OpCode(u8) {
14 | |         Request = 1,
15 | |         Reply = 2,
16 | |     }
17 | | }
   | |_- in this macro invocation
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```
It doesn't seem like that entire part of the macro is necessary, so simplify the macro and the call sites. As a bonus it no longer uses custom "keyword" `doc`.