### PR TITLE
Fixed an issue with DHCP client and an assert which conflict

### DIFF
--- a/src/iface/interface.rs
+++ b/src/iface/interface.rs
@@ -2417,7 +2417,6 @@ impl<'a> InterfaceInner<'a> {
 
     fn dispatch_ip<Tx: TxToken>(&mut self, tx_token: Tx, packet: IpPacket) -> Result<()> {
         let ip_repr = packet.ip_repr();
-        assert!(!ip_repr.src_addr().is_unspecified());
         assert!(!ip_repr.dst_addr().is_unspecified());
 
         match self.caps.medium {

--- a/src/iface/neighbor.rs
+++ b/src/iface/neighbor.rs
@@ -196,6 +196,8 @@ impl<'a> Cache<'a> {
     }
 
     pub(crate) fn lookup(&self, protocol_addr: &IpAddress, timestamp: Instant) -> Answer {
+        assert!(protocol_addr.is_unicast());
+        
         if let Some(&Neighbor {
             expires_at,
             hardware_addr,
@@ -205,8 +207,6 @@ impl<'a> Cache<'a> {
                 return Answer::Found(hardware_addr);
             }
         }
-
-        assert!(protocol_addr.is_unicast());
 
         if timestamp < self.silent_until {
             Answer::RateLimited

--- a/src/iface/neighbor.rs
+++ b/src/iface/neighbor.rs
@@ -197,7 +197,7 @@ impl<'a> Cache<'a> {
 
     pub(crate) fn lookup(&self, protocol_addr: &IpAddress, timestamp: Instant) -> Answer {
         assert!(protocol_addr.is_unicast());
-        
+
         if let Some(&Neighbor {
             expires_at,
             hardware_addr,
@@ -211,7 +211,6 @@ impl<'a> Cache<'a> {
         if timestamp < self.silent_until {
             Answer::RateLimited
         } else {
-            assert!(protocol_addr.is_unicast());
             Answer::NotFound
         }
     }

--- a/src/iface/neighbor.rs
+++ b/src/iface/neighbor.rs
@@ -62,6 +62,7 @@ impl Answer {
 #[derive(Debug)]
 pub struct Cache<'a> {
     storage: ManagedMap<'a, IpAddress, Neighbor>,
+    broadcast: Option<HardwareAddress>,
     silent_until: Instant,
     #[cfg(any(feature = "std", feature = "alloc"))]
     gc_threshold: usize,
@@ -91,6 +92,7 @@ impl<'a> Cache<'a> {
 
         Cache {
             storage,
+            broadcast: None,
             #[cfg(any(feature = "std", feature = "alloc"))]
             gc_threshold: Self::GC_THRESHOLD,
             silent_until: Instant::from_millis(0),
@@ -107,9 +109,17 @@ impl<'a> Cache<'a> {
 
         Cache {
             storage,
+            broadcast: None,
             gc_threshold,
             silent_until: Instant::from_millis(0),
         }
+    }
+
+    pub fn set_broadcast(
+        &mut self,
+        hardware_addr: HardwareAddress,
+    ) {
+        self.broadcast = Some(hardware_addr);
     }
 
     pub fn fill(
@@ -196,9 +206,12 @@ impl<'a> Cache<'a> {
     }
 
     pub(crate) fn lookup(&self, protocol_addr: &IpAddress, timestamp: Instant) -> Answer {
-        if protocol_addr.is_unicast() == false {
-            return Answer::NotFound;
+        if protocol_addr.is_broadcast() {
+            if let Some(hardware_addr) = self.broadcast {
+                return Answer::Found(hardware_addr);
+            }
         }
+        assert!(protocol_addr.is_unicast());
 
         if let Some(&Neighbor {
             expires_at,

--- a/src/iface/neighbor.rs
+++ b/src/iface/neighbor.rs
@@ -196,7 +196,9 @@ impl<'a> Cache<'a> {
     }
 
     pub(crate) fn lookup(&self, protocol_addr: &IpAddress, timestamp: Instant) -> Answer {
-        assert!(protocol_addr.is_unicast());
+        if protocol_addr.is_unicast() == false {
+            return Answer::NotFound;
+        }
 
         if let Some(&Neighbor {
             expires_at,


### PR DESCRIPTION
The DHCP client will broadcast a packet at the IPv4 address 255.255.255.255 hence when using iface.poll_at it fails with an assert that is checking if the source address is unspecified which of course it is as it defaults to 0.0.0.0.

```
Apr 16 14:32:10.910 DEBUG smoltcp::socket::dhcpv4: DHCP send DISCOVER to 255.255.255.255: Repr { message_type: Discover, transaction_id: 2704349917, client_hardware_address: Address([6, 241, 20, 229, 85, 169]), client_ip: Address([0, 0, 0, 0]), your_ip: Address([0, 0, 0, 0]), server_ip: Address([0, 0, 0, 0]), router: None, subnet_mask: None, relay_agent_ip: Address([0, 0, 0, 0]), broadcast: false, requested_ip: None, client_identifier: Some(Address([6, 241, 20, 229, 85, 169])), server_identifier: None, parameter_request_list: Some([1, 3, 6]), dns_servers: None, max_size: Some(1418), lease_duration: None } 
```

Stack trace:
```
thread 'tcp_simple_dhcp' panicked at 'assertion failed: !ip_repr.src_addr().is_unspecified()', /home/john/.cargo/git/checkouts/smoltcp-3d1f2cb07ccf3010/3e7c21b/src/iface/interface.rs:2420:9
stack backtrace:
   0: rust_begin_unwind
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panicking.rs:498:5
   1: core::panicking::panic_fmt
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/panicking.rs:107:14
   2: core::panicking::panic
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/panicking.rs:48:5
   3: smoltcp::iface::interface::InterfaceInner::dispatch_ip
             at /home/john/.cargo/git/checkouts/smoltcp-3d1f2cb07ccf3010/3e7c21b/src/iface/interface.rs:2420:9
   4: smoltcp::iface::interface::Interface<DeviceT>::socket_egress::{{closure}}
             at /home/john/.cargo/git/checkouts/smoltcp-3d1f2cb07ccf3010/3e7c21b/src/iface/interface.rs:942:21
   5: smoltcp::socket::dhcpv4::Dhcpv4Socket::dispatch
             at /home/john/.cargo/git/checkouts/smoltcp-3d1f2cb07ccf3010/3e7c21b/src/socket/dhcpv4.rs:448:17
   6: smoltcp::iface::interface::Interface<DeviceT>::socket_egress
             at /home/john/.cargo/git/checkouts/smoltcp-3d1f2cb07ccf3010/3e7c21b/src/iface/interface.rs:941:43
   7: smoltcp::iface::interface::Interface<DeviceT>::poll
             at /home/john/.cargo/git/checkouts/smoltcp-3d1f2cb07ccf3010/3e7c21b/src/iface/interface.rs:753:31
```