### PR TITLE
Bump MSRV to 1.46

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,11 @@ jobs:
     continue-on-error: ${{ matrix.rust == 'nightly' }}
     strategy:
       matrix:
-        # Test on stable, MSRV 1.40, and nightly.
+        # Test on stable, MSRV 1.46, and nightly.
         # Failure is permitted on nightly.
         rust:
           - stable
-          - 1.40.0
+          - 1.46.0
           - nightly
 
         features:
@@ -58,18 +58,18 @@ jobs:
     continue-on-error: ${{ matrix.rust == 'nightly' }}
     strategy:
       matrix:
-        # Test on stable, MSRV 1.40, and nightly.
+        # Test on stable, MSRV 1.46, and nightly.
         # Failure is permitted on nightly.
         rust:
           - stable
-          - 1.40.0
+          - 1.46.0
           - nightly
 
         features:
           # These feature sets cannot run tests, so we only check they build.
           - medium-ip medium-ethernet proto-ipv6 proto-ipv6 proto-igmp proto-dhcpv4 socket-raw socket-udp socket-tcp socket-icmp async
         include:
-          # defmt doesn't support 1.40
+          # defmt doesn't support 1.46
           - rust: stable
             features: defmt defmt-trace medium-ip medium-ethernet proto-ipv6 proto-ipv6 proto-igmp proto-dhcpv4 socket-raw socket-udp socket-tcp socket-icmp async
           - rust: nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Version bumped to 0.8
+- Minimum Supported Rust Version (MSRV) **bumped** from 1.40 to 1.46
 - Update `managed` from 0.7 to 0.8 ([442](https://github.com/smoltcp-rs/smoltcp/pull/442))
 - udp: Add `close()` method to unbind socket.
 
@@ -46,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0] - 2021-01-20
 
-Minimum Supported Rust Version (MSRV) **bumped** from 1.36 to 1.40
+- Minimum Supported Rust Version (MSRV) **bumped** from 1.36 to 1.40
 
 ### New features
 - tcp: Allow distinguishing between graceful (FIN) and ungraceful (RST) close. On graceful close, `recv()` now returns `Error::Finished`. On ungraceful close, `Error::Illegal` is returned, as before. ([351](https://github.com/smoltcp-rs/smoltcp/pull/351))

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ include complicated compile-time computations, such as macro or type tricks, eve
 at cost of performance degradation.
 
 _smoltcp_ does not need heap allocation *at all*, is [extensively documented][docs],
-and compiles on stable Rust 1.40 and later.
+and compiles on stable Rust 1.46 and later.
 
 _smoltcp_ achieves [~Gbps of throughput](#examplesbenchmarkrs) when tested against
 the Linux TCP stack in loopback mode.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,11 +72,11 @@
 //!
 //! # Minimum Supported Rust Version (MSRV)
 //!
-//! This crate is guaranteed to compile on stable Rust 1.40 and up with any valid set of features.
+//! This crate is guaranteed to compile on stable Rust 1.46 and up with any valid set of features.
 //! It *might* compile on older versions but that may change in any new patch release.
 //!
 //! The exception is when using the `defmt` feature, in which case `defmt`'s MSRV applies, which
-//! is higher than 1.40.
+//! is higher than 1.46.
 //!
 //! [wire]: wire/index.html
 //! [osi]: https://en.wikipedia.org/wiki/OSI_model


### PR DESCRIPTION
`bitflags` 1.3 bumps it to 1.46 due to some const fn stuff, so we follow.