### PR TITLE
use micros in Instant and Duration

### DIFF
--- a/examples/loopback.rs
+++ b/examples/loopback.rs
@@ -171,7 +171,7 @@ fn main() {
         }
 
         match iface.poll_delay(&socket_set, clock.elapsed()) {
-            Some(Duration { millis: 0 }) => debug!("resuming"),
+            Some(Duration::ZERO) => debug!("resuming"),
             Some(delay) => {
                 debug!("sleeping for {} ms", delay);
                 clock.advance(delay)

--- a/fuzz/fuzz_targets/tcp_headers.rs
+++ b/fuzz/fuzz_targets/tcp_headers.rs
@@ -207,7 +207,7 @@ fuzz_target!(|data: &[u8]| {
         }
 
         match iface.poll_delay(&socket_set, clock.elapsed()) {
-            Some(Duration { millis: 0 }) => {}
+            Some(Duration::ZERO) => {}
             Some(delay) => clock.advance(delay),
             None => clock.advance(Duration::from_millis(1)),
         }

--- a/src/iface/neighbor.rs
+++ b/src/iface/neighbor.rs
@@ -69,10 +69,10 @@ pub struct Cache<'a> {
 
 impl<'a> Cache<'a> {
     /// Minimum delay between discovery requests, in milliseconds.
-    pub(crate) const SILENT_TIME: Duration = Duration { millis: 1_000 };
+    pub(crate) const SILENT_TIME: Duration = Duration::from_millis(1_000);
 
     /// Neighbor entry lifetime, in milliseconds.
-    pub(crate) const ENTRY_LIFETIME: Duration = Duration { millis: 60_000 };
+    pub(crate) const ENTRY_LIFETIME: Duration = Duration::from_millis(60_000);
 
     /// Default number of entries in the cache before GC kicks in
     #[cfg(any(feature = "std", feature = "alloc"))]

--- a/src/socket/meta.rs
+++ b/src/socket/meta.rs
@@ -44,7 +44,7 @@ impl Meta {
     /// in milliseconds.
     ///
     /// See also `iface::NeighborCache::SILENT_TIME`.
-    pub(crate) const DISCOVERY_SILENT_TIME: Duration = Duration { millis: 3_000 };
+    pub(crate) const DISCOVERY_SILENT_TIME: Duration = Duration::from_millis(3_000);
 
     pub(crate) fn poll_at<F>(&self, socket_poll_at: PollAt, has_neighbor: F) -> PollAt
     where

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -217,6 +217,6 @@ impl Context {
         },
         #[cfg(all(feature = "medium-ethernet", feature = "socket-dhcpv4"))]
         ethernet_address: None,
-        now: Instant { millis: 0 },
+        now: Instant::from_millis_const(0),
     };
 }

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -185,8 +185,8 @@ enum Timer {
     },
 }
 
-const ACK_DELAY_DEFAULT: Duration = Duration { millis: 10 };
-const CLOSE_DELAY: Duration = Duration { millis: 10_000 };
+const ACK_DELAY_DEFAULT: Duration = Duration::from_millis(10);
+const CLOSE_DELAY: Duration = Duration::from_millis(10_000);
 
 impl Timer {
     fn new() -> Timer {

--- a/src/time.rs
+++ b/src/time.rs
@@ -24,21 +24,39 @@ use core::{fmt, ops};
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Instant {
-    pub millis: i64,
+    micros: i64,
 }
 
 impl Instant {
+    /// Create a new `Instant` from a number of microseconds.
+    pub fn from_micros<T: Into<i64>>(micros: T) -> Instant {
+        Instant {
+            micros: micros.into(),
+        }
+    }
+
+    pub const fn from_micros_const(micros: i64) -> Instant {
+        Instant { micros }
+    }
+
     /// Create a new `Instant` from a number of milliseconds.
     pub fn from_millis<T: Into<i64>>(millis: T) -> Instant {
         Instant {
-            millis: millis.into(),
+            micros: millis.into() * 1000,
+        }
+    }
+
+    /// Create a new `Instant` from a number of milliseconds.
+    pub const fn from_millis_const(millis: i64) -> Instant {
+        Instant {
+            micros: millis * 1000,
         }
     }
 
     /// Create a new `Instant` from a number of seconds.
     pub fn from_secs<T: Into<i64>>(secs: T) -> Instant {
         Instant {
-            millis: secs.into() * 1000,
+            micros: secs.into() * 1000000,
         }
     }
 
@@ -56,25 +74,30 @@ impl Instant {
     /// The fractional number of milliseconds that have passed
     /// since the beginning of time.
     pub const fn millis(&self) -> i64 {
-        self.millis % 1000
+        self.micros % 1000000 / 1000
     }
 
     /// The fractional number of microseconds that have passed
     /// since the beginning of time.
     pub const fn micros(&self) -> i64 {
-        self.millis % 1000 * 1000
+        self.micros % 1000000
     }
 
     /// The number of whole seconds that have passed since the
     /// beginning of time.
     pub const fn secs(&self) -> i64 {
-        self.millis / 1000
+        self.micros / 1000000
     }
 
     /// The total number of milliseconds that have passed since
     /// the biginning of time.
     pub const fn total_millis(&self) -> i64 {
-        self.millis
+        self.micros / 1000
+    }
+    /// The total number of milliseconds that have passed since
+    /// the biginning of time.
+    pub const fn total_micros(&self) -> i64 {
+        self.micros
     }
 }
 
@@ -82,7 +105,7 @@ impl Instant {
 impl From<::std::time::Instant> for Instant {
     fn from(other: ::std::time::Instant) -> Instant {
         let elapsed = other.elapsed();
-        Instant::from_millis((elapsed.as_secs() * 1_000) as i64 + elapsed.subsec_millis() as i64)
+        Instant::from_millis((elapsed.as_secs() * 1_000000) as i64 + elapsed.subsec_micros() as i64)
     }
 }
 
@@ -92,14 +115,14 @@ impl From<::std::time::SystemTime> for Instant {
         let n = other
             .duration_since(::std::time::UNIX_EPOCH)
             .expect("start time must not be before the unix epoch");
-        Self::from_millis(n.as_secs() as i64 * 1000 + n.subsec_millis() as i64)
+        Self::from_millis(n.as_secs() as i64 * 1000000 + n.subsec_micros() as i64)
     }
 }
 
 #[cfg(feature = "std")]
 impl From<Instant> for ::std::time::SystemTime {
     fn from(val: Instant) -> Self {
-        ::std::time::UNIX_EPOCH + ::std::time::Duration::from_millis(val.millis as u64)
+        ::std::time::UNIX_EPOCH + ::std::time::Duration::from_micros(val.micros as u64)
     }
 }
 
@@ -113,13 +136,13 @@ impl ops::Add<Duration> for Instant {
     type Output = Instant;
 
     fn add(self, rhs: Duration) -> Instant {
-        Instant::from_millis(self.millis + rhs.total_millis() as i64)
+        Instant::from_micros(self.micros + rhs.total_micros() as i64)
     }
 }
 
 impl ops::AddAssign<Duration> for Instant {
     fn add_assign(&mut self, rhs: Duration) {
-        self.millis += rhs.total_millis() as i64;
+        self.micros += rhs.total_micros() as i64;
     }
 }
 
@@ -127,13 +150,13 @@ impl ops::Sub<Duration> for Instant {
     type Output = Instant;
 
     fn sub(self, rhs: Duration) -> Instant {
-        Instant::from_millis(self.millis - rhs.total_millis() as i64)
+        Instant::from_micros(self.micros - rhs.total_micros() as i64)
     }
 }
 
 impl ops::SubAssign<Duration> for Instant {
     fn sub_assign(&mut self, rhs: Duration) {
-        self.millis -= rhs.total_millis() as i64;
+        self.micros -= rhs.total_micros() as i64;
     }
 }
 
@@ -141,7 +164,7 @@ impl ops::Sub<Instant> for Instant {
     type Output = Duration;
 
     fn sub(self, rhs: Instant) -> Duration {
-        Duration::from_millis((self.millis - rhs.millis).abs() as u64)
+        Duration::from_micros((self.micros - rhs.micros).abs() as u64)
     }
 }
 
@@ -149,35 +172,53 @@ impl ops::Sub<Instant> for Instant {
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Duration {
-    pub millis: u64,
+    micros: u64,
 }
 
 impl Duration {
+    pub const ZERO: Duration = Duration::from_micros(0);
+    /// Create a new `Duration` from a number of microeconds.
+    pub const fn from_micros(micros: u64) -> Duration {
+        Duration { micros }
+    }
+
     /// Create a new `Duration` from a number of milliseconds.
     pub const fn from_millis(millis: u64) -> Duration {
-        Duration { millis }
+        Duration {
+            micros: millis * 1000,
+        }
     }
 
     /// Create a new `Instant` from a number of seconds.
     pub const fn from_secs(secs: u64) -> Duration {
         Duration {
-            millis: secs * 1000,
+            micros: secs * 1000000,
         }
     }
 
     /// The fractional number of milliseconds in this `Duration`.
     pub const fn millis(&self) -> u64 {
-        self.millis % 1000
+        self.micros / 1000 % 1000
+    }
+
+    /// The fractional number of milliseconds in this `Duration`.
+    pub const fn micros(&self) -> u64 {
+        self.micros % 1000000
     }
 
     /// The number of whole seconds in this `Duration`.
     pub const fn secs(&self) -> u64 {
-        self.millis / 1000
+        self.micros / 1000000
     }
 
     /// The total number of milliseconds in this `Duration`.
     pub const fn total_millis(&self) -> u64 {
-        self.millis
+        self.micros / 1000
+    }
+
+    /// The total number of microseconds in this `Duration`.
+    pub const fn total_micros(&self) -> u64 {
+        self.micros
     }
 }
 
@@ -191,13 +232,13 @@ impl ops::Add<Duration> for Duration {
     type Output = Duration;
 
     fn add(self, rhs: Duration) -> Duration {
-        Duration::from_millis(self.millis + rhs.total_millis())
+        Duration::from_micros(self.micros + rhs.total_micros())
     }
 }
 
 impl ops::AddAssign<Duration> for Duration {
     fn add_assign(&mut self, rhs: Duration) {
-        self.millis += rhs.total_millis();
+        self.micros += rhs.total_micros();
     }
 }
 
@@ -205,9 +246,9 @@ impl ops::Sub<Duration> for Duration {
     type Output = Duration;
 
     fn sub(self, rhs: Duration) -> Duration {
-        Duration::from_millis(
-            self.millis
-                .checked_sub(rhs.total_millis())
+        Duration::from_micros(
+            self.micros
+                .checked_sub(rhs.total_micros())
                 .expect("overflow when subtracting durations"),
         )
     }
@@ -215,9 +256,9 @@ impl ops::Sub<Duration> for Duration {
 
 impl ops::SubAssign<Duration> for Duration {
     fn sub_assign(&mut self, rhs: Duration) {
-        self.millis = self
-            .millis
-            .checked_sub(rhs.total_millis())
+        self.micros = self
+            .micros
+            .checked_sub(rhs.total_micros())
             .expect("overflow when subtracting durations");
     }
 }
@@ -226,13 +267,13 @@ impl ops::Mul<u32> for Duration {
     type Output = Duration;
 
     fn mul(self, rhs: u32) -> Duration {
-        Duration::from_millis(self.millis * rhs as u64)
+        Duration::from_micros(self.micros * rhs as u64)
     }
 }
 
 impl ops::MulAssign<u32> for Duration {
     fn mul_assign(&mut self, rhs: u32) {
-        self.millis *= rhs as u64;
+        self.micros *= rhs as u64;
     }
 }
 
@@ -240,13 +281,13 @@ impl ops::Div<u32> for Duration {
     type Output = Duration;
 
     fn div(self, rhs: u32) -> Duration {
-        Duration::from_millis(self.millis / rhs as u64)
+        Duration::from_micros(self.micros / rhs as u64)
     }
 }
 
 impl ops::DivAssign<u32> for Duration {
     fn div_assign(&mut self, rhs: u32) {
-        self.millis /= rhs as u64;
+        self.micros /= rhs as u64;
     }
 }
 
@@ -254,13 +295,13 @@ impl ops::Shl<u32> for Duration {
     type Output = Duration;
 
     fn shl(self, rhs: u32) -> Duration {
-        Duration::from_millis(self.millis << rhs)
+        Duration::from_micros(self.micros << rhs)
     }
 }
 
 impl ops::ShlAssign<u32> for Duration {
     fn shl_assign(&mut self, rhs: u32) {
-        self.millis <<= rhs;
+        self.micros <<= rhs;
     }
 }
 
@@ -268,25 +309,25 @@ impl ops::Shr<u32> for Duration {
     type Output = Duration;
 
     fn shr(self, rhs: u32) -> Duration {
-        Duration::from_millis(self.millis >> rhs)
+        Duration::from_micros(self.micros >> rhs)
     }
 }
 
 impl ops::ShrAssign<u32> for Duration {
     fn shr_assign(&mut self, rhs: u32) {
-        self.millis >>= rhs;
+        self.micros >>= rhs;
     }
 }
 
 impl From<::core::time::Duration> for Duration {
     fn from(other: ::core::time::Duration) -> Duration {
-        Duration::from_millis(other.as_secs() * 1000 + other.subsec_millis() as u64)
+        Duration::from_micros(other.as_secs() * 1000000 + other.subsec_micros() as u64)
     }
 }
 
 impl From<Duration> for ::core::time::Duration {
     fn from(val: Duration) -> Self {
-        ::core::time::Duration::from_millis(val.total_millis())
+        ::core::time::Duration::from_micros(val.total_micros())
     }
 }
 
@@ -353,7 +394,7 @@ mod test {
         // std::ops::Mul
         assert_eq!(Duration::from_millis(13) * 22, Duration::from_millis(286));
         // std::ops::Div
-        assert_eq!(Duration::from_millis(53) / 4, Duration::from_millis(13));
+        assert_eq!(Duration::from_millis(53) / 4, Duration::from_micros(13250));
     }
 
     #[test]
@@ -366,7 +407,7 @@ mod test {
         duration *= 4;
         assert_eq!(duration, Duration::from_millis(20936));
         duration /= 5;
-        assert_eq!(duration, Duration::from_millis(4187));
+        assert_eq!(duration, Duration::from_micros(4187200));
     }
 
     #[test]


### PR DESCRIPTION
This improves precision everywhere, especially pcap
https://github.com/smoltcp-rs/smoltcp/pull/513