### PR TITLE
socket: simplify, make SocketSet private.

### DIFF
--- a/src/iface/interface.rs
+++ b/src/iface/interface.rs
@@ -5,6 +5,8 @@
 use core::cmp;
 use managed::{ManagedMap, ManagedSlice};
 
+use super::socket_set::SocketSet;
+use super::{SocketHandle, SocketStorage};
 use crate::iface::Routes;
 #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
 use crate::iface::{NeighborAnswer, NeighborCache};
@@ -108,7 +110,7 @@ let iface = InterfaceBuilder::new(device, vec![])
     )]
     pub fn new<SocketsT>(device: DeviceT, sockets: SocketsT) -> Self
     where
-        SocketsT: Into<ManagedSlice<'a, Option<SocketSetItem<'a>>>>,
+        SocketsT: Into<ManagedSlice<'a, SocketStorage<'a>>>,
     {
         InterfaceBuilder {
             device: device,

--- a/src/iface/interface.rs
+++ b/src/iface/interface.rs
@@ -556,13 +556,15 @@ where
     }
 
     /// Get an iterator to the inner sockets.
-    pub fn sockets(&self) -> impl Iterator<Item = &Socket<'a>> {
-        self.sockets.iter().map(|i| &i.socket)
+    pub fn sockets(&self) -> impl Iterator<Item = (SocketHandle, &Socket<'a>)> {
+        self.sockets.iter().map(|i| (i.meta.handle, &i.socket))
     }
 
     /// Get a mutable iterator to the inner sockets.
-    pub fn sockets_mut(&mut self) -> impl Iterator<Item = &mut Socket<'a>> {
-        self.sockets.iter_mut().map(|i| &mut i.socket)
+    pub fn sockets_mut(&mut self) -> impl Iterator<Item = (SocketHandle, &mut Socket<'a>)> {
+        self.sockets
+            .iter_mut()
+            .map(|i| (i.meta.handle, &mut i.socket))
     }
 
     /// Add an address to a list of subscribed multicast IP addresses.

--- a/src/iface/interface.rs
+++ b/src/iface/interface.rs
@@ -1198,6 +1198,12 @@ impl<'a> InterfaceInner<'a> {
                         net_debug!("Extension headers are currently not supported for 6LoWPAN");
                         Ok(None)
                     }
+                    #[cfg(not(feature = "socket-udp"))]
+                    SixlowpanNhcPacket::UdpHeader(_) => {
+                        net_debug!("UDP support is disabled, enable cargo feature `socket-udp`.");
+                        Ok(None)
+                    }
+                    #[cfg(feature = "socket-udp")]
                     SixlowpanNhcPacket::UdpHeader(udp_packet) => {
                         ipv6_repr.next_header = IpProtocol::Udp;
                         // Handle the UDP
@@ -2444,6 +2450,7 @@ impl<'a> InterfaceInner<'a> {
 
                     #[allow(unreachable_patterns)]
                     match packet {
+                        #[cfg(feature = "socket-udp")]
                         IpPacket::Udp((_, udp_repr, payload)) => {
                             // 3. Create the header for 6LoWPAN UDP
                             let mut udp_packet =

--- a/src/iface/interface.rs
+++ b/src/iface/interface.rs
@@ -867,10 +867,7 @@ where
                 Socket::Raw(ref mut socket) => {
                     socket.dispatch(cx, |response| respond!(IpPacket::Raw(response)))
                 }
-                #[cfg(all(
-                    feature = "socket-icmp",
-                    any(feature = "proto-ipv4", feature = "proto-ipv6")
-                ))]
+                #[cfg(feature = "socket-icmp")]
                 Socket::Icmp(ref mut socket) => socket.dispatch(cx, |response| match response {
                     #[cfg(feature = "proto-ipv4")]
                     (IpRepr::Ipv4(ipv4_repr), IcmpRepr::Ipv4(icmpv4_repr)) => {
@@ -1325,10 +1322,7 @@ impl<'a> InterfaceInner<'a> {
         }
     }
 
-    #[cfg(all(
-        any(feature = "proto-ipv4", feature = "proto-ipv6"),
-        feature = "socket-raw"
-    ))]
+    #[cfg(feature = "socket-raw")]
     fn raw_socket_filter<'frame>(
         &mut self,
         cx: &Context,

--- a/src/iface/mod.rs
+++ b/src/iface/mod.rs
@@ -8,6 +8,8 @@ mod interface;
 #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
 mod neighbor;
 mod route;
+mod socket_meta;
+mod socket_set;
 
 #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
 pub(crate) use self::neighbor::Answer as NeighborAnswer;
@@ -16,5 +18,6 @@ pub use self::neighbor::Cache as NeighborCache;
 #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
 pub use self::neighbor::Neighbor;
 pub use self::route::{Route, Routes};
+pub use socket_set::{SocketHandle, SocketStorage};
 
 pub use self::interface::{Interface, InterfaceBuilder};

--- a/src/iface/mod.rs
+++ b/src/iface/mod.rs
@@ -4,11 +4,6 @@ The `iface` module deals with the *network interfaces*. It filters incoming fram
 provides lookup and caching of hardware addresses, and handles management packets.
 */
 
-#[cfg(any(
-    feature = "medium-ethernet",
-    feature = "medium-ip",
-    feature = "medium-ieee802154"
-))]
 mod interface;
 #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
 mod neighbor;
@@ -22,9 +17,4 @@ pub use self::neighbor::Cache as NeighborCache;
 pub use self::neighbor::Neighbor;
 pub use self::route::{Route, Routes};
 
-#[cfg(any(
-    feature = "medium-ethernet",
-    feature = "medium-ip",
-    feature = "medium-ieee802154"
-))]
 pub use self::interface::{Interface, InterfaceBuilder};

--- a/src/iface/socket_meta.rs
+++ b/src/iface/socket_meta.rs
@@ -1,4 +1,5 @@
-use crate::socket::{PollAt, SocketHandle};
+use super::SocketHandle;
+use crate::socket::PollAt;
 use crate::time::{Duration, Instant};
 use crate::wire::IpAddress;
 

--- a/src/iface/socket_set.rs
+++ b/src/iface/socket_set.rs
@@ -1,26 +1,35 @@
 use core::fmt;
 use managed::ManagedSlice;
 
+use super::socket_meta::Meta;
 use crate::socket::{AnySocket, Socket};
 
-use super::meta::Meta;
+/// Opaque struct with space for storing one socket.
+///
+/// This is public so you can use it to allocate space for storing
+/// sockets when creating an Interface.
+#[derive(Debug, Default)]
+pub struct SocketStorage<'a> {
+    inner: Option<Item<'a>>,
+}
+
+impl<'a> SocketStorage<'a> {
+    pub const EMPTY: Self = Self { inner: None };
+}
 
 /// An item of a socket set.
-///
-/// The only reason this struct is public is to allow the socket set storage
-/// to be allocated externally.
 #[derive(Debug)]
-pub struct Item<'a> {
+pub(crate) struct Item<'a> {
     pub(crate) meta: Meta,
     pub(crate) socket: Socket<'a>,
 }
 
-/// A handle, identifying a socket in a set.
+/// A handle, identifying a socket in an Interface.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Handle(usize);
+pub struct SocketHandle(usize);
 
-impl fmt::Display for Handle {
+impl fmt::Display for SocketHandle {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "#{}", self.0)
     }
@@ -30,38 +39,40 @@ impl fmt::Display for Handle {
 ///
 /// The lifetime `'a` is used when storing a `Socket<'a>`.
 #[derive(Debug)]
-pub struct Set<'a> {
-    sockets: ManagedSlice<'a, Option<Item<'a>>>,
+pub(crate) struct SocketSet<'a> {
+    sockets: ManagedSlice<'a, SocketStorage<'a>>,
 }
 
-impl<'a> Set<'a> {
+impl<'a> SocketSet<'a> {
     /// Create a socket set using the provided storage.
-    pub fn new<SocketsT>(sockets: SocketsT) -> Set<'a>
+    pub fn new<SocketsT>(sockets: SocketsT) -> SocketSet<'a>
     where
-        SocketsT: Into<ManagedSlice<'a, Option<Item<'a>>>>,
+        SocketsT: Into<ManagedSlice<'a, SocketStorage<'a>>>,
     {
         let sockets = sockets.into();
-        Set { sockets }
+        SocketSet { sockets }
     }
 
     /// Add a socket to the set, and return its handle.
     ///
     /// # Panics
     /// This function panics if the storage is fixed-size (not a `Vec`) and is full.
-    pub fn add<T: AnySocket<'a>>(&mut self, socket: T) -> Handle {
-        fn put<'a>(index: usize, slot: &mut Option<Item<'a>>, socket: Socket<'a>) -> Handle {
+    pub fn add<T: AnySocket<'a>>(&mut self, socket: T) -> SocketHandle {
+        fn put<'a>(index: usize, slot: &mut SocketStorage<'a>, socket: Socket<'a>) -> SocketHandle {
             net_trace!("[{}]: adding", index);
-            let handle = Handle(index);
+            let handle = SocketHandle(index);
             let mut meta = Meta::default();
             meta.handle = handle;
-            *slot = Some(Item { socket, meta });
+            *slot = SocketStorage {
+                inner: Some(Item { meta, socket }),
+            };
             handle
         }
 
         let socket = socket.upcast();
 
         for (index, slot) in self.sockets.iter_mut().enumerate() {
-            if slot.is_none() {
+            if slot.inner.is_none() {
                 return put(index, slot, socket);
             }
         }
@@ -70,7 +81,7 @@ impl<'a> Set<'a> {
             ManagedSlice::Borrowed(_) => panic!("adding a socket to a full SocketSet"),
             #[cfg(any(feature = "std", feature = "alloc"))]
             ManagedSlice::Owned(ref mut sockets) => {
-                sockets.push(None);
+                sockets.push(SocketStorage { inner: None });
                 let index = sockets.len() - 1;
                 put(index, &mut sockets[index], socket)
             }
@@ -82,8 +93,8 @@ impl<'a> Set<'a> {
     /// # Panics
     /// This function may panic if the handle does not belong to this socket set
     /// or the socket has the wrong type.
-    pub fn get<T: AnySocket<'a>>(&mut self, handle: Handle) -> &mut T {
-        match self.sockets[handle.0].as_mut() {
+    pub fn get<T: AnySocket<'a>>(&mut self, handle: SocketHandle) -> &mut T {
+        match self.sockets[handle.0].inner.as_mut() {
             Some(item) => {
                 T::downcast(&mut item.socket).expect("handle refers to a socket of a wrong type")
             }
@@ -95,9 +106,9 @@ impl<'a> Set<'a> {
     ///
     /// # Panics
     /// This function may panic if the handle does not belong to this socket set.
-    pub fn remove(&mut self, handle: Handle) -> Socket<'a> {
+    pub fn remove(&mut self, handle: SocketHandle) -> Socket<'a> {
         net_trace!("[{}]: removing", handle.0);
-        match self.sockets[handle.0].take() {
+        match self.sockets[handle.0].inner.take() {
             Some(item) => item.socket,
             None => panic!("handle does not refer to a valid socket"),
         }
@@ -105,11 +116,11 @@ impl<'a> Set<'a> {
 
     /// Iterate every socket in this set.
     pub fn iter(&self) -> impl Iterator<Item = &Item<'a>> + '_ {
-        self.sockets.iter().filter_map(|x| x.as_ref())
+        self.sockets.iter().filter_map(|x| x.inner.as_ref())
     }
 
     /// Iterate every socket in this set.
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Item<'a>> + '_ {
-        self.sockets.iter_mut().filter_map(|x| x.as_mut())
+        self.sockets.iter_mut().filter_map(|x| x.inner.as_mut())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,13 @@ mod rand;
 #[cfg(feature = "rand-custom-impl")]
 pub use crate::rand::Rand;
 
+#[cfg(any(
+    feature = "medium-ethernet",
+    feature = "medium-ip",
+    feature = "medium-ieee802154"
+))]
 pub mod iface;
+
 pub mod phy;
 #[cfg(feature = "socket")]
 pub mod socket;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,9 +111,10 @@ compile_error!("You must enable at least one of the following features: proto-ip
         feature = "socket-udp",
         feature = "socket-tcp",
         feature = "socket-icmp",
+        feature = "socket-dhcp",
     ))
 ))]
-compile_error!("If you enable the socket feature, you must enable at least one of the following features: socket-raw, socket-udp, socket-tcp, socket-icmp");
+compile_error!("If you enable the socket feature, you must enable at least one of the following features: socket-raw, socket-udp, socket-tcp, socket-icmp, socket-dhcp");
 
 #[cfg(all(
     feature = "socket",

--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -1,5 +1,4 @@
-use crate::socket::SocketHandle;
-use crate::socket::{Context, SocketMeta};
+use crate::socket::Context;
 use crate::time::{Duration, Instant};
 use crate::wire::dhcpv4::field as dhcpv4_field;
 use crate::wire::HardwareAddress;
@@ -9,7 +8,7 @@ use crate::wire::{
 };
 use crate::{Error, Result};
 
-use super::{PollAt, Socket};
+use super::PollAt;
 
 const DISCOVER_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -112,7 +111,6 @@ pub enum Event {
 
 #[derive(Debug)]
 pub struct Dhcpv4Socket {
-    pub(crate) meta: SocketMeta,
     /// State of the DHCP client.
     state: ClientState,
     /// Set to true on config/state change, cleared back to false by the `config` function.
@@ -138,7 +136,6 @@ impl Dhcpv4Socket {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Dhcpv4Socket {
-            meta: SocketMeta::default(),
             state: ClientState::Discovering(DiscoverState {
                 retry_at: Instant::from_millis(0),
             }),
@@ -520,12 +517,6 @@ impl Dhcpv4Socket {
         }
     }
 
-    /// Return the socket handle.
-    #[inline]
-    pub fn handle(&self) -> SocketHandle {
-        self.meta.handle
-    }
-
     /// Reset state and restart discovery phase.
     ///
     /// Use this to speed up acquisition of an address in a new
@@ -554,12 +545,6 @@ impl Dhcpv4Socket {
             self.config_changed = false;
             Some(Event::Deconfigured)
         }
-    }
-}
-
-impl<'a> From<Dhcpv4Socket> for Socket<'a> {
-    fn from(val: Dhcpv4Socket) -> Self {
-        Socket::Dhcpv4(val)
     }
 }
 

--- a/src/socket/meta.rs
+++ b/src/socket/meta.rs
@@ -31,7 +31,7 @@ impl Default for NeighborState {
 /// is interested in, but which are more conveniently stored inside the socket itself.
 #[derive(Debug, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Meta {
+pub(crate) struct Meta {
     /// Handle of this socket within its enclosing `SocketSet`.
     /// Mainly useful for debug output.
     pub(crate) handle: SocketHandle,

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -14,9 +14,6 @@ size for a buffer, allocate it, and let the networking stack use it.
 use crate::phy::DeviceCapabilities;
 use crate::time::Instant;
 
-mod meta;
-mod set;
-
 #[cfg(feature = "socket-dhcpv4")]
 mod dhcpv4;
 #[cfg(feature = "socket-icmp")]
@@ -30,8 +27,6 @@ mod udp;
 
 #[cfg(feature = "async")]
 mod waker;
-
-pub use self::set::{Handle as SocketHandle, Item as SocketSetItem, Set as SocketSet};
 
 #[cfg(feature = "socket-dhcpv4")]
 pub use self::dhcpv4::{Config as Dhcpv4Config, Dhcpv4Socket, Event as Dhcpv4Event};


### PR DESCRIPTION
This completes the work started in #557.

Since `Interface` now owns the sockets, `SocketSet` is now an implementation detail, so it is made private. 

Also `SocketMeta` is moved from each socket to the SocketSet. `SocketMeta` is arguably an `Interface` implementation detail as well, mainly used for neighbor discovery. it also reduces a bit of code duplication.