### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ autoexamples = false
 
 [dependencies]
 managed = { version = "0.8", default-features = false, features = ["map"] }
-byteorder = { version = "1.4", default-features = false }
-log = { version = "0.4.14", default-features = false, optional = true }
-libc = { version = "0.2.115", optional = true }
-bitflags = { version = "1.3", default-features = false }
+byteorder = { version = "1.0", default-features = false }
+log = { version = "0.4.4", default-features = false, optional = true }
+libc = { version = "0.2.18", optional = true }
+bitflags = { version = "1.0", default-features = false }
 defmt = { version = "0.3", optional = true }
 rand_core = { version = "0.6.3", optional = true, default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,18 +17,18 @@ autoexamples = false
 
 [dependencies]
 managed = { version = "0.8", default-features = false, features = ["map"] }
-byteorder = { version = "1.0", default-features = false }
-log = { version = "0.4.4", default-features = false, optional = true }
-libc = { version = "0.2.18", optional = true }
-bitflags = { version = "1.0", default-features = false }
+byteorder = { version = "1.4", default-features = false }
+log = { version = "0.4.14", default-features = false, optional = true }
+libc = { version = "0.2.115", optional = true }
+bitflags = { version = "1.3", default-features = false }
 defmt = { version = "0.3", optional = true }
 rand_core = { version = "0.6.3", optional = true, default-features = false }
 
 [dev-dependencies]
-env_logger = "0.5"
+env_logger = "0.9"
 getopts = "0.2"
-rand = "0.3"
-url = "1.0"
+rand = "0.8"
+url = "2.0"
 
 [features]
 std = ["managed/std", "rand_core/std"]

--- a/examples/utils.rs
+++ b/examples/utils.rs
@@ -23,7 +23,7 @@ pub fn setup_logging_with_clock<F>(filter: &str, since_startup: F)
 where
     F: Fn() -> Instant + Send + Sync + 'static,
 {
-    Builder::new()
+    Builder::from_default_env()
         .format(move |buf, record| {
             let elapsed = since_startup();
             let timestamp = format!("[{}]", elapsed);
@@ -54,8 +54,7 @@ where
             }
         })
         .filter(None, LevelFilter::Trace)
-        .parse(filter)
-        .parse(&env::var("RUST_LOG").unwrap_or_else(|_| "".to_owned()))
+        .parse_filters(filter)
         .init();
 }
 

--- a/examples/utils.rs
+++ b/examples/utils.rs
@@ -23,7 +23,7 @@ pub fn setup_logging_with_clock<F>(filter: &str, since_startup: F)
 where
     F: Fn() -> Instant + Send + Sync + 'static,
 {
-    Builder::from_default_env()
+    Builder::new()
         .format(move |buf, record| {
             let elapsed = since_startup();
             let timestamp = format!("[{}]", elapsed);
@@ -55,6 +55,7 @@ where
         })
         .filter(None, LevelFilter::Trace)
         .parse_filters(filter)
+        .parse_env("RUST_LOG")
         .init();
 }
 


### PR DESCRIPTION
Hi. This PR bumps smoltcp dependencies version to `latest` according to [crates.io](https://crates.io/).
The `env_logger` update brings an API change, the [parse](https://docs.rs/env_logger/0.5.0/src/env_logger/lib.rs.html#380-383) Builder method was replaced with [parse_filters](https://docs.rs/env_logger/0.9.0/env_logger/struct.Builder.html#method.parse_filters).

Apart from `parse_filters`, I noticed that the original code parsed `RUST_LOG` **after** setting the log level to `trace` and parsing the filters. My understanding is that this overwrites the builder setup with what `RUST_LOG` contains.
My change parses the [default environment](https://docs.rs/env_logger/0.9.0/env_logger/struct.Env.html#default-environment-variables) first with `from_default_env` and then applies the filter changes.

If the desired behaviour is the original one (overwrite `setup_logging_with_clock` filters with the ones defined by `RUST_LOG`) let me know.

Tnx :)
