### PR TITLE
Remove trailing commas in macros

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,13 +1,13 @@
 #[cfg(feature = "log")]
 macro_rules! net_log {
-    (trace, $($arg:expr),*) => { log::trace!($($arg),*); };
-    (debug, $($arg:expr),*) => { log::debug!($($arg),*); };
+    (trace, $($arg:expr),*) => { log::trace!($($arg),*) };
+    (debug, $($arg:expr),*) => { log::debug!($($arg),*) };
 }
 
 #[cfg(feature = "defmt")]
 macro_rules! net_log {
-    (trace, $($arg:expr),*) => { defmt::trace!($($arg),*); };
-    (debug, $($arg:expr),*) => { defmt::debug!($($arg),*); };
+    (trace, $($arg:expr),*) => { defmt::trace!($($arg),*) };
+    (debug, $($arg:expr),*) => { defmt::debug!($($arg),*) };
 }
 
 #[cfg(not(any(feature = "log", feature = "defmt")))]

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -103,10 +103,10 @@ pub enum Socket<'a> {
 
 macro_rules! dispatch_socket {
     ($self_:expr, |$socket:ident| $code:expr) => {
-        dispatch_socket!(@inner $self_, |$socket| $code);
+        dispatch_socket!(@inner $self_, |$socket| $code)
     };
     (mut $self_:expr, |$socket:ident| $code:expr) => {
-        dispatch_socket!(@inner mut $self_, |$socket| $code);
+        dispatch_socket!(@inner mut $self_, |$socket| $code)
     };
     (@inner $( $mut_:ident )* $self_:expr, |$socket:ident| $code:expr) => {
         match $self_ {


### PR DESCRIPTION
This is going to become a hard error in future releases of the compiler (https://github.com/rust-lang/rust/issues/79813).