### PR TITLE
Correct net_trace! bug in UdpSocket dispatch & rename endpoint elsewhere.

### DIFF
--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -230,7 +230,8 @@ impl<'a> UdpSocket<'a> {
     ///
     /// See also [send](#method.send).
     pub fn send_slice(&mut self, data: &[u8], remote_endpoint: IpEndpoint) -> Result<()> {
-        self.send(data.len(), remote_endpoint)?.copy_from_slice(data);
+        self.send(data.len(), remote_endpoint)?
+            .copy_from_slice(data);
         Ok(())
     }
 


### PR DESCRIPTION
Correct net_trace! bug in UdpSocket dispatch where the local endpoint was used instead of endpoint.  Also changed other endpoint naming to add clarity that it is the remote endpoint.