### PR TITLE
GAT-based Device trait.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,8 @@ jobs:
         # Test on stable, MSRV, and nightly.
         # Failure is permitted on nightly.
         rust:
-          - stable
-          - 1.61.0
+          #- stable  # TODO: enable again when "stable" is 1.66 or higher.
+          - 1.65.0
           - nightly
 
         features:
@@ -64,8 +64,8 @@ jobs:
         # Test on stable, MSRV, and nightly.
         # Failure is permitted on nightly.
         rust:
-          - stable
-          - 1.61.0
+          #- stable  # TODO: enable again when "stable" is 1.66 or higher.
+          - 1.65.0
           - nightly
 
         features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove IpAddress::Unspecified
 - When sending packets with a raw socket, the source IP address is sent unmodified (it was previously replaced with the interface's address if it was unspecified).
 - Fix enable `defmt/alloc` if `alloc` or `std` is enabled.
-- Minimum Supported Rust Version (MSRV) **bumped** from 1.56 to 1.60
+- Minimum Supported Rust Version (MSRV) **bumped** from 1.56 to 1.65
 
 ## [0.8.1] - 2022-05-12
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "smoltcp"
 version = "0.8.1"
 edition = "2018"
-rust-version = "1.61"
+rust-version = "1.65"
 authors = ["whitequark <whitequark@whitequark.org>"]
 description = "A TCP/IP stack designed for bare-metal, real-time systems without a heap."
 documentation = "https://docs.rs/smoltcp/"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ include complicated compile-time computations, such as macro or type tricks, eve
 at cost of performance degradation.
 
 _smoltcp_ does not need heap allocation *at all*, is [extensively documented][docs],
-and compiles on stable Rust 1.61 and later.
+and compiles on stable Rust 1.65 and later.
 
 _smoltcp_ achieves [~Gbps of throughput](#examplesbenchmarkrs) when tested against
 the Linux TCP stack in loopback mode.

--- a/examples/utils.rs
+++ b/examples/utils.rs
@@ -159,7 +159,7 @@ pub fn parse_middleware_options<D>(
     loopback: bool,
 ) -> FaultInjector<Tracer<PcapWriter<D, Box<dyn io::Write>>>>
 where
-    D: for<'a> Device<'a>,
+    D: Device,
 {
     let drop_chance = matches
         .opt_str("drop-chance")

--- a/examples/utils.rs
+++ b/examples/utils.rs
@@ -84,11 +84,7 @@ pub fn parse_options(options: &Options, free: Vec<&str>) -> Matches {
                     free.join(" ")
                 );
                 print!("{}", options.usage(&brief));
-                process::exit(if matches.free.len() != free.len() {
-                    1
-                } else {
-                    0
-                })
+                process::exit((matches.free.len() != free.len()) as _);
             }
             matches
         }

--- a/fuzz/utils.rs
+++ b/fuzz/utils.rs
@@ -93,7 +93,7 @@ pub fn parse_middleware_options<D>(
     loopback: bool,
 ) -> FaultInjector<Tracer<PcapWriter<D, Box<dyn Write>>>>
 where
-    D: for<'a> Device<'a>,
+    D: Device,
 {
     let drop_chance = matches
         .opt_str("drop-chance")

--- a/src/iface/fragmentation.rs
+++ b/src/iface/fragmentation.rs
@@ -364,7 +364,7 @@ impl<'a, K: Eq + Ord + Clone + Copy> PacketAssemblerSet<'a, K> {
     /// - Returns [`Error::PacketAssemblerSetKeyNotFound`] when the key was not found in the set.
     pub(crate) fn get_packet_assembler_mut(&mut self, key: &K) -> Result<&mut PacketAssembler<'a>> {
         if let Some(i) = self.index_buffer.get(key) {
-            Ok(&mut self.packet_buffer[*i as usize])
+            Ok(&mut self.packet_buffer[*i])
         } else {
             Err(Error::PacketAssemblerSetKeyNotFound)
         }
@@ -379,7 +379,7 @@ impl<'a, K: Eq + Ord + Clone + Copy> PacketAssemblerSet<'a, K> {
     /// - Returns [`Error::PacketAssemblerIncomplete`] when the fragments assembler was empty or not fully assembled.
     pub(crate) fn get_assembled_packet(&mut self, key: &K) -> Result<&[u8]> {
         if let Some(i) = self.index_buffer.get(key) {
-            let p = self.packet_buffer[*i as usize].assemble()?;
+            let p = self.packet_buffer[*i].assemble()?;
             self.index_buffer.remove(key);
             Ok(p)
         } else {
@@ -392,10 +392,7 @@ impl<'a, K: Eq + Ord + Clone + Copy> PacketAssemblerSet<'a, K> {
         loop {
             let mut key = None;
             for (k, i) in self.index_buffer.iter() {
-                if matches!(
-                    self.packet_buffer[*i as usize].assembler,
-                    AssemblerState::NotInit
-                ) {
+                if matches!(self.packet_buffer[*i].assembler, AssemblerState::NotInit) {
                     key = Some(*k);
                     break;
                 }
@@ -416,7 +413,7 @@ impl<'a, K: Eq + Ord + Clone + Copy> PacketAssemblerSet<'a, K> {
         F: Fn(&mut PacketAssembler<'_>) -> Result<bool>,
     {
         for (_, i) in &mut self.index_buffer.iter() {
-            let frag = &mut self.packet_buffer[*i as usize];
+            let frag = &mut self.packet_buffer[*i];
             if f(frag)? {
                 frag.mark_discarded();
             }

--- a/src/iface/interface/ipv4.rs
+++ b/src/iface/interface/ipv4.rs
@@ -507,7 +507,7 @@ impl<'a> InterfaceInner<'a> {
             }
 
             tx_buffer[repr.buffer_len()..][..payload_len].copy_from_slice(
-                &buffer[*frag_offset as usize + repr.buffer_len() as usize..][..payload_len],
+                &buffer[*frag_offset as usize + repr.buffer_len()..][..payload_len],
             );
 
             // Update the frag offset for the next fragment.

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -563,7 +563,7 @@ let iface = builder.finalize(&mut device);
     /// [neighbor_cache]: #method.neighbor_cache
     pub fn finalize<D>(self, device: &mut D) -> Interface<'a>
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         let caps = device.capabilities();
 
@@ -905,7 +905,7 @@ impl<'a> Interface<'a> {
         timestamp: Instant,
     ) -> Result<bool>
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         self.inner.now = timestamp;
 
@@ -947,7 +947,7 @@ impl<'a> Interface<'a> {
         timestamp: Instant,
     ) -> Result<bool>
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         self.inner.now = timestamp;
 
@@ -1047,7 +1047,7 @@ impl<'a> Interface<'a> {
         sockets: &mut SocketSet<'_>,
     ) -> Result<bool>
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         self.inner.now = timestamp;
 
@@ -1152,7 +1152,7 @@ impl<'a> Interface<'a> {
 
     fn socket_ingress<D>(&mut self, device: &mut D, sockets: &mut SocketSet<'_>) -> bool
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         let mut processed_any = false;
         let Self {
@@ -1208,7 +1208,7 @@ impl<'a> Interface<'a> {
 
     fn socket_egress<D>(&mut self, device: &mut D, sockets: &mut SocketSet<'_>) -> bool
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         let Self {
             inner,
@@ -1318,7 +1318,7 @@ impl<'a> Interface<'a> {
     #[cfg(feature = "proto-igmp")]
     fn igmp_egress<D>(&mut self, device: &mut D) -> Result<bool>
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         match self.inner.igmp_report_state {
             IgmpReportState::ToSpecificQuery {
@@ -1384,7 +1384,7 @@ impl<'a> Interface<'a> {
     #[cfg(feature = "proto-ipv4-fragmentation")]
     fn ipv4_egress<D>(&mut self, device: &mut D) -> Result<bool>
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         // Reset the buffer when we transmitted everything.
         if self.out_packets.ipv4_out_packet.finished() {
@@ -1422,7 +1422,7 @@ impl<'a> Interface<'a> {
     #[cfg(feature = "proto-sixlowpan-fragmentation")]
     fn sixlowpan_egress<D>(&mut self, device: &mut D) -> Result<bool>
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         // Reset the buffer when we transmitted everything.
         if self.out_packets.sixlowpan_out_packet.finished() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 //!
 //! # Minimum Supported Rust Version (MSRV)
 //!
-//! This crate is guaranteed to compile on stable Rust 1.61 and up with any valid set of features.
+//! This crate is guaranteed to compile on stable Rust 1.65 and up with any valid set of features.
 //! It *might* compile on older versions but that may change in any new patch release.
 //!
 //! The exception is when using the `defmt` feature, in which case `defmt`'s MSRV applies, which

--- a/src/phy/loopback.rs
+++ b/src/phy/loopback.rs
@@ -29,9 +29,9 @@ impl Loopback {
     }
 }
 
-impl<'a> Device<'a> for Loopback {
-    type RxToken = RxToken;
-    type TxToken = TxToken<'a>;
+impl Device for Loopback {
+    type RxToken<'a> = RxToken;
+    type TxToken<'a> = TxToken<'a>;
 
     fn capabilities(&self) -> DeviceCapabilities {
         DeviceCapabilities {
@@ -41,7 +41,7 @@ impl<'a> Device<'a> for Loopback {
         }
     }
 
-    fn receive(&'a mut self) -> Option<(Self::RxToken, Self::TxToken)> {
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         self.queue.pop_front().map(move |buffer| {
             let rx = RxToken { buffer };
             let tx = TxToken {
@@ -51,7 +51,7 @@ impl<'a> Device<'a> for Loopback {
         })
     }
 
-    fn transmit(&'a mut self) -> Option<Self::TxToken> {
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>> {
         Some(TxToken {
             queue: &mut self.queue,
         })

--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -38,16 +38,16 @@ impl<'a> StmPhy {
     }
 }
 
-impl<'a> phy::Device<'a> for StmPhy {
-    type RxToken = StmPhyRxToken<'a>;
-    type TxToken = StmPhyTxToken<'a>;
+impl phy::Device for StmPhy {
+    type RxToken<'a> = StmPhyRxToken<'a> where Self: 'a;
+    type TxToken<'a> = StmPhyTxToken<'a> where Self: 'a;
 
-    fn receive(&'a mut self) -> Option<(Self::RxToken, Self::TxToken)> {
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         Some((StmPhyRxToken(&mut self.rx_buffer[..]),
               StmPhyTxToken(&mut self.tx_buffer[..])))
     }
 
-    fn transmit(&'a mut self) -> Option<Self::TxToken> {
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>> {
         Some(StmPhyTxToken(&mut self.tx_buffer[..]))
     }
 
@@ -308,9 +308,13 @@ impl Default for Medium {
 /// The interface is based on _tokens_, which are types that allow to receive/transmit a
 /// single packet. The `receive` and `transmit` functions only construct such tokens, the
 /// real sending/receiving operation are performed when the tokens are consumed.
-pub trait Device<'a> {
-    type RxToken: RxToken + 'a;
-    type TxToken: TxToken + 'a;
+pub trait Device {
+    type RxToken<'a>: RxToken
+    where
+        Self: 'a;
+    type TxToken<'a>: TxToken
+    where
+        Self: 'a;
 
     /// Construct a token pair consisting of one receive token and one transmit token.
     ///
@@ -318,10 +322,10 @@ pub trait Device<'a> {
     /// on the contents of the received packet. For example, this makes it possible to
     /// handle arbitrarily large ICMP echo ("ping") requests, where the all received bytes
     /// need to be sent back, without heap allocation.
-    fn receive(&'a mut self) -> Option<(Self::RxToken, Self::TxToken)>;
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)>;
 
     /// Construct a transmit token.
-    fn transmit(&'a mut self) -> Option<Self::TxToken>;
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>>;
 
     /// Get a description of device capabilities.
     fn capabilities(&self) -> DeviceCapabilities;

--- a/src/phy/raw_socket.rs
+++ b/src/phy/raw_socket.rs
@@ -54,9 +54,13 @@ impl RawSocket {
     }
 }
 
-impl<'a> Device<'a> for RawSocket {
-    type RxToken = RxToken;
-    type TxToken = TxToken;
+impl Device for RawSocket {
+    type RxToken<'a> = RxToken
+    where
+        Self: 'a;
+    type TxToken<'a> = TxToken
+    where
+        Self: 'a;
 
     fn capabilities(&self) -> DeviceCapabilities {
         DeviceCapabilities {
@@ -66,7 +70,7 @@ impl<'a> Device<'a> for RawSocket {
         }
     }
 
-    fn receive(&'a mut self) -> Option<(Self::RxToken, Self::TxToken)> {
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         let mut lower = self.lower.borrow_mut();
         let mut buffer = vec![0; self.mtu];
         match lower.recv(&mut buffer[..]) {
@@ -83,7 +87,7 @@ impl<'a> Device<'a> for RawSocket {
         }
     }
 
-    fn transmit(&'a mut self) -> Option<Self::TxToken> {
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>> {
         Some(TxToken {
             lower: self.lower.clone(),
         })

--- a/src/phy/tracer.rs
+++ b/src/phy/tracer.rs
@@ -12,12 +12,12 @@ use crate::{
 /// A tracer is a device that pretty prints all packets traversing it
 /// using the provided writer function, and then passes them to another
 /// device.
-pub struct Tracer<D: for<'a> Device<'a>> {
+pub struct Tracer<D: Device> {
     inner: D,
     writer: fn(Instant, Packet),
 }
 
-impl<D: for<'a> Device<'a>> Tracer<D> {
+impl<D: Device> Tracer<D> {
     /// Create a tracer device.
     pub fn new(inner: D, writer: fn(timestamp: Instant, packet: Packet)) -> Tracer<D> {
         Tracer { inner, writer }
@@ -44,18 +44,19 @@ impl<D: for<'a> Device<'a>> Tracer<D> {
     }
 }
 
-impl<'a, D> Device<'a> for Tracer<D>
-where
-    D: for<'b> Device<'b>,
-{
-    type RxToken = RxToken<<D as Device<'a>>::RxToken>;
-    type TxToken = TxToken<<D as Device<'a>>::TxToken>;
+impl<D: Device> Device for Tracer<D> {
+    type RxToken<'a> = RxToken<D::RxToken<'a>>
+    where
+        Self: 'a;
+    type TxToken<'a> = TxToken<D::TxToken<'a>>
+    where
+        Self: 'a;
 
     fn capabilities(&self) -> DeviceCapabilities {
         self.inner.capabilities()
     }
 
-    fn receive(&'a mut self) -> Option<(Self::RxToken, Self::TxToken)> {
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         let &mut Self {
             ref mut inner,
             writer,
@@ -77,7 +78,7 @@ where
         })
     }
 
-    fn transmit(&'a mut self) -> Option<Self::TxToken> {
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>> {
         let &mut Self {
             ref mut inner,
             writer,

--- a/src/phy/tuntap_interface.rs
+++ b/src/phy/tuntap_interface.rs
@@ -40,9 +40,9 @@ impl TunTapInterface {
     }
 }
 
-impl<'a> Device<'a> for TunTapInterface {
-    type RxToken = RxToken;
-    type TxToken = TxToken;
+impl Device for TunTapInterface {
+    type RxToken<'a> = RxToken;
+    type TxToken<'a> = TxToken;
 
     fn capabilities(&self) -> DeviceCapabilities {
         DeviceCapabilities {
@@ -52,7 +52,7 @@ impl<'a> Device<'a> for TunTapInterface {
         }
     }
 
-    fn receive(&'a mut self) -> Option<(Self::RxToken, Self::TxToken)> {
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         let mut lower = self.lower.borrow_mut();
         let mut buffer = vec![0; self.mtu];
         match lower.recv(&mut buffer[..]) {
@@ -69,7 +69,7 @@ impl<'a> Device<'a> for TunTapInterface {
         }
     }
 
-    fn transmit(&'a mut self) -> Option<Self::TxToken> {
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>> {
         Some(TxToken {
             lower: self.lower.clone(),
         })

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -129,7 +129,7 @@ impl Default for RttEstimator {
 impl RttEstimator {
     fn retransmission_timeout(&self) -> Duration {
         let margin = RTTE_MIN_MARGIN.max(self.deviation * 4);
-        let ms = (self.rtt + margin).max(RTTE_MIN_RTO).min(RTTE_MAX_RTO);
+        let ms = (self.rtt + margin).clamp(RTTE_MIN_RTO, RTTE_MAX_RTO);
         Duration::from_millis(ms as u64)
     }
 
@@ -1442,7 +1442,7 @@ impl<'a> Socket<'a> {
 
                 if segment_in_window {
                     // We've checked that segment_start >= window_start above.
-                    payload_offset = (segment_start - window_start) as usize;
+                    payload_offset = segment_start - window_start;
                     self.local_rx_last_seq = Some(repr.seq_number);
                 } else {
                     // If we're in the TIME-WAIT state, restart the TIME-WAIT timeout, since

--- a/src/wire/icmpv6.rs
+++ b/src/wire/icmpv6.rs
@@ -555,7 +555,7 @@ impl<'a> Repr<'a> {
         {
             let ip_packet = Ipv6Packet::new_checked(packet.payload())?;
 
-            let payload = &packet.payload()[ip_packet.header_len() as usize..];
+            let payload = &packet.payload()[ip_packet.header_len()..];
             if payload.len() < 8 {
                 return Err(Error);
             }

--- a/src/wire/igmp.rs
+++ b/src/wire/igmp.rs
@@ -72,7 +72,7 @@ impl<T: AsRef<[u8]>> Packet<T> {
     /// Returns `Err(Error)` if the buffer is too short.
     pub fn check_len(&self) -> Result<()> {
         let len = self.buffer.as_ref().len();
-        if len < field::GROUP_ADDRESS.end as usize {
+        if len < field::GROUP_ADDRESS.end {
             Err(Error)
         } else {
             Ok(())

--- a/src/wire/ipv6hopbyhop.rs
+++ b/src/wire/ipv6hopbyhop.rs
@@ -296,14 +296,14 @@ mod test {
     #[test]
     fn test_header_len_overflow() {
         let mut bytes = vec![];
-        bytes.extend(&REPR_PACKET_PAD4);
+        bytes.extend(REPR_PACKET_PAD4);
         let len = bytes.len() as u8;
         Header::new_unchecked(&mut bytes).set_header_len(len + 1);
 
         assert_eq!(Header::new_checked(&bytes).unwrap_err(), Error);
 
         let mut bytes = vec![];
-        bytes.extend(&REPR_PACKET_PAD12);
+        bytes.extend(REPR_PACKET_PAD12);
         let len = bytes.len() as u8;
         Header::new_unchecked(&mut bytes).set_header_len(len + 1);
 

--- a/src/wire/ipv6routing.rs
+++ b/src/wire/ipv6routing.rs
@@ -169,7 +169,7 @@ impl<T: AsRef<[u8]>> Header<T> {
             return Err(Error);
         }
 
-        if len < field::DATA(self.header_len()).end as usize {
+        if len < field::DATA(self.header_len()).end {
             return Err(Error);
         }
 

--- a/src/wire/sixlowpan.rs
+++ b/src/wire/sixlowpan.rs
@@ -1215,10 +1215,9 @@ pub mod iphc {
             let mut len = 0;
             len += 2; // The minimal header length
 
-            len += if self.next_header == NextHeader::Compressed {
-                0 // The next header is compressed (we don't need to inline what the next header is)
-            } else {
-                1 // The next header field is inlined
+            len += match self.next_header {
+                NextHeader::Compressed => 0, // The next header is compressed (we don't need to inline what the next header is)
+                NextHeader::Uncompressed(_) => 1, // The next header field is inlined
             };
 
             // Hop Limit size
@@ -1604,10 +1603,10 @@ pub mod nhc {
         /// Return the size of the Next Header field.
         fn next_header_size(&self) -> usize {
             // If nh is set, then the Next Header is compressed using LOWPAN_NHC
-            if self.nh_field() == 1 {
-                0
-            } else {
-                1
+            match self.nh_field() {
+                0 => 1,
+                1 => 0,
+                _ => unreachable!(),
             }
         }
     }


### PR DESCRIPTION
The current `'a` lifetime in the `Device` trait is essentially a workaround for lack of GATs.
I'm just experimenting how this would look like, it'll have to wait until GATs are stable to go in.

The main benefit is structs implementing `Device` can now borrow stuff. This wasn't possible
before because the `for<'d> T: Device<'d>` bounds would essentially imply `T: 'static`.