### PR TITLE
Adding support for retrieving socket handle from DHCP sockets

### DIFF
--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -6,6 +6,7 @@ use crate::wire::{EthernetAddress, IpProtocol, IpAddress,
 use crate::wire::dhcpv4::{field as dhcpv4_field};
 use crate::socket::SocketMeta;
 use crate::time::{Instant, Duration};
+use crate::socket::SocketHandle;
 
 use super::{PollAt, Socket};
 
@@ -418,6 +419,12 @@ impl Dhcpv4Socket {
                 Ok(())
             }
         }
+    }
+
+    /// Return the socket handle.
+    #[inline]
+    pub fn handle(&self) -> SocketHandle {
+        self.meta.handle
     }
 
     /// Reset state and restart discovery phase.


### PR DESCRIPTION
This PR adds support for getting the socket handle from a DHCP socket similar to the support provided by other socket types (e.g. UDP and TCP)