### PR TITLE
Add Context struct.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,8 +43,6 @@ jobs:
           # Test alloc feature which requires nightly.
           - rust: nightly
             features: alloc medium-ethernet proto-ipv4 proto-ipv6 socket-raw socket-udp socket-tcp socket-icmp
-          - rust: nightly
-            features: alloc proto-ipv4 proto-ipv6 socket-raw socket-udp socket-tcp socket-icmp
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,15 @@ compile_error!("You must enable at least one of the following features: proto-ip
 ))]
 compile_error!("If you enable the socket feature, you must enable at least one of the following features: socket-raw, socket-udp, socket-tcp, socket-icmp");
 
+#[cfg(all(
+    feature = "socket",
+    not(any(
+        feature = "medium-ethernet",
+        feature = "medium-ip",
+    ))
+))]
+compile_error!("If you enable the socket feature, you must enable at least one of the following features: medium-ip, medium-ethernet");
+
 #[cfg(all(feature = "defmt", feature = "log"))]
 compile_error!("You must enable at most one of the following features: defmt, log");
 

--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -230,6 +230,17 @@ pub struct DeviceCapabilities {
     pub checksum: ChecksumCapabilities,
 }
 
+impl DeviceCapabilities {
+    pub fn ip_mtu(&self) -> usize {
+        match self.medium {
+            #[cfg(feature = "medium-ethernet")]
+            Medium::Ethernet => self.max_transmission_unit - crate::wire::EthernetFrame::<&[u8]>::header_len(),
+            #[cfg(feature = "medium-ip")]
+            Medium::Ip => self.max_transmission_unit,
+        }
+    }
+}
+
 /// Type of medium of a device.
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]


### PR DESCRIPTION
Many socket methods need access to small bits of context about the environment they run in, such as checksum capabilities, MTU, etc. Previously these were passed as params as needed. Works, but it makes the socket APIs inconsistent, and passing new things is annoying.

This PR adds a Context struct with these commonly needed bits, and standardizes the socket API so that `process`, `dispatch` and `poll_at` all take a `&Context`. 