### PR TITLE
Support defmt version span 0.2 to 0.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         # Failure is permitted on nightly.
         rust:
           - stable
-          - 1.53.0
+          - 1.56.0
           - nightly
 
         features:
@@ -68,13 +68,13 @@ jobs:
         # Failure is permitted on nightly.
         rust:
           - stable
-          - 1.53.0
+          - 1.56.0
           - nightly
 
         features:
           # These feature sets cannot run tests, so we only check they build.
           - rand-custom-impl medium-ip medium-ethernet medium-ieee802154 proto-ipv6 proto-ipv6 proto-igmp proto-dhcpv4 socket-raw socket-udp socket-tcp socket-icmp async
-          - rand-custom-impl defmt defmt-trace medium-ip medium-ethernet proto-ipv6 proto-ipv6 proto-igmp proto-dhcpv4 socket-raw socket-udp socket-tcp socket-icmp async
+          - rand-custom-impl defmt medium-ip medium-ethernet proto-ipv6 proto-ipv6 proto-igmp proto-dhcpv4 socket-raw socket-udp socket-tcp socket-icmp async
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ byteorder = { version = "1.0", default-features = false }
 log = { version = "0.4.4", default-features = false, optional = true }
 libc = { version = "0.2.18", optional = true }
 bitflags = { version = "1.0", default-features = false }
-defmt = { version = "0.2.0", optional = true }
+defmt = { version = "0.3", optional = true }
 rand_core = { version = "0.6.3", optional = true, default-features = false }
 
 [dev-dependencies]
@@ -56,12 +56,6 @@ rand-custom-impl = []
 "socket-dhcpv4" = ["socket", "medium-ethernet", "proto-dhcpv4"]
 
 "async" = []
-
-defmt-trace = []
-defmt-debug = []
-defmt-info = []
-defmt-warn = []
-defmt-error = []
 
 default = [
   "std", "log", # needed for `cargo test --no-default-features --features default` :/

--- a/src/wire/ieee802154.rs
+++ b/src/wire/ieee802154.rs
@@ -67,6 +67,7 @@ impl fmt::Display for AddressingMode {
 
 /// A IEEE 802.15.4 PAN.
 #[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Pan(pub u16);
 
 impl Pan {
@@ -82,6 +83,7 @@ impl Pan {
 
 /// A IEEE 802.15.4 address.
 #[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Address {
     Absent,
     Short([u8; 2]),
@@ -745,6 +747,7 @@ impl<T: AsRef<[u8]>> fmt::Display for Frame<T> {
 
 /// A high-level representation of an IEEE802.15.4 frame.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Repr {
     pub frame_type: FrameType,
     pub security_enabled: bool,


### PR DESCRIPTION
A trick to support multiple versions of `defmt`. This allows the user crate to select the version in the end.