### PR TITLE
IEEE802.15.4 decryption

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ bitflags = { version = "1.0", default-features = false }
 defmt = { version = "0.2.0", optional = true }
 rand_core = { version = "0.6.3", optional = true, default-features = false }
 
-ccm = "0.4.4"
-cipher = "0.3.0"
-aes = "0.7.5"
+ccm = { version = "0.4.4", optional = true }
+cipher = { version = "0.3.0", optional = true }
+aes = { version = "0.7.5", optional = true }
 
 
 [dev-dependencies]
@@ -43,6 +43,7 @@ rand-custom-impl = []
 "medium-ethernet" = ["socket"]
 "medium-ip" = ["socket"]
 "medium-ieee802154" = ["socket", "proto-sixlowpan"]
+"ieee802154-crypto" = ["ccm", "cipher", "aes"]
 
 "phy-raw_socket" = ["std", "libc"]
 "phy-tuntap_interface" = ["std", "libc", "medium-ethernet"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,11 @@ bitflags = { version = "1.0", default-features = false }
 defmt = { version = "0.2.0", optional = true }
 rand_core = { version = "0.6.3", optional = true, default-features = false }
 
+ccm = "0.4.4"
+cipher = "0.3.0"
+aes = "0.7.5"
+
+
 [dev-dependencies]
 env_logger = "0.5"
 getopts = "0.2"

--- a/src/iface/interface.rs
+++ b/src/iface/interface.rs
@@ -1151,6 +1151,12 @@ impl<'a> InterfaceInner<'a> {
             return Ok(None);
         }
 
+        if ieee802154_frame.security_enabled() {
+            // We need to unsecure the frame.
+            net_debug!("Dropping because secured frames are not supported");
+            return Ok(None);
+        }
+
         match ieee802154_frame.payload() {
             Some(payload) => self.process_sixlowpan(cx, sockets, &ieee802154_repr, payload),
             None => Ok(None),

--- a/src/wire/ieee802154.rs
+++ b/src/wire/ieee802154.rs
@@ -622,7 +622,6 @@ impl<T: AsRef<[u8]>> Frame<T> {
             }
         }
     }
-
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Frame<&'a T> {
@@ -786,6 +785,7 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Frame<T> {
     }
 
     /// Unsecure a secured IEEE 802.15.4 frame into `buffer`.
+    #[cfg(feature = "ieee802154-crypto")]
     pub fn decrypt(&mut self, key: &[u8; 16]) -> Result<()> {
         use aes::Aes128;
         use ccm::{
@@ -901,8 +901,7 @@ pub struct Repr {
 
 impl Repr {
     /// Parse an IEEE 802.15.4 frame and return a high-level representation.
-    pub fn parse<T: AsRef<[u8]> + ?Sized>(packet: &Frame<&T>) -> Result<Repr> {
-
+    pub fn parse<T: AsRef<[u8]>>(packet: &Frame<T>) -> Result<Repr> {
         Ok(Repr {
             frame_type: packet.frame_type(),
             security_enabled: packet.security_enabled(),
@@ -1140,6 +1139,7 @@ mod test {
         ][..],
     }
 
+    #[cfg(feature = "ieee802154-crypto")]
     #[test]
     fn decryption() {
         let mut frame = [


### PR DESCRIPTION
Decryption of IEEE802154 frames. Still very much a work in progress.

I am currently able to decrypt and check the authentication for a 32-bit authentication tag (the EncMic32 mode). Other modes are implemented, except for the encryption only mode (Enc mode), since this requires a modified AES-CCM construction (IEEE802.15.4 uses AES-CCM*).