### PR TITLE
Update MSV of Rust

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.49.0
+          toolchain: 1.53.0
           override: true
           components: clippy
       - uses: actions-rs/clippy-check@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         # Failure is permitted on nightly.
         rust:
           - stable
-          - 1.46.0
+          - 1.53.0
           - nightly
 
         features:
@@ -62,7 +62,7 @@ jobs:
         # Failure is permitted on nightly.
         rust:
           - stable
-          - 1.46.0
+          - 1.53.0
           - nightly
 
         features:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ include complicated compile-time computations, such as macro or type tricks, eve
 at cost of performance degradation.
 
 _smoltcp_ does not need heap allocation *at all*, is [extensively documented][docs],
-and compiles on stable Rust 1.46 and later.
+and compiles on stable Rust 1.53 and later.
 
 _smoltcp_ achieves [~Gbps of throughput](#examplesbenchmarkrs) when tested against
 the Linux TCP stack in loopback mode.
@@ -125,7 +125,7 @@ To use the _smoltcp_ library in your project, add the following to `Cargo.toml`:
 
 ```toml
 [dependencies]
-smoltcp = "0.5"
+smoltcp = "0.7.5"
 ```
 
 The default configuration assumes a hosted environment, for ease of evaluation.
@@ -133,7 +133,7 @@ You probably want to disable default features and configure them one by one:
 
 ```toml
 [dependencies]
-smoltcp = { version = "0.5", default-features = false, features = ["log"] }
+smoltcp = { version = "0.7.5", default-features = false, features = ["log"] }
 ```
 
 ### Feature `std`


### PR DESCRIPTION
Force the MSV of Rust as the toolchain to use. This reduces the chance of using new features, such as or-pattern syntax (which is a really nice feature to use).