### PR TITLE
Add lint `#[must_use]` for ring buffer functions

### DIFF
--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1875,7 +1875,8 @@ impl<'a> TcpSocket<'a> {
                     payload_len,
                     payload_offset
                 );
-                let len_written = self.rx_buffer
+                let len_written = self
+                    .rx_buffer
                     .write_unallocated(payload_offset, repr.payload);
                 debug_assert!(len_written == payload_len);
             }

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1875,8 +1875,9 @@ impl<'a> TcpSocket<'a> {
                     payload_len,
                     payload_offset
                 );
-                self.rx_buffer
+                let len_written = self.rx_buffer
                     .write_unallocated(payload_offset, repr.payload);
+                debug_assert!(len_written == payload_len);
             }
             Err(_) => {
                 net_debug!(

--- a/src/storage/packet_buffer.rs
+++ b/src/storage/packet_buffer.rs
@@ -102,7 +102,7 @@ impl<'a, H> PacketBuffer<'a, H> {
                 // Add padding to the end of the ring buffer so that the
                 // contiguous window is at the beginning of the ring buffer.
                 *self.metadata_ring.enqueue_one()? = PacketMetadata::padding(contig_window);
-                // note(discard): function does not write to the result 
+                // note(discard): function does not write to the result
                 // enqueued padding buffer location
                 let _buf_enqueued = self.payload_ring.enqueue_many(contig_window);
             }

--- a/src/storage/ring_buffer.rs
+++ b/src/storage/ring_buffer.rs
@@ -1,4 +1,4 @@
-// Some of the functions in ring buffer is marked as #[must_use]. It notes that 
+// Some of the functions in ring buffer is marked as #[must_use]. It notes that
 // these functions may have side effects, and it's implemented by [RFC 1940].
 // [RFC 1940]: https://github.com/rust-lang/rust/issues/43302
 


### PR DESCRIPTION
This pull request adds `#[must_use]` flag on several ring buffer functions that have side-effects.

This lint is in stable Rust now: https://github.com/rust-lang/rust/issues/43302, these changes are noted according to code comment from @whitequark: https://github.com/smoltcp-rs/smoltcp/commit/f65bc8aa7910ab3e66bf6245634cb115829c7594.

Some test cases and functions are altered due to changes of `#[must_use]`.