### PR TITLE
Add fuzzing for IEEE802.15.4 frame

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -34,3 +34,9 @@ name = "dhcp_header"
 path = "fuzz_targets/dhcp_header.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "ieee802154_header"
+path = "fuzz_targets/ieee802154_header.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/ieee802154_header.rs
+++ b/fuzz/fuzz_targets/ieee802154_header.rs
@@ -1,0 +1,19 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use smoltcp::wire::{Ieee802154Frame, Ieee802154Repr};
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(ref frame) = Ieee802154Frame::new_checked(data) {
+        if let Ok(repr) = Ieee802154Repr::parse(frame) {
+            // The buffer len returns only the lenght required for emitting the header
+            // and does not take into account the length of the payload.
+            let mut buffer = vec![0; repr.buffer_len()];
+
+            // NOTE: unchecked because the checked version checks if the addressing mode field
+            // is valid or not. The addressing mode field is required for calculating the length of
+            // the header, which is used in `check_len`.
+            let mut frame = Ieee802154Frame::new_unchecked(&mut buffer[..]);
+            repr.emit(&mut frame);
+        }
+    };
+});


### PR DESCRIPTION
Because IEEE802.15.4 uses compression in its frame, fuzzing it is maybe a good idea. Adding this fuzz target showed that some frame methods were panicking. `check_len` now checks if accessors will panic or not.

I ran the fuzzer for about 15 minutes and nothing showed up after the changes in `check_len`.