### PR TITLE
Update managed to the latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "0BSD"
 autoexamples = false
 
 [dependencies]
-managed = { version = "0.7", default-features = false, features = ["map"] }
+managed = { version = "0.8", default-features = false, features = ["map"] }
 byteorder = { version = "1.0", default-features = false }
 log = { version = "0.4.4", default-features = false, optional = true }
 libc = { version = "0.2.18", optional = true }


### PR DESCRIPTION
Makes it possible to use alloc on stable, see https://github.com/smoltcp-rs/rust-managed/pull/16.