### PR TITLE
phy: fix FaultInjector returning a too big buffer

### DIFF
--- a/src/phy/fault_injector.rs
+++ b/src/phy/fault_injector.rs
@@ -297,7 +297,7 @@ impl<'a, Tx: phy::TxToken> phy::TxToken for TxToken<'a, Tx> {
         };
 
         if drop {
-            return f(&mut self.junk);
+            return f(&mut self.junk[..len]);
         }
 
         let Self { token, state, config, .. } = self;


### PR DESCRIPTION
Device impls must return a buffer of the exact requested size. This caused an assertion failure in Interface:

```
[1617755835.841s] (phy::fault_injector): tx: randomly dropping a packet
thread 'main' panicked at 'assertion failed: tx_buffer.as_ref().len() == tx_len', /home/dirbaio/akiles/smoltcp/src/iface/interface.rs:1553:13
stack backtrace:
   0: rust_begin_unwind
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/std/src/panicking.rs:493:5
   1: core::panicking::panic_fmt
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/core/src/panicking.rs:92:14
   2: core::panicking::panic
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/core/src/panicking.rs:50:5
   3: smoltcp::iface::interface::InterfaceInner::dispatch_ethernet::{{closure}}
             at ./src/iface/interface.rs:1553:13
   4: <smoltcp::phy::fault_injector::TxToken<Tx> as smoltcp::phy::TxToken>::consume
             at ./src/phy/fault_injector.rs:300:20
   5: smoltcp::iface::interface::InterfaceInner::dispatch_ethernet
             at ./src/iface/interface.rs:1552:9
   6: smoltcp::iface::interface::InterfaceInner::dispatch_ip
             at ./src/iface/interface.rs:1705:17
   7: smoltcp::iface::interface::InterfaceInner::dispatch
             at ./src/iface/interface.rs:1541:17
   8: smoltcp::iface::interface::Interface<DeviceT>::socket_ingress::{{closure}}::{{closure}}
             at ./src/iface/interface.rs:604:37
   9: core::result::Result<T,E>::and_then
             at /home/dirbaio/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/result.rs:704:22
  10: smoltcp::iface::interface::Interface<DeviceT>::socket_ingress::{{closure}}
             at ./src/iface/interface.rs:594:25
  11: <smoltcp::phy::fault_injector::RxToken<Rx> as smoltcp::phy::RxToken>::consume::{{closure}}
             at ./src/phy/fault_injector.rs:268:17
  12: <smoltcp::phy::tracer::RxToken<Rx> as smoltcp::phy::RxToken>::consume::{{closure}}
             at ./src/phy/tracer.rs:89:13
  13: <smoltcp::phy::pcap_writer::RxToken<Rx,S> as smoltcp::phy::RxToken>::consume::{{closure}}
             at ./src/phy/pcap_writer.rs:189:13
  14: <smoltcp::phy::tuntap_interface::RxToken as smoltcp::phy::RxToken>::consume
             at ./src/phy/tuntap_interface.rs:88:9
  15: <smoltcp::phy::pcap_writer::RxToken<Rx,S> as smoltcp::phy::RxToken>::consume
             at ./src/phy/pcap_writer.rs:183:9
  16: <smoltcp::phy::tracer::RxToken<Rx> as smoltcp::phy::RxToken>::consume
             at ./src/phy/tracer.rs:83:9
  17: <smoltcp::phy::fault_injector::RxToken<Rx> as smoltcp::phy::RxToken>::consume
             at ./src/phy/fault_injector.rs:256:9
  18: smoltcp::iface::interface::Interface<DeviceT>::socket_ingress
             at ./src/iface/interface.rs:590:13
  19: smoltcp::iface::interface::Interface<DeviceT>::poll
             at ./src/iface/interface.rs:527:33
  20: server::main
             at ./examples/server.rs:78:15
```