### PR TITLE
use socklen_t instead of u32 for bind() parameter

### DIFF
--- a/src/phy/sys/raw_socket.rs
+++ b/src/phy/sys/raw_socket.rs
@@ -70,7 +70,7 @@ impl RawSocketDesc {
             let res = libc::bind(
                 self.lower,
                 &sockaddr as *const libc::sockaddr_ll as *const libc::sockaddr,
-                mem::size_of::<libc::sockaddr_ll>() as u32,
+                mem::size_of::<libc::sockaddr_ll>() as libc::socklen_t,
             );
             if res == -1 {
                 return Err(io::Error::last_os_error());


### PR DESCRIPTION
Fix compilation on Android 32b, where `socklen_t` is `i32`. This changes nothing on almost all other platforms as their `socklen_t` is  already `u32`.
Solarish and VxWorks are the two other exceptions, they both use `c_uint` as their `socklen_t`. For x86_64-sun-solaris and sparcv9-sun-solaris I was able to confirm `c_uint` is in fact a `u32`, so it worked before, and still works now.
For vxworks, I did not found a toolchain I could install with rustup to confirm whether it worked before, but anyway it should work now.