### PR TITLE
ci: do not run tests on master push

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [ staging, trying, master ]
+    branches: [ staging, trying ]
   pull_request_target:
 
 name: Clippy check

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [ staging, trying, master ]
+    branches: [ staging, trying ]
   pull_request:
 
 name: Fuzz

--- a/.github/workflows/rustfmt.yaml
+++ b/.github/workflows/rustfmt.yaml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [ staging, trying, master ]
+    branches: [ staging, trying ]
   pull_request:
 
 name: Rustfmt check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [ staging, trying, master ]
+    branches: [ staging, trying ]
   pull_request:
 
 name: Test


### PR DESCRIPTION
bors already tests the *result* of merging PRs into master, and then
pushes the *exact same commit* to master on success, so it's guaranteed
to pass CI. No point in running everything again.

This'll make other CI runs faster, since we have so many jobs that we're
always running against the GHA limit of 10 concurrent jobs.