### PR TITLE
Update loopback.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@ compile_error!("at least one socket needs to be enabled"); */
 #![allow(clippy::option_map_unit_fn)]
 #![allow(clippy::unit_arg)]
 
+#[cfg(any(feature = "std", feature = "alloc"))]
 extern crate alloc;
 
 #[cfg(not(any(feature = "proto-ipv4", feature = "proto-ipv6")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,6 @@ compile_error!("at least one socket needs to be enabled"); */
 #![allow(clippy::option_map_unit_fn)]
 #![allow(clippy::unit_arg)]
 
-#[cfg(feature = "alloc")]
 extern crate alloc;
 
 #[cfg(not(any(feature = "proto-ipv4", feature = "proto-ipv6")))]

--- a/src/phy/loopback.rs
+++ b/src/phy/loopback.rs
@@ -1,12 +1,7 @@
-#[cfg(feature = "std")]
-use std::vec::Vec;
-#[cfg(feature = "std")]
-use std::collections::VecDeque;
-#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
-#[cfg(all(feature = "alloc", not(feature = "rust-1_28")))]
+#[cfg(not(feature = "rust-1_28"))]
 use alloc::collections::VecDeque;
-#[cfg(all(feature = "alloc", feature = "rust-1_28"))]
+#[cfg(feature = "rust-1_28")]
 use alloc::VecDeque;
 
 use crate::Result;


### PR DESCRIPTION
Fixes a compiler error which imports `Vec` and `VecDeque` twice if for example we have an app that has smoltcp as a dependency and links it with feature `std`, and then also links with a no-std library that uses `smoltcp` with the `alloc` feature. 

The fix is to import `Vec` and `VecDeque` using the `alloc::*` path which works in both (`std` and `alloc`) configurations.

The easiest way to reproduce the error is to do a
`cargo build --features alloc`
(compiles smoltcp with alloc and std features)