### PR TITLE
Simpler rand

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
         include:
           # Test alloc feature which requires nightly.
           - rust: nightly
-            features: alloc rand-custom-impl medium-ethernet proto-ipv4 proto-ipv6 socket-raw socket-udp socket-tcp socket-icmp
+            features: alloc medium-ethernet proto-ipv4 proto-ipv6 socket-raw socket-udp socket-tcp socket-icmp
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -73,8 +73,8 @@ jobs:
 
         features:
           # These feature sets cannot run tests, so we only check they build.
-          - rand-custom-impl medium-ip medium-ethernet medium-ieee802154 proto-ipv6 proto-ipv6 proto-igmp proto-dhcpv4 socket-raw socket-udp socket-tcp socket-icmp async
-          - rand-custom-impl defmt medium-ip medium-ethernet proto-ipv6 proto-ipv6 proto-igmp proto-dhcpv4 socket-raw socket-udp socket-tcp socket-icmp async
+          - medium-ip medium-ethernet medium-ieee802154 proto-ipv6 proto-ipv6 proto-igmp proto-dhcpv4 socket-raw socket-udp socket-tcp socket-icmp async
+          - defmt medium-ip medium-ethernet proto-ipv6 proto-ipv6 proto-igmp proto-dhcpv4 socket-raw socket-udp socket-tcp socket-icmp async
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ url = "1.0"
 std = ["managed/std", "rand_core/std"]
 alloc = ["managed/alloc"]
 verbose = []
-rand-custom-impl = []
 "medium-ethernet" = ["socket"]
 "medium-ip" = ["socket"]
 "medium-ieee802154" = ["socket", "proto-sixlowpan"]

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -54,8 +54,8 @@ fn main() {
 
     let tcp_handle = iface.add_socket(tcp_socket);
 
-    let socket = iface.get_socket::<TcpSocket>(tcp_handle);
-    socket.connect((address, port), 49500).unwrap();
+    let (socket, cx) = iface.get_socket_and_context::<TcpSocket>(tcp_handle);
+    socket.connect(cx, (address, port), 49500).unwrap();
 
     let mut tcp_active = false;
     loop {

--- a/examples/httpclient.rs
+++ b/examples/httpclient.rs
@@ -76,14 +76,14 @@ fn main() {
             }
         }
 
-        let socket = iface.get_socket::<TcpSocket>(tcp_handle);
+        let (socket, cx) = iface.get_socket_and_context::<TcpSocket>(tcp_handle);
 
         state = match state {
             State::Connect if !socket.is_active() => {
                 debug!("connecting");
                 let local_port = 49152 + rand::random::<u16>() % 16384;
                 socket
-                    .connect((address, url.port().unwrap_or(80)), local_port)
+                    .connect(cx, (address, url.port().unwrap_or(80)), local_port)
                     .unwrap();
                 State::Request
             }

--- a/examples/loopback.rs
+++ b/examples/loopback.rs
@@ -37,14 +37,6 @@ mod mock {
             self.0.get()
         }
     }
-
-    struct Rand;
-    smoltcp::rand_custom_impl!(Rand);
-    impl smoltcp::Rand for Rand {
-        fn rand_bytes(buf: &mut [u8]) {
-            buf.fill(0x42);
-        }
-    }
 }
 
 #[cfg(feature = "std")]
@@ -153,12 +145,13 @@ fn main() {
             done = true;
         }
 
-        let mut socket = iface.get_socket::<TcpSocket>(client_handle);
+        let (mut socket, cx) = iface.get_socket_and_context::<TcpSocket>(client_handle);
         if !socket.is_open() {
             if !did_connect {
                 debug!("connecting");
                 socket
                     .connect(
+                        cx,
                         (IpAddress::v4(127, 0, 0, 1), 1234),
                         (IpAddress::Unspecified, 65000),
                     )

--- a/src/iface/mod.rs
+++ b/src/iface/mod.rs
@@ -20,4 +20,4 @@ pub use self::neighbor::Neighbor;
 pub use self::route::{Route, Routes};
 pub use socket_set::{SocketHandle, SocketStorage};
 
-pub use self::interface::{Interface, InterfaceBuilder};
+pub use self::interface::{Interface, InterfaceBuilder, InterfaceInner as Context};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,10 +134,7 @@ use core::fmt;
 #[macro_use]
 mod macros;
 mod parsers;
-
 mod rand;
-#[cfg(feature = "rand-custom-impl")]
-pub use crate::rand::Rand;
 
 #[cfg(any(
     feature = "medium-ethernet",

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -1,67 +1,26 @@
 #![allow(unsafe_code)]
 #![allow(unused)]
 
-#[cfg(not(any(test, feature = "std", feature = "rand-custom-impl")))]
-compile_error!("None of the Cargo features `std` or `rand-custom-impl` is enabled. smoltcp needs a `rand` implementation to work. If your target supports `std`, enable the `std` feature to use the OS's RNG. Otherwise, you must enable the `rand-custom-impl` Cargo feature, and supply your own custom implementation using the `smoltcp::rand_custom_impl!()` macro");
-
-pub fn rand_u32() -> u32 {
-    let mut val = [0; 4];
-    rand_bytes(&mut val);
-    u32::from_ne_bytes(val)
+#[derive(Debug)]
+pub(crate) struct Rand {
+    state: u64,
 }
 
-/// Fill `buf` with random bytes.
-pub fn rand_bytes(buf: &mut [u8]) {
-    extern "Rust" {
-        fn _smoltcp_rand(buf: &mut [u8]);
+impl Rand {
+    pub(crate) const fn new(seed: u64) -> Self {
+        Self { state: seed }
     }
 
-    unsafe { _smoltcp_rand(buf) }
-}
+    pub(crate) fn rand_u32(&mut self) -> u32 {
+        // sPCG32 from https://www.pcg-random.org/paper.html
+        // see also https://nullprogram.com/blog/2017/09/21/
+        const M: u64 = 0xbb2efcec3c39611d;
+        const A: u64 = 0x7590ef39;
 
-/// Methods required for a custom rand implementation.
-///
-/// This trait is not intended to be used directly, just to supply a custom rand implementation to smoltcp.
-#[cfg(feature = "rand-custom-impl")]
-pub trait Rand {
-    /// Fill `buf` with random bytes.
-    fn rand_bytes(buf: &mut [u8]);
-}
+        let s = self.state * M + A;
+        self.state = s;
 
-/// Set the custom rand implementation.
-///
-/// # Example
-///
-/// ```
-/// struct Rand;
-/// smoltcp::rand_custom_impl!(Rand);
-/// impl smoltcp::Rand for Rand {
-///     fn rand_bytes(buf: &mut [u8]) {
-///         // TODO
-///     }
-/// }
-///
-#[macro_export]
-#[cfg(feature = "rand-custom-impl")]
-macro_rules! rand_custom_impl {
-    ($t: ty) => {
-        #[no_mangle]
-        fn _smoltcp_rand(buf: &mut [u8]) {
-            <$t as $crate::Rand>::rand_bytes(buf)
-        }
-    };
-}
-
-#[cfg(all(feature = "std", not(feature = "rand-custom-impl"), not(test)))]
-#[no_mangle]
-fn _smoltcp_rand(buf: &mut [u8]) {
-    use rand_core::RngCore;
-
-    rand_core::OsRng.fill_bytes(buf)
-}
-
-#[cfg(test)]
-#[no_mangle]
-fn _smoltcp_rand(buf: &mut [u8]) {
-    panic!("Rand should not be used when testing");
+        let shift = 29 - (s >> 61);
+        (s >> shift) as u32
+    }
 }

--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -370,12 +370,12 @@ impl Dhcpv4Socket {
     }
 
     #[cfg(not(test))]
-    fn random_transaction_id() -> u32 {
-        crate::rand::rand_u32()
+    fn random_transaction_id(cx: &mut Context) -> u32 {
+        cx.rand().rand_u32()
     }
 
     #[cfg(test)]
-    fn random_transaction_id() -> u32 {
+    fn random_transaction_id(_cx: &mut Context) -> u32 {
         0x12345678
     }
 
@@ -397,7 +397,7 @@ impl Dhcpv4Socket {
 
         // We don't directly modify self.transaction_id because sending the packet
         // may fail. We only want to update state after succesfully sending.
-        let next_transaction_id = Self::random_transaction_id();
+        let next_transaction_id = Self::random_transaction_id(cx);
 
         let mut dhcp_repr = DhcpRepr {
             message_type: DhcpMessageType::Discover,

--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -1,4 +1,4 @@
-use crate::socket::Context;
+use crate::iface::Context;
 use crate::time::{Duration, Instant};
 use crate::wire::dhcpv4::field as dhcpv4_field;
 use crate::wire::HardwareAddress;
@@ -181,7 +181,7 @@ impl Dhcpv4Socket {
         self.ignore_naks = ignore_naks;
     }
 
-    pub(crate) fn poll_at(&self, _cx: &Context) -> PollAt {
+    pub(crate) fn poll_at(&self, _cx: &mut Context) -> PollAt {
         let t = match &self.state {
             ClientState::Discovering(state) => state.retry_at,
             ClientState::Requesting(state) => state.retry_at,
@@ -192,7 +192,7 @@ impl Dhcpv4Socket {
 
     pub(crate) fn process(
         &mut self,
-        cx: &Context,
+        cx: &mut Context,
         ip_repr: &Ipv4Repr,
         repr: &UdpRepr,
         payload: &[u8],
@@ -216,7 +216,7 @@ impl Dhcpv4Socket {
                 return Ok(());
             }
         };
-        let hardware_addr = if let Some(HardwareAddress::Ethernet(addr)) = cx.hardware_addr {
+        let hardware_addr = if let Some(HardwareAddress::Ethernet(addr)) = cx.hardware_addr() {
             addr
         } else {
             return Err(Error::Malformed);
@@ -254,7 +254,7 @@ impl Dhcpv4Socket {
                 }
 
                 self.state = ClientState::Requesting(RequestState {
-                    retry_at: cx.now,
+                    retry_at: cx.now(),
                     retry: 0,
                     server: ServerInfo {
                         address: src_ip,
@@ -265,7 +265,7 @@ impl Dhcpv4Socket {
             }
             (ClientState::Requesting(state), DhcpMessageType::Ack) => {
                 if let Some((config, renew_at, expires_at)) =
-                    Self::parse_ack(cx.now, &dhcp_repr, self.max_lease_duration)
+                    Self::parse_ack(cx.now(), &dhcp_repr, self.max_lease_duration)
                 {
                     self.config_changed = true;
                     self.state = ClientState::Renewing(RenewState {
@@ -283,7 +283,7 @@ impl Dhcpv4Socket {
             }
             (ClientState::Renewing(state), DhcpMessageType::Ack) => {
                 if let Some((config, renew_at, expires_at)) =
-                    Self::parse_ack(cx.now, &dhcp_repr, self.max_lease_duration)
+                    Self::parse_ack(cx.now(), &dhcp_repr, self.max_lease_duration)
                 {
                     state.renew_at = renew_at;
                     state.expires_at = expires_at;
@@ -379,13 +379,13 @@ impl Dhcpv4Socket {
         0x12345678
     }
 
-    pub(crate) fn dispatch<F>(&mut self, cx: &Context, emit: F) -> Result<()>
+    pub(crate) fn dispatch<F>(&mut self, cx: &mut Context, emit: F) -> Result<()>
     where
-        F: FnOnce((Ipv4Repr, UdpRepr, DhcpRepr)) -> Result<()>,
+        F: FnOnce(&mut Context, (Ipv4Repr, UdpRepr, DhcpRepr)) -> Result<()>,
     {
         // note: Dhcpv4Socket is only usable in ethernet mediums, so the
         // unwrap can never fail.
-        let ethernet_addr = if let Some(HardwareAddress::Ethernet(addr)) = cx.hardware_addr {
+        let ethernet_addr = if let Some(HardwareAddress::Ethernet(addr)) = cx.hardware_addr() {
             addr
         } else {
             return Err(Error::Malformed);
@@ -414,7 +414,7 @@ impl Dhcpv4Socket {
             client_identifier: Some(ethernet_addr),
             server_identifier: None,
             parameter_request_list: Some(PARAMETER_REQUEST_LIST),
-            max_size: Some((cx.caps.ip_mtu() - MAX_IPV4_HEADER_LEN - UDP_HEADER_LEN) as u16),
+            max_size: Some((cx.ip_mtu() - MAX_IPV4_HEADER_LEN - UDP_HEADER_LEN) as u16),
             lease_duration: None,
             dns_servers: None,
         };
@@ -434,7 +434,7 @@ impl Dhcpv4Socket {
 
         match &mut self.state {
             ClientState::Discovering(state) => {
-                if cx.now < state.retry_at {
+                if cx.now() < state.retry_at {
                     return Err(Error::Exhausted);
                 }
 
@@ -445,15 +445,15 @@ impl Dhcpv4Socket {
                     dhcp_repr
                 );
                 ipv4_repr.payload_len = udp_repr.header_len() + dhcp_repr.buffer_len();
-                emit((ipv4_repr, udp_repr, dhcp_repr))?;
+                emit(cx, (ipv4_repr, udp_repr, dhcp_repr))?;
 
                 // Update state AFTER the packet has been successfully sent.
-                state.retry_at = cx.now + DISCOVER_TIMEOUT;
+                state.retry_at = cx.now() + DISCOVER_TIMEOUT;
                 self.transaction_id = next_transaction_id;
                 Ok(())
             }
             ClientState::Requesting(state) => {
-                if cx.now < state.retry_at {
+                if cx.now() < state.retry_at {
                     return Err(Error::Exhausted);
                 }
 
@@ -474,24 +474,24 @@ impl Dhcpv4Socket {
                     dhcp_repr
                 );
                 ipv4_repr.payload_len = udp_repr.header_len() + dhcp_repr.buffer_len();
-                emit((ipv4_repr, udp_repr, dhcp_repr))?;
+                emit(cx, (ipv4_repr, udp_repr, dhcp_repr))?;
 
                 // Exponential backoff: Double every 2 retries.
-                state.retry_at = cx.now + (REQUEST_TIMEOUT << (state.retry as u32 / 2));
+                state.retry_at = cx.now() + (REQUEST_TIMEOUT << (state.retry as u32 / 2));
                 state.retry += 1;
 
                 self.transaction_id = next_transaction_id;
                 Ok(())
             }
             ClientState::Renewing(state) => {
-                if state.expires_at <= cx.now {
+                if state.expires_at <= cx.now() {
                     net_debug!("DHCP lease expired");
                     self.reset();
                     // return Ok so we get polled again
                     return Ok(());
                 }
 
-                if cx.now < state.renew_at {
+                if cx.now() < state.renew_at {
                     return Err(Error::Exhausted);
                 }
 
@@ -502,14 +502,15 @@ impl Dhcpv4Socket {
 
                 net_debug!("DHCP send renew to {}: {:?}", ipv4_repr.dst_addr, dhcp_repr);
                 ipv4_repr.payload_len = udp_repr.header_len() + dhcp_repr.buffer_len();
-                emit((ipv4_repr, udp_repr, dhcp_repr))?;
+                emit(cx, (ipv4_repr, udp_repr, dhcp_repr))?;
 
                 // In both RENEWING and REBINDING states, if the client receives no
                 // response to its DHCPREQUEST message, the client SHOULD wait one-half
                 // of the remaining time until T2 (in RENEWING state) and one-half of
                 // the remaining lease time (in REBINDING state), down to a minimum of
                 // 60 seconds, before retransmitting the DHCPREQUEST message.
-                state.renew_at = cx.now + MIN_RENEW_TIMEOUT.max((state.expires_at - cx.now) / 2);
+                state.renew_at =
+                    cx.now() + MIN_RENEW_TIMEOUT.max((state.expires_at - cx.now()) / 2);
 
                 self.transaction_id = next_transaction_id;
                 Ok(())
@@ -551,17 +552,39 @@ impl Dhcpv4Socket {
 #[cfg(test)]
 mod test {
 
+    use std::ops::{Deref, DerefMut};
+
     use super::*;
     use crate::wire::EthernetAddress;
 
     // =========================================================================================//
     // Helper functions
 
+    struct TestSocket {
+        socket: Dhcpv4Socket,
+        cx: Context<'static>,
+    }
+
+    impl Deref for TestSocket {
+        type Target = Dhcpv4Socket;
+        fn deref(&self) -> &Self::Target {
+            &self.socket
+        }
+    }
+
+    impl DerefMut for TestSocket {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.socket
+        }
+    }
+
     fn send(
-        socket: &mut Dhcpv4Socket,
+        s: &mut TestSocket,
         timestamp: Instant,
         (ip_repr, udp_repr, dhcp_repr): (Ipv4Repr, UdpRepr, DhcpRepr),
     ) -> Result<()> {
+        s.cx.set_now(timestamp);
+
         net_trace!("send: {:?}", ip_repr);
         net_trace!("      {:?}", udp_repr);
         net_trace!("      {:?}", dhcp_repr);
@@ -571,44 +594,39 @@ mod test {
             .emit(&mut DhcpPacket::new_unchecked(&mut payload))
             .unwrap();
 
-        let mut cx = Context::DUMMY.clone();
-        cx.now = timestamp;
-        socket.process(&cx, &ip_repr, &udp_repr, &payload)
+        s.socket.process(&mut s.cx, &ip_repr, &udp_repr, &payload)
     }
 
-    fn recv(
-        socket: &mut Dhcpv4Socket,
-        timestamp: Instant,
-        reprs: &[(Ipv4Repr, UdpRepr, DhcpRepr)],
-    ) {
-        let mut cx = Context::DUMMY.clone();
-        cx.now = timestamp;
+    fn recv(s: &mut TestSocket, timestamp: Instant, reprs: &[(Ipv4Repr, UdpRepr, DhcpRepr)]) {
+        s.cx.set_now(timestamp);
 
         let mut i = 0;
 
-        while socket.poll_at(&cx) <= PollAt::Time(timestamp) {
-            let _ = socket.dispatch(&cx, |(mut ip_repr, udp_repr, dhcp_repr)| {
-                assert_eq!(ip_repr.protocol, IpProtocol::Udp);
-                assert_eq!(
-                    ip_repr.payload_len,
-                    udp_repr.header_len() + dhcp_repr.buffer_len()
-                );
+        while s.socket.poll_at(&mut s.cx) <= PollAt::Time(timestamp) {
+            let _ = s
+                .socket
+                .dispatch(&mut s.cx, |_, (mut ip_repr, udp_repr, dhcp_repr)| {
+                    assert_eq!(ip_repr.protocol, IpProtocol::Udp);
+                    assert_eq!(
+                        ip_repr.payload_len,
+                        udp_repr.header_len() + dhcp_repr.buffer_len()
+                    );
 
-                // We validated the payload len, change it to 0 to make equality testing easier
-                ip_repr.payload_len = 0;
+                    // We validated the payload len, change it to 0 to make equality testing easier
+                    ip_repr.payload_len = 0;
 
-                net_trace!("recv: {:?}", ip_repr);
-                net_trace!("      {:?}", udp_repr);
-                net_trace!("      {:?}", dhcp_repr);
+                    net_trace!("recv: {:?}", ip_repr);
+                    net_trace!("      {:?}", udp_repr);
+                    net_trace!("      {:?}", dhcp_repr);
 
-                let got_repr = (ip_repr, udp_repr, dhcp_repr);
-                match reprs.get(i) {
-                    Some(want_repr) => assert_eq!(want_repr, &got_repr),
-                    None => panic!("Too many reprs emitted"),
-                }
-                i += 1;
-                Ok(())
-            });
+                    let got_repr = (ip_repr, udp_repr, dhcp_repr);
+                    match reprs.get(i) {
+                        Some(want_repr) => assert_eq!(want_repr, &got_repr),
+                        None => panic!("Too many reprs emitted"),
+                    }
+                    i += 1;
+                    Ok(())
+                });
         }
 
         assert_eq!(i, reprs.len());
@@ -780,13 +798,16 @@ mod test {
     // =========================================================================================//
     // Tests
 
-    fn socket() -> Dhcpv4Socket {
+    fn socket() -> TestSocket {
         let mut s = Dhcpv4Socket::new();
         assert_eq!(s.poll(), Some(Event::Deconfigured));
-        s
+        TestSocket {
+            socket: s,
+            cx: Context::mock(),
+        }
     }
 
-    fn socket_bound() -> Dhcpv4Socket {
+    fn socket_bound() -> TestSocket {
         let mut s = socket();
         s.state = ClientState::Renewing(RenewState {
             config: Config {


### PR DESCRIPTION
Requires #571 

Revisits #547, because it turns out the `rand_custom_impl!` macro stuff was less nice than I thought. It's now a simple PRNG owned by Interface. The builder allows setting the random seed.