### PR TITLE
dhcp: always send parameter_request_list. 

### DIFF
--- a/src/dhcp/clientv4.rs
+++ b/src/dhcp/clientv4.rs
@@ -356,6 +356,7 @@ impl Client {
         net_trace!("DHCP reset");
         self.state = ClientState::Discovering;
         self.next_egress = now;
+        self.lease_expiration = None;
     }
 }
 

--- a/src/dhcp/clientv4.rs
+++ b/src/dhcp/clientv4.rs
@@ -292,7 +292,7 @@ impl Client {
             requested_ip: None,
             client_identifier: Some(mac),
             server_identifier: None,
-            parameter_request_list: None,
+            parameter_request_list: Some(PARAMETER_REQUEST_LIST),
             max_size: Some(raw_socket.payload_recv_capacity() as u16),
             lease_duration: None,
             dns_servers: None,
@@ -325,7 +325,6 @@ impl Client {
                 dhcp_repr.broadcast = false;
                 dhcp_repr.requested_ip = Some(r_state.requested_ip);
                 dhcp_repr.server_identifier = Some(r_state.server_identifier);
-                dhcp_repr.parameter_request_list = Some(PARAMETER_REQUEST_LIST);
                 net_trace!("DHCP send request to {} = {:?}", endpoint, dhcp_repr);
                 send_packet(iface, endpoint, dhcp_repr)
             }


### PR DESCRIPTION
Fixes #445.

Turns out the DHCP server wasn't sending the router/netmask/dns options due to us not requesting them on renews.

From reading the RFC it seems the server is allowed to not respond with parameters we don't ask. The solution is to ask for them.

Just asking for them on all DHCPREQUESTs seems to work, but I've seen all other DHCP clients request them in DHCPDISCOVERs too, so this is what I'm doing here.

----

Fixes a bug where the lease expiration is not cleared on reset. 

If the DHCP server is gone and the lease expires, it would call reset(), which wouldn't clear the `self.lease_expiration` field. In next poll, `lease_expired` condition would match, immediatelly reset()ing again. This makes the client stuck in a reset loop.