### PR TITLE
impl std::error::Error for smoltcp::Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,9 @@ pub enum Error {
     Dropped,
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
 /// The result type for the networking stack.
 pub type Result<T> = core::result::Result<T, Error>;
 


### PR DESCRIPTION
closes #484