### PR TITLE
Bumping smoltcp version to 0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Version bumped to 0.8
 - Update `managed` from 0.7 to 0.8 ([442](https://github.com/smoltcp-rs/smoltcp/pull/442))
 - udp: Add `close()` method to unbind socket.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoltcp"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2018"
 authors = ["whitequark <whitequark@whitequark.org>"]
 description = "A TCP/IP stack designed for bare-metal, real-time systems without a heap."


### PR DESCRIPTION
This PR bumps the stored version in Cargo.toml to 0.8 so that any cargo-patch will utilize the `master` branch of smoltcp instead of published 0.7.4 versions. The `master` branch is incompatible with existing 0.7.x code already, so this will force dependency updates as well.