### PR TITLE
Fix "leftover tokens" macro error

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -25,8 +25,8 @@ macro_rules! enum_with_unknown {
         pub enum $name:ident($ty:ty) {
             $(
               $( #[$variant_attr:meta] )*
-              $variant:ident = $value:expr $(,)*
-            ),+
+              $variant:ident = $value:expr
+            ),+ $(,)?
         }
     ) => {
         #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]


### PR DESCRIPTION
Rust-analyzer broke with a "leftover tokens" macro error when using that macro without a trailing comma. The macro is no issue for rustc but fixing it is worth it for dev ux :) 