### PR TITLE
Remove IpRepr::Unspecified

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ log = { version = "0.4.4", default-features = false, optional = true }
 libc = { version = "0.2.18", optional = true }
 bitflags = { version = "1.0", default-features = false }
 defmt = { version = "0.3", optional = true }
+cfg-if = "1.0.0"
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -85,7 +85,7 @@ mod wire {
         let repr = Ipv4Repr {
             src_addr: Ipv4Address([192, 168, 1, 1]),
             dst_addr: Ipv4Address([192, 168, 1, 2]),
-            protocol: IpProtocol::Tcp,
+            next_header: IpProtocol::Tcp,
             payload_len: 100,
             hop_limit: 64,
         };

--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -427,7 +427,7 @@ impl Dhcpv4Socket {
         let mut ipv4_repr = Ipv4Repr {
             src_addr: Ipv4Address::UNSPECIFIED,
             dst_addr: Ipv4Address::BROADCAST,
-            protocol: IpProtocol::Udp,
+            next_header: IpProtocol::Udp,
             payload_len: 0, // filled right before emit
             hop_limit: 64,
         };
@@ -606,7 +606,7 @@ mod test {
             let _ = s
                 .socket
                 .dispatch(&mut s.cx, |_, (mut ip_repr, udp_repr, dhcp_repr)| {
-                    assert_eq!(ip_repr.protocol, IpProtocol::Udp);
+                    assert_eq!(ip_repr.next_header, IpProtocol::Udp);
                     assert_eq!(
                         ip_repr.payload_len,
                         udp_repr.header_len() + dhcp_repr.buffer_len()
@@ -671,7 +671,7 @@ mod test {
     const IP_BROADCAST: Ipv4Repr = Ipv4Repr {
         src_addr: Ipv4Address::UNSPECIFIED,
         dst_addr: Ipv4Address::BROADCAST,
-        protocol: IpProtocol::Udp,
+        next_header: IpProtocol::Udp,
         payload_len: 0,
         hop_limit: 64,
     };
@@ -679,7 +679,7 @@ mod test {
     const IP_SERVER_BROADCAST: Ipv4Repr = Ipv4Repr {
         src_addr: SERVER_IP,
         dst_addr: Ipv4Address::BROADCAST,
-        protocol: IpProtocol::Udp,
+        next_header: IpProtocol::Udp,
         payload_len: 0,
         hop_limit: 64,
     };
@@ -687,7 +687,7 @@ mod test {
     const IP_RECV: Ipv4Repr = Ipv4Repr {
         src_addr: SERVER_IP,
         dst_addr: MY_IP,
-        protocol: IpProtocol::Udp,
+        next_header: IpProtocol::Udp,
         payload_len: 0,
         hop_limit: 64,
     };
@@ -695,7 +695,7 @@ mod test {
     const IP_SEND: Ipv4Repr = Ipv4Repr {
         src_addr: MY_IP,
         dst_addr: SERVER_IP,
-        protocol: IpProtocol::Udp,
+        next_header: IpProtocol::Udp,
         payload_len: 0,
         hop_limit: 64,
     };

--- a/src/socket/icmp.rs
+++ b/src/socket/icmp.rs
@@ -453,7 +453,7 @@ impl<'a> IcmpSocket<'a> {
                     let ip_repr = IpRepr::Ipv4(Ipv4Repr {
                         src_addr: Ipv4Address::default(),
                         dst_addr: ipv4_addr,
-                        protocol: IpProtocol::Icmp,
+                        next_header: IpProtocol::Icmp,
                         payload_len: repr.buffer_len(),
                         hop_limit: hop_limit,
                     });
@@ -549,7 +549,7 @@ mod test_ipv4 {
     static LOCAL_IPV4_REPR: IpRepr = IpRepr::Ipv4(Ipv4Repr {
         src_addr: Ipv4Address::UNSPECIFIED,
         dst_addr: REMOTE_IPV4,
-        protocol: IpProtocol::Icmp,
+        next_header: IpProtocol::Icmp,
         payload_len: 24,
         hop_limit: 0x40,
     });
@@ -557,7 +557,7 @@ mod test_ipv4 {
     static REMOTE_IPV4_REPR: IpRepr = IpRepr::Ipv4(Ipv4Repr {
         src_addr: REMOTE_IPV4,
         dst_addr: LOCAL_IPV4,
-        protocol: IpProtocol::Icmp,
+        next_header: IpProtocol::Icmp,
         payload_len: 24,
         hop_limit: 0x40,
     });
@@ -650,7 +650,7 @@ mod test_ipv4 {
                     IpRepr::Ipv4(Ipv4Repr {
                         src_addr: Ipv4Address::UNSPECIFIED,
                         dst_addr: REMOTE_IPV4,
-                        protocol: IpProtocol::Icmp,
+                        next_header: IpProtocol::Icmp,
                         payload_len: ECHOV4_REPR.buffer_len(),
                         hop_limit: 0x2a,
                     })
@@ -741,7 +741,7 @@ mod test_ipv4 {
             header: Ipv4Repr {
                 src_addr: LOCAL_IPV4,
                 dst_addr: REMOTE_IPV4,
-                protocol: IpProtocol::Icmp,
+                next_header: IpProtocol::Icmp,
                 payload_len: 12,
                 hop_limit: 0x40,
             },
@@ -750,7 +750,7 @@ mod test_ipv4 {
         let ip_repr = IpRepr::Unspecified {
             src_addr: REMOTE_IPV4.into(),
             dst_addr: LOCAL_IPV4.into(),
-            protocol: IpProtocol::Icmp,
+            next_header: IpProtocol::Icmp,
             payload_len: icmp_repr.buffer_len(),
             hop_limit: 0x40,
         };
@@ -1018,7 +1018,7 @@ mod test_ipv6 {
         let ip_repr = IpRepr::Unspecified {
             src_addr: REMOTE_IPV6.into(),
             dst_addr: LOCAL_IPV6.into(),
-            protocol: IpProtocol::Icmpv6,
+            next_header: IpProtocol::Icmpv6,
             payload_len: icmp_repr.buffer_len(),
             hop_limit: 0x40,
         };

--- a/src/socket/icmp.rs
+++ b/src/socket/icmp.rs
@@ -747,13 +747,13 @@ mod test_ipv4 {
             },
             data: data,
         };
-        let ip_repr = IpRepr::Unspecified {
-            src_addr: REMOTE_IPV4.into(),
-            dst_addr: LOCAL_IPV4.into(),
+        let ip_repr = IpRepr::Ipv4(Ipv4Repr {
+            src_addr: REMOTE_IPV4,
+            dst_addr: LOCAL_IPV4,
             next_header: IpProtocol::Icmp,
             payload_len: icmp_repr.buffer_len(),
             hop_limit: 0x40,
-        };
+        });
 
         assert!(!socket.can_recv());
 
@@ -1015,13 +1015,13 @@ mod test_ipv6 {
             },
             data: data,
         };
-        let ip_repr = IpRepr::Unspecified {
-            src_addr: REMOTE_IPV6.into(),
-            dst_addr: LOCAL_IPV6.into(),
+        let ip_repr = IpRepr::Ipv6(Ipv6Repr {
+            src_addr: REMOTE_IPV6,
+            dst_addr: LOCAL_IPV6,
             next_header: IpProtocol::Icmpv6,
             payload_len: icmp_repr.buffer_len(),
             hop_limit: 0x40,
-        };
+        });
 
         assert!(!socket.can_recv());
 

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1137,13 +1137,13 @@ impl<'a> TcpSocket<'a> {
             sack_ranges: [None, None, None],
             payload: &[],
         };
-        let ip_reply_repr = IpRepr::Unspecified {
-            src_addr: ip_repr.dst_addr(),
-            dst_addr: ip_repr.src_addr(),
-            next_header: IpProtocol::Tcp,
-            payload_len: reply_repr.buffer_len(),
-            hop_limit: 64,
-        };
+        let ip_reply_repr = IpRepr::new(
+            ip_repr.dst_addr(),
+            ip_repr.src_addr(),
+            IpProtocol::Tcp,
+            reply_repr.buffer_len(),
+            64,
+        );
         (ip_reply_repr, reply_repr)
     }
 
@@ -2136,14 +2136,13 @@ impl<'a> TcpSocket<'a> {
 
         // Construct the lowered IP representation.
         // We might need this to calculate the MSS, so do it early.
-        let mut ip_repr = IpRepr::Unspecified {
-            src_addr: self.local_endpoint.addr,
-            dst_addr: self.remote_endpoint.addr,
-            next_header: IpProtocol::Tcp,
-            hop_limit: self.hop_limit.unwrap_or(64),
-            payload_len: 0,
-        }
-        .lower(&[])?;
+        let mut ip_repr = IpRepr::new(
+            self.local_endpoint.addr,
+            self.remote_endpoint.addr,
+            IpProtocol::Tcp,
+            0,
+            self.hop_limit.unwrap_or(64),
+        );
 
         // Construct the basic TCP representation, an empty ACK packet.
         // We'll adjust this to be more specific as needed.
@@ -2417,8 +2416,7 @@ impl<'a> fmt::Write for TcpSocket<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::wire::ip::test::{MOCK_IP_ADDR_1, MOCK_IP_ADDR_2, MOCK_IP_ADDR_3, MOCK_UNSPECIFIED};
-    use crate::wire::{IpAddress, IpCidr, IpRepr};
+    use crate::wire::{IpAddress, IpRepr};
     use core::i32;
     use std::ops::{Deref, DerefMut};
     use std::vec::Vec;
@@ -2430,23 +2428,53 @@ mod test {
     const LOCAL_PORT: u16 = 80;
     const REMOTE_PORT: u16 = 49500;
     const LOCAL_END: IpEndpoint = IpEndpoint {
-        addr: MOCK_IP_ADDR_1,
+        addr: LOCAL_ADDR.into_address(),
         port: LOCAL_PORT,
     };
     const REMOTE_END: IpEndpoint = IpEndpoint {
-        addr: MOCK_IP_ADDR_2,
+        addr: REMOTE_ADDR.into_address(),
         port: REMOTE_PORT,
     };
     const LOCAL_SEQ: TcpSeqNumber = TcpSeqNumber(10000);
     const REMOTE_SEQ: TcpSeqNumber = TcpSeqNumber(-10001);
 
-    const SEND_IP_TEMPL: IpRepr = IpRepr::Unspecified {
-        src_addr: MOCK_IP_ADDR_1,
-        dst_addr: MOCK_IP_ADDR_2,
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "proto-ipv4")] {
+            use crate::wire::Ipv4Address as IpvXAddress;
+            use crate::wire::Ipv4Repr as IpvXRepr;
+            use IpRepr::Ipv4 as IpReprIpvX;
+
+            const LOCAL_ADDR: IpvXAddress = IpvXAddress([192, 168, 1, 1]);
+            const REMOTE_ADDR: IpvXAddress = IpvXAddress([192, 168, 1, 2]);
+            const OTHER_ADDR: IpvXAddress = IpvXAddress([192, 168, 1, 3]);
+
+            const BASE_MSS: u16 = 1460;
+        } else {
+            use crate::wire::Ipv6Address as IpvXAddress;
+            use crate::wire::Ipv6Repr as IpvXRepr;
+            use IpRepr::Ipv6 as IpReprIpvX;
+
+            const LOCAL_ADDR: IpvXAddress = IpvXAddress([
+                0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+            ]);
+            const REMOTE_ADDR: IpvXAddress = IpvXAddress([
+                0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
+            ]);
+            const OTHER_ADDR: IpvXAddress = IpvXAddress([
+                0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3,
+            ]);
+
+            const BASE_MSS: u16 = 1440;
+        }
+    }
+
+    const SEND_IP_TEMPL: IpRepr = IpReprIpvX(IpvXRepr {
+        src_addr: LOCAL_ADDR,
+        dst_addr: REMOTE_ADDR,
         next_header: IpProtocol::Tcp,
         payload_len: 20,
         hop_limit: 64,
-    };
+    });
     const SEND_TEMPL: TcpRepr<'static> = TcpRepr {
         src_port: REMOTE_PORT,
         dst_port: LOCAL_PORT,
@@ -2460,13 +2488,13 @@ mod test {
         sack_ranges: [None, None, None],
         payload: &[],
     };
-    const _RECV_IP_TEMPL: IpRepr = IpRepr::Unspecified {
-        src_addr: MOCK_IP_ADDR_1,
-        dst_addr: MOCK_IP_ADDR_2,
+    const _RECV_IP_TEMPL: IpRepr = IpReprIpvX(IpvXRepr {
+        src_addr: LOCAL_ADDR,
+        dst_addr: REMOTE_ADDR,
         next_header: IpProtocol::Tcp,
         payload_len: 20,
         hop_limit: 64,
-    };
+    });
     const RECV_TEMPL: TcpRepr<'static> = TcpRepr {
         src_port: LOCAL_PORT,
         dst_port: REMOTE_PORT,
@@ -2480,11 +2508,6 @@ mod test {
         sack_ranges: [None, None, None],
         payload: &[],
     };
-
-    #[cfg(feature = "proto-ipv6")]
-    const BASE_MSS: u16 = 1440;
-    #[cfg(all(feature = "proto-ipv4", not(feature = "proto-ipv6")))]
-    const BASE_MSS: u16 = 1460;
 
     // =========================================================================================//
     // Helper functions
@@ -2515,13 +2538,13 @@ mod test {
     ) -> Result<Option<TcpRepr<'static>>> {
         socket.cx.set_now(timestamp);
 
-        let ip_repr = IpRepr::Unspecified {
-            src_addr: MOCK_IP_ADDR_2,
-            dst_addr: MOCK_IP_ADDR_1,
+        let ip_repr = IpReprIpvX(IpvXRepr {
+            src_addr: REMOTE_ADDR,
+            dst_addr: LOCAL_ADDR,
             next_header: IpProtocol::Tcp,
             payload_len: repr.buffer_len(),
             hop_limit: 64,
-        };
+        });
         net_trace!("send: {}", repr);
 
         assert!(socket.socket.accepts(&mut socket.cx, &ip_repr, repr));
@@ -2545,11 +2568,9 @@ mod test {
         let result = socket
             .socket
             .dispatch(&mut socket.cx, |_, (ip_repr, tcp_repr)| {
-                let ip_repr = ip_repr.lower(&[IpCidr::new(LOCAL_END.addr, 24)]).unwrap();
-
                 assert_eq!(ip_repr.next_header(), IpProtocol::Tcp);
-                assert_eq!(ip_repr.src_addr(), MOCK_IP_ADDR_1);
-                assert_eq!(ip_repr.dst_addr(), MOCK_IP_ADDR_2);
+                assert_eq!(ip_repr.src_addr(), LOCAL_ADDR.into());
+                assert_eq!(ip_repr.dst_addr(), REMOTE_ADDR.into());
                 assert_eq!(ip_repr.payload_len(), tcp_repr.buffer_len());
 
                 net_trace!("recv: {}", tcp_repr);
@@ -3223,12 +3244,12 @@ mod test {
         );
         assert_eq!(
             s.socket
-                .connect(&mut s.cx, REMOTE_END, (MOCK_UNSPECIFIED, 0)),
+                .connect(&mut s.cx, REMOTE_END, (IpvXAddress::UNSPECIFIED, 0)),
             Err(Error::Unaddressable)
         );
         assert_eq!(
             s.socket
-                .connect(&mut s.cx, (MOCK_UNSPECIFIED, 0), LOCAL_END),
+                .connect(&mut s.cx, (IpvXAddress::UNSPECIFIED, 0), LOCAL_END),
             Err(Error::Unaddressable)
         );
         assert_eq!(
@@ -3282,7 +3303,7 @@ mod test {
         let mut s = socket();
         assert_eq!(
             s.socket
-                .connect(&mut s.cx, REMOTE_END, (MOCK_UNSPECIFIED, 80)),
+                .connect(&mut s.cx, REMOTE_END, (IpvXAddress::UNSPECIFIED, 80)),
             Ok(())
         );
         s.abort();
@@ -3298,8 +3319,7 @@ mod test {
     fn test_connect_specified_local() {
         let mut s = socket();
         assert_eq!(
-            s.socket
-                .connect(&mut s.cx, REMOTE_END, (MOCK_IP_ADDR_2, 80)),
+            s.socket.connect(&mut s.cx, REMOTE_END, (REMOTE_ADDR, 80)),
             Ok(())
         );
     }
@@ -6945,31 +6965,31 @@ mod test {
             ..SEND_TEMPL
         };
 
-        let ip_repr = IpRepr::Unspecified {
-            src_addr: MOCK_IP_ADDR_2,
-            dst_addr: MOCK_IP_ADDR_1,
+        let ip_repr = IpReprIpvX(IpvXRepr {
+            src_addr: REMOTE_ADDR,
+            dst_addr: LOCAL_ADDR,
             next_header: IpProtocol::Tcp,
             payload_len: tcp_repr.buffer_len(),
             hop_limit: 64,
-        };
+        });
         assert!(s.socket.accepts(&mut s.cx, &ip_repr, &tcp_repr));
 
-        let ip_repr_wrong_src = IpRepr::Unspecified {
-            src_addr: MOCK_IP_ADDR_3,
-            dst_addr: MOCK_IP_ADDR_1,
+        let ip_repr_wrong_src = IpReprIpvX(IpvXRepr {
+            src_addr: OTHER_ADDR,
+            dst_addr: LOCAL_ADDR,
             next_header: IpProtocol::Tcp,
             payload_len: tcp_repr.buffer_len(),
             hop_limit: 64,
-        };
+        });
         assert!(!s.socket.accepts(&mut s.cx, &ip_repr_wrong_src, &tcp_repr));
 
-        let ip_repr_wrong_dst = IpRepr::Unspecified {
-            src_addr: MOCK_IP_ADDR_2,
-            dst_addr: MOCK_IP_ADDR_3,
+        let ip_repr_wrong_dst = IpReprIpvX(IpvXRepr {
+            src_addr: REMOTE_ADDR,
+            dst_addr: OTHER_ADDR,
             next_header: IpProtocol::Tcp,
             payload_len: tcp_repr.buffer_len(),
             hop_limit: 64,
-        };
+        });
         assert!(!s.socket.accepts(&mut s.cx, &ip_repr_wrong_dst, &tcp_repr));
     }
 

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1140,7 +1140,7 @@ impl<'a> TcpSocket<'a> {
         let ip_reply_repr = IpRepr::Unspecified {
             src_addr: ip_repr.dst_addr(),
             dst_addr: ip_repr.src_addr(),
-            protocol: IpProtocol::Tcp,
+            next_header: IpProtocol::Tcp,
             payload_len: reply_repr.buffer_len(),
             hop_limit: 64,
         };
@@ -2139,7 +2139,7 @@ impl<'a> TcpSocket<'a> {
         let mut ip_repr = IpRepr::Unspecified {
             src_addr: self.local_endpoint.addr,
             dst_addr: self.remote_endpoint.addr,
-            protocol: IpProtocol::Tcp,
+            next_header: IpProtocol::Tcp,
             hop_limit: self.hop_limit.unwrap_or(64),
             payload_len: 0,
         }
@@ -2443,7 +2443,7 @@ mod test {
     const SEND_IP_TEMPL: IpRepr = IpRepr::Unspecified {
         src_addr: MOCK_IP_ADDR_1,
         dst_addr: MOCK_IP_ADDR_2,
-        protocol: IpProtocol::Tcp,
+        next_header: IpProtocol::Tcp,
         payload_len: 20,
         hop_limit: 64,
     };
@@ -2463,7 +2463,7 @@ mod test {
     const _RECV_IP_TEMPL: IpRepr = IpRepr::Unspecified {
         src_addr: MOCK_IP_ADDR_1,
         dst_addr: MOCK_IP_ADDR_2,
-        protocol: IpProtocol::Tcp,
+        next_header: IpProtocol::Tcp,
         payload_len: 20,
         hop_limit: 64,
     };
@@ -2518,7 +2518,7 @@ mod test {
         let ip_repr = IpRepr::Unspecified {
             src_addr: MOCK_IP_ADDR_2,
             dst_addr: MOCK_IP_ADDR_1,
-            protocol: IpProtocol::Tcp,
+            next_header: IpProtocol::Tcp,
             payload_len: repr.buffer_len(),
             hop_limit: 64,
         };
@@ -2547,7 +2547,7 @@ mod test {
             .dispatch(&mut socket.cx, |_, (ip_repr, tcp_repr)| {
                 let ip_repr = ip_repr.lower(&[IpCidr::new(LOCAL_END.addr, 24)]).unwrap();
 
-                assert_eq!(ip_repr.protocol(), IpProtocol::Tcp);
+                assert_eq!(ip_repr.next_header(), IpProtocol::Tcp);
                 assert_eq!(ip_repr.src_addr(), MOCK_IP_ADDR_1);
                 assert_eq!(ip_repr.dst_addr(), MOCK_IP_ADDR_2);
                 assert_eq!(ip_repr.payload_len(), tcp_repr.buffer_len());
@@ -2641,7 +2641,7 @@ mod test {
     fn socket_syn_sent_with_buffer_sizes(tx_len: usize, rx_len: usize) -> TestSocket {
         let mut s = socket_with_buffer_sizes(tx_len, rx_len);
         s.state = State::SynSent;
-        s.local_endpoint = IpEndpoint::new(MOCK_UNSPECIFIED, LOCAL_PORT);
+        s.local_endpoint = LOCAL_END;
         s.remote_endpoint = REMOTE_END;
         s.local_seq_no = LOCAL_SEQ;
         s.remote_last_seq = LOCAL_SEQ;
@@ -6948,7 +6948,7 @@ mod test {
         let ip_repr = IpRepr::Unspecified {
             src_addr: MOCK_IP_ADDR_2,
             dst_addr: MOCK_IP_ADDR_1,
-            protocol: IpProtocol::Tcp,
+            next_header: IpProtocol::Tcp,
             payload_len: tcp_repr.buffer_len(),
             hop_limit: 64,
         };
@@ -6957,7 +6957,7 @@ mod test {
         let ip_repr_wrong_src = IpRepr::Unspecified {
             src_addr: MOCK_IP_ADDR_3,
             dst_addr: MOCK_IP_ADDR_1,
-            protocol: IpProtocol::Tcp,
+            next_header: IpProtocol::Tcp,
             payload_len: tcp_repr.buffer_len(),
             hop_limit: 64,
         };
@@ -6966,7 +6966,7 @@ mod test {
         let ip_repr_wrong_dst = IpRepr::Unspecified {
             src_addr: MOCK_IP_ADDR_2,
             dst_addr: MOCK_IP_ADDR_3,
-            protocol: IpProtocol::Tcp,
+            next_header: IpProtocol::Tcp,
             payload_len: tcp_repr.buffer_len(),
             hop_limit: 64,
         };

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -362,7 +362,7 @@ impl<'a> UdpSocket<'a> {
                 let ip_repr = IpRepr::Unspecified {
                     src_addr: endpoint.addr,
                     dst_addr: remote_endpoint.addr,
-                    protocol: IpProtocol::Udp,
+                    next_header: IpProtocol::Udp,
                     payload_len: repr.header_len() + payload_buf.len(),
                     hop_limit: hop_limit,
                 };
@@ -423,7 +423,7 @@ mod test {
     pub const LOCAL_IP_REPR: IpRepr = IpRepr::Unspecified {
         src_addr: MOCK_IP_ADDR_1,
         dst_addr: MOCK_IP_ADDR_2,
-        protocol: IpProtocol::Udp,
+        next_header: IpProtocol::Udp,
         payload_len: 8 + 6,
         hop_limit: 64,
     };
@@ -446,7 +446,7 @@ mod test {
             (IpAddress::Ipv4(src), IpAddress::Ipv4(dst)) => IpRepr::Ipv4(Ipv4Repr {
                 src_addr: src,
                 dst_addr: dst,
-                protocol: IpProtocol::Udp,
+                next_header: IpProtocol::Udp,
                 payload_len: 8 + 6,
                 hop_limit: 64,
             }),
@@ -655,7 +655,7 @@ mod test {
                     IpRepr::Unspecified {
                         src_addr: MOCK_IP_ADDR_1,
                         dst_addr: MOCK_IP_ADDR_2,
-                        protocol: IpProtocol::Udp,
+                        next_header: IpProtocol::Udp,
                         payload_len: 8 + 6,
                         hop_limit: 0x2a,
                     }
@@ -687,7 +687,7 @@ mod test {
                 (IpAddress::Ipv4(src), IpAddress::Ipv4(dst)) => IpRepr::Ipv4(Ipv4Repr {
                     src_addr: src,
                     dst_addr: dst,
-                    protocol: IpProtocol::Udp,
+                    next_header: IpProtocol::Udp,
                     payload_len: 8 + 6,
                     hop_limit: 64,
                 }),

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -359,13 +359,13 @@ impl<'a> UdpSocket<'a> {
                     src_port: endpoint.port,
                     dst_port: remote_endpoint.port,
                 };
-                let ip_repr = IpRepr::Unspecified {
-                    src_addr: endpoint.addr,
-                    dst_addr: remote_endpoint.addr,
-                    next_header: IpProtocol::Udp,
-                    payload_len: repr.header_len() + payload_buf.len(),
-                    hop_limit: hop_limit,
-                };
+                let ip_repr = IpRepr::new(
+                    endpoint.addr,
+                    remote_endpoint.addr,
+                    IpProtocol::Udp,
+                    repr.header_len() + payload_buf.len(),
+                    hop_limit,
+                );
                 emit(cx, (ip_repr, repr, payload_buf))
             })?;
 
@@ -387,11 +387,6 @@ impl<'a> UdpSocket<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::wire::ip::test::{MOCK_IP_ADDR_1, MOCK_IP_ADDR_2, MOCK_IP_ADDR_3};
-    #[cfg(feature = "proto-ipv4")]
-    use crate::wire::Ipv4Repr;
-    #[cfg(feature = "proto-ipv6")]
-    use crate::wire::Ipv6Repr;
     use crate::wire::{IpAddress, IpRepr, UdpRepr};
 
     fn buffer(packets: usize) -> UdpSocketBuffer<'static> {
@@ -411,22 +406,64 @@ mod test {
     const LOCAL_PORT: u16 = 53;
     const REMOTE_PORT: u16 = 49500;
 
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "proto-ipv4")] {
+            use crate::wire::Ipv4Address as IpvXAddress;
+            use crate::wire::Ipv4Repr as IpvXRepr;
+            use IpRepr::Ipv4 as IpReprIpvX;
+
+            const LOCAL_ADDR: IpvXAddress = IpvXAddress([192, 168, 1, 1]);
+            const REMOTE_ADDR: IpvXAddress = IpvXAddress([192, 168, 1, 2]);
+            const OTHER_ADDR: IpvXAddress = IpvXAddress([192, 168, 1, 3]);
+        } else {
+            use crate::wire::Ipv6Address as IpvXAddress;
+            use crate::wire::Ipv6Repr as IpvXRepr;
+            use IpRepr::Ipv6 as IpReprIpvX;
+
+            const LOCAL_ADDR: IpvXAddress = IpvXAddress([
+                0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+            ]);
+            const REMOTE_ADDR: IpvXAddress = IpvXAddress([
+                0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
+            ]);
+            const OTHER_ADDR: IpvXAddress = IpvXAddress([
+                0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3,
+            ]);
+        }
+    }
+
     pub const LOCAL_END: IpEndpoint = IpEndpoint {
-        addr: MOCK_IP_ADDR_1,
+        addr: LOCAL_ADDR.into_address(),
         port: LOCAL_PORT,
     };
     pub const REMOTE_END: IpEndpoint = IpEndpoint {
-        addr: MOCK_IP_ADDR_2,
+        addr: REMOTE_ADDR.into_address(),
         port: REMOTE_PORT,
     };
 
-    pub const LOCAL_IP_REPR: IpRepr = IpRepr::Unspecified {
-        src_addr: MOCK_IP_ADDR_1,
-        dst_addr: MOCK_IP_ADDR_2,
+    pub const LOCAL_IP_REPR: IpRepr = IpReprIpvX(IpvXRepr {
+        src_addr: LOCAL_ADDR,
+        dst_addr: REMOTE_ADDR,
         next_header: IpProtocol::Udp,
         payload_len: 8 + 6,
         hop_limit: 64,
-    };
+    });
+
+    pub const REMOTE_IP_REPR: IpRepr = IpReprIpvX(IpvXRepr {
+        src_addr: REMOTE_ADDR,
+        dst_addr: LOCAL_ADDR,
+        next_header: IpProtocol::Udp,
+        payload_len: 8 + 6,
+        hop_limit: 64,
+    });
+
+    pub const BAD_IP_REPR: IpRepr = IpReprIpvX(IpvXRepr {
+        src_addr: REMOTE_ADDR,
+        dst_addr: OTHER_ADDR,
+        next_header: IpProtocol::Udp,
+        payload_len: 8 + 6,
+        hop_limit: 64,
+    });
 
     const LOCAL_UDP_REPR: UdpRepr = UdpRepr {
         src_port: LOCAL_PORT,
@@ -439,28 +476,6 @@ mod test {
     };
 
     const PAYLOAD: &[u8] = b"abcdef";
-
-    fn remote_ip_repr() -> IpRepr {
-        match (MOCK_IP_ADDR_2, MOCK_IP_ADDR_1) {
-            #[cfg(feature = "proto-ipv4")]
-            (IpAddress::Ipv4(src), IpAddress::Ipv4(dst)) => IpRepr::Ipv4(Ipv4Repr {
-                src_addr: src,
-                dst_addr: dst,
-                next_header: IpProtocol::Udp,
-                payload_len: 8 + 6,
-                hop_limit: 64,
-            }),
-            #[cfg(feature = "proto-ipv6")]
-            (IpAddress::Ipv6(src), IpAddress::Ipv6(dst)) => IpRepr::Ipv6(Ipv6Repr {
-                src_addr: src,
-                dst_addr: dst,
-                next_header: IpProtocol::Udp,
-                payload_len: 8 + 6,
-                hop_limit: 64,
-            }),
-            _ => unreachable!(),
-        }
-    }
 
     #[test]
     fn test_bind_unaddressable() {
@@ -567,16 +582,16 @@ mod test {
         assert!(!socket.can_recv());
         assert_eq!(socket.recv(), Err(Error::Exhausted));
 
-        assert!(socket.accepts(&mut cx, &remote_ip_repr(), &REMOTE_UDP_REPR));
+        assert!(socket.accepts(&mut cx, &REMOTE_IP_REPR, &REMOTE_UDP_REPR));
         assert_eq!(
-            socket.process(&mut cx, &remote_ip_repr(), &REMOTE_UDP_REPR, PAYLOAD),
+            socket.process(&mut cx, &REMOTE_IP_REPR, &REMOTE_UDP_REPR, PAYLOAD),
             Ok(())
         );
         assert!(socket.can_recv());
 
-        assert!(socket.accepts(&mut cx, &remote_ip_repr(), &REMOTE_UDP_REPR));
+        assert!(socket.accepts(&mut cx, &REMOTE_IP_REPR, &REMOTE_UDP_REPR));
         assert_eq!(
-            socket.process(&mut cx, &remote_ip_repr(), &REMOTE_UDP_REPR, PAYLOAD),
+            socket.process(&mut cx, &REMOTE_IP_REPR, &REMOTE_UDP_REPR, PAYLOAD),
             Err(Error::Exhausted)
         );
         assert_eq!(socket.recv(), Ok((&b"abcdef"[..], REMOTE_END)));
@@ -593,7 +608,7 @@ mod test {
         assert_eq!(socket.peek(), Err(Error::Exhausted));
 
         assert_eq!(
-            socket.process(&mut cx, &remote_ip_repr(), &REMOTE_UDP_REPR, PAYLOAD),
+            socket.process(&mut cx, &REMOTE_IP_REPR, &REMOTE_UDP_REPR, PAYLOAD),
             Ok(())
         );
         assert_eq!(socket.peek(), Ok((&b"abcdef"[..], &REMOTE_END)));
@@ -608,9 +623,9 @@ mod test {
 
         assert_eq!(socket.bind(LOCAL_PORT), Ok(()));
 
-        assert!(socket.accepts(&mut cx, &remote_ip_repr(), &REMOTE_UDP_REPR));
+        assert!(socket.accepts(&mut cx, &REMOTE_IP_REPR, &REMOTE_UDP_REPR));
         assert_eq!(
-            socket.process(&mut cx, &remote_ip_repr(), &REMOTE_UDP_REPR, PAYLOAD),
+            socket.process(&mut cx, &REMOTE_IP_REPR, &REMOTE_UDP_REPR, PAYLOAD),
             Ok(())
         );
 
@@ -627,7 +642,7 @@ mod test {
         assert_eq!(socket.bind(LOCAL_PORT), Ok(()));
 
         assert_eq!(
-            socket.process(&mut cx, &remote_ip_repr(), &REMOTE_UDP_REPR, PAYLOAD),
+            socket.process(&mut cx, &REMOTE_IP_REPR, &REMOTE_UDP_REPR, PAYLOAD),
             Ok(())
         );
 
@@ -652,13 +667,13 @@ mod test {
             s.dispatch(&mut cx, |_, (ip_repr, _, _)| {
                 assert_eq!(
                     ip_repr,
-                    IpRepr::Unspecified {
-                        src_addr: MOCK_IP_ADDR_1,
-                        dst_addr: MOCK_IP_ADDR_2,
+                    IpReprIpvX(IpvXRepr {
+                        src_addr: LOCAL_ADDR,
+                        dst_addr: REMOTE_ADDR,
                         next_header: IpProtocol::Udp,
                         payload_len: 8 + 6,
                         hop_limit: 0x2a,
-                    }
+                    })
                 );
                 Ok(())
             }),
@@ -674,44 +689,22 @@ mod test {
         assert_eq!(socket.bind(LOCAL_PORT), Ok(()));
 
         let mut udp_repr = REMOTE_UDP_REPR;
-        assert!(socket.accepts(&mut cx, &remote_ip_repr(), &udp_repr));
+        assert!(socket.accepts(&mut cx, &REMOTE_IP_REPR, &udp_repr));
         udp_repr.dst_port += 1;
-        assert!(!socket.accepts(&mut cx, &remote_ip_repr(), &udp_repr));
+        assert!(!socket.accepts(&mut cx, &REMOTE_IP_REPR, &udp_repr));
     }
 
     #[test]
     fn test_doesnt_accept_wrong_ip() {
-        fn generate_bad_repr() -> IpRepr {
-            match (MOCK_IP_ADDR_2, MOCK_IP_ADDR_3) {
-                #[cfg(feature = "proto-ipv4")]
-                (IpAddress::Ipv4(src), IpAddress::Ipv4(dst)) => IpRepr::Ipv4(Ipv4Repr {
-                    src_addr: src,
-                    dst_addr: dst,
-                    next_header: IpProtocol::Udp,
-                    payload_len: 8 + 6,
-                    hop_limit: 64,
-                }),
-                #[cfg(feature = "proto-ipv6")]
-                (IpAddress::Ipv6(src), IpAddress::Ipv6(dst)) => IpRepr::Ipv6(Ipv6Repr {
-                    src_addr: src,
-                    dst_addr: dst,
-                    next_header: IpProtocol::Udp,
-                    payload_len: 8 + 6,
-                    hop_limit: 64,
-                }),
-                _ => unreachable!(),
-            }
-        }
-
         let mut cx = Context::mock();
 
         let mut port_bound_socket = socket(buffer(1), buffer(0));
         assert_eq!(port_bound_socket.bind(LOCAL_PORT), Ok(()));
-        assert!(port_bound_socket.accepts(&mut cx, &generate_bad_repr(), &REMOTE_UDP_REPR));
+        assert!(port_bound_socket.accepts(&mut cx, &BAD_IP_REPR, &REMOTE_UDP_REPR));
 
         let mut ip_bound_socket = socket(buffer(1), buffer(0));
         assert_eq!(ip_bound_socket.bind(LOCAL_END), Ok(()));
-        assert!(!ip_bound_socket.accepts(&mut cx, &generate_bad_repr(), &REMOTE_UDP_REPR));
+        assert!(!ip_bound_socket.accepts(&mut cx, &BAD_IP_REPR, &REMOTE_UDP_REPR));
     }
 
     #[test]
@@ -740,10 +733,7 @@ mod test {
             src_port: REMOTE_PORT,
             dst_port: LOCAL_PORT,
         };
-        assert_eq!(
-            socket.process(&mut cx, &remote_ip_repr(), &repr, &[]),
-            Ok(())
-        );
+        assert_eq!(socket.process(&mut cx, &REMOTE_IP_REPR, &repr, &[]), Ok(()));
         assert_eq!(socket.recv(), Ok((&[][..], REMOTE_END)));
     }
 

--- a/src/wire/icmpv4.rs
+++ b/src/wire/icmpv4.rs
@@ -417,7 +417,7 @@ impl<'a> Repr<'a> {
                     header: Ipv4Repr {
                         src_addr: ip_packet.src_addr(),
                         dst_addr: ip_packet.dst_addr(),
-                        protocol: ip_packet.protocol(),
+                        next_header: ip_packet.next_header(),
                         payload_len: payload.len(),
                         hop_limit: ip_packet.hop_limit(),
                     },

--- a/src/wire/ip.rs
+++ b/src/wire/ip.rs
@@ -111,6 +111,17 @@ impl Address {
         Address::Ipv6(Ipv6Address::new(a0, a1, a2, a3, a4, a5, a6, a7))
     }
 
+    /// Return the protocol version.
+    pub fn version(&self) -> Option<Version> {
+        match self {
+            Address::Unspecified => None,
+            #[cfg(feature = "proto-ipv4")]
+            Address::Ipv4(_) => Some(Version::Ipv4),
+            #[cfg(feature = "proto-ipv6")]
+            Address::Ipv6(_) => Some(Version::Ipv6),
+        }
+    }
+
     /// Return an address as a sequence of octets, in big-endian.
     pub fn as_bytes(&self) -> &[u8] {
         match *self {

--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -396,9 +396,9 @@ impl<T: AsRef<[u8]>> Packet<T> {
         data[field::TTL]
     }
 
-    /// Return the protocol field.
+    /// Return the next_header (protocol) field.
     #[inline]
-    pub fn protocol(&self) -> Protocol {
+    pub fn next_header(&self) -> Protocol {
         let data = self.buffer.as_ref();
         Protocol::from(data[field::PROTOCOL])
     }
@@ -532,9 +532,9 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Packet<T> {
         data[field::TTL] = value
     }
 
-    /// Set the protocol field.
+    /// Set the next header (protocol) field.
     #[inline]
-    pub fn set_protocol(&mut self, value: Protocol) {
+    pub fn set_next_header(&mut self, value: Protocol) {
         let data = self.buffer.as_mut();
         data[field::PROTOCOL] = value.into()
     }
@@ -591,7 +591,7 @@ impl<T: AsRef<[u8]>> AsRef<[u8]> for Packet<T> {
 pub struct Repr {
     pub src_addr: Address,
     pub dst_addr: Address,
-    pub protocol: Protocol,
+    pub next_header: Protocol,
     pub payload_len: usize,
     pub hop_limit: u8,
 }
@@ -626,7 +626,7 @@ impl Repr {
         Ok(Repr {
             src_addr: packet.src_addr(),
             dst_addr: packet.dst_addr(),
-            protocol: packet.protocol(),
+            next_header: packet.next_header(),
             payload_len: payload_len,
             hop_limit: packet.hop_limit(),
         })
@@ -656,7 +656,7 @@ impl Repr {
         packet.set_dont_frag(true);
         packet.set_frag_offset(0);
         packet.set_hop_limit(self.hop_limit);
-        packet.set_protocol(self.protocol);
+        packet.set_next_header(self.next_header);
         packet.set_src_addr(self.src_addr);
         packet.set_dst_addr(self.dst_addr);
 
@@ -681,7 +681,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> fmt::Display for Packet<&'a T> {
                     " src={} dst={} proto={} hop_limit={}",
                     self.src_addr(),
                     self.dst_addr(),
-                    self.protocol(),
+                    self.next_header(),
                     self.hop_limit()
                 )?;
                 if self.version() != 4 {
@@ -720,7 +720,7 @@ impl fmt::Display for Repr {
         write!(
             f,
             "IPv4 src={} dst={} proto={}",
-            self.src_addr, self.dst_addr, self.protocol
+            self.src_addr, self.dst_addr, self.next_header
         )
     }
 }
@@ -777,7 +777,7 @@ mod test {
         assert!(packet.dont_frag());
         assert_eq!(packet.frag_offset(), 0x203 * 8);
         assert_eq!(packet.hop_limit(), 0x1a);
-        assert_eq!(packet.protocol(), Protocol::Icmp);
+        assert_eq!(packet.next_header(), Protocol::Icmp);
         assert_eq!(packet.checksum(), 0xd56e);
         assert_eq!(packet.src_addr(), Address([0x11, 0x12, 0x13, 0x14]));
         assert_eq!(packet.dst_addr(), Address([0x21, 0x22, 0x23, 0x24]));
@@ -800,7 +800,7 @@ mod test {
         packet.set_dont_frag(true);
         packet.set_frag_offset(0x203 * 8);
         packet.set_hop_limit(0x1a);
-        packet.set_protocol(Protocol::Icmp);
+        packet.set_next_header(Protocol::Icmp);
         packet.set_src_addr(Address([0x11, 0x12, 0x13, 0x14]));
         packet.set_dst_addr(Address([0x21, 0x22, 0x23, 0x24]));
         packet.fill_checksum();
@@ -844,7 +844,7 @@ mod test {
         Repr {
             src_addr: Address([0x11, 0x12, 0x13, 0x14]),
             dst_addr: Address([0x21, 0x22, 0x23, 0x24]),
-            protocol: Protocol::Icmp,
+            next_header: Protocol::Icmp,
             payload_len: 4,
             hop_limit: 64,
         }

--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -87,6 +87,13 @@ impl Address {
     pub const fn is_loopback(&self) -> bool {
         self.0[0] == 127
     }
+
+    /// Convert to an `IpAddress`.
+    ///
+    /// Same as `.into()`, but works in `const`.
+    pub const fn into_address(self) -> super::IpAddress {
+        super::IpAddress::Ipv4(self)
+    }
 }
 
 #[cfg(feature = "std")]

--- a/src/wire/ipv6.rs
+++ b/src/wire/ipv6.rs
@@ -188,6 +188,13 @@ impl Address {
             self.0[13], self.0[14], self.0[15],
         ])
     }
+
+    /// Convert to an `IpAddress`.
+    ///
+    /// Same as `.into()`, but works in `const`.
+    pub const fn into_address(self) -> super::IpAddress {
+        super::IpAddress::Ipv6(self)
+    }
 }
 
 #[cfg(feature = "std")]

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -50,7 +50,7 @@ use smoltcp::wire::*;
 let repr = Ipv4Repr {
     src_addr:    Ipv4Address::new(10, 0, 0, 1),
     dst_addr:    Ipv4Address::new(10, 0, 0, 2),
-    protocol:    IpProtocol::Tcp,
+    next_header: IpProtocol::Tcp,
     payload_len: 10,
     hop_limit:   64
 };


### PR DESCRIPTION
Implement simplifications unlocked by adding the `Context` parameter to socket methods. 

- tcp: immediately choose src addr on connect. Now that we have access to `Context` from `.connect()`, we don't have to delay setting it anymore.
- Remove IpRepr::Unspecified and lowering. Choosing the right source IP address is now responsibility of the individual sockets.

