### PR TITLE
(Incomplete) Implement `join_multicast_group()` for IPv6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,10 @@ name = "multicast"
 required-features = ["std", "medium-ethernet", "medium-ip", "phy-tuntap_interface", "proto-ipv4", "proto-igmp", "socket-udp"]
 
 [[example]]
+name = "multicast6"
+required-features = ["std", "medium-ethernet", "medium-ip", "phy-tuntap_interface", "proto-ipv6", "socket-udp"]
+
+[[example]]
 name = "benchmark"
 required-features = ["std", "medium-ethernet", "medium-ip", "phy-tuntap_interface", "proto-ipv4", "socket-raw", "socket-udp"]
 

--- a/examples/multicast6.rs
+++ b/examples/multicast6.rs
@@ -1,0 +1,85 @@
+mod utils;
+
+use log::debug;
+use std::collections::BTreeMap;
+use std::os::unix::io::AsRawFd;
+
+use smoltcp::iface::{InterfaceBuilder, NeighborCache};
+use smoltcp::phy::wait as phy_wait;
+use smoltcp::socket::{UdpPacketMetadata, UdpSocket, UdpSocketBuffer};
+use smoltcp::time::Instant;
+use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr, Ipv6Address};
+
+// Note: If testing with a tap interface in linux, you may need to specify the
+// interface index when addressing. E.g.,
+//
+// ```
+// nc -u ff02::1234%tap0 8123
+// ```
+//
+// will send packets to the multicast group we join below on tap0.
+
+const PORT: u16 = 8123;
+const GROUP: [u16; 8] = [0xff02, 0, 0, 0, 0, 0, 0, 0x1234];
+const LOCAL_ADDR: [u16; 8] = [0xfe80, 0, 0, 0, 0, 0, 0, 0x101];
+
+fn main() {
+    utils::setup_logging("warn");
+
+    let (mut opts, mut free) = utils::create_options();
+    utils::add_tuntap_options(&mut opts, &mut free);
+    utils::add_middleware_options(&mut opts, &mut free);
+
+    let mut matches = utils::parse_options(&opts, free);
+    let device = utils::parse_tuntap_options(&mut matches);
+    let fd = device.as_raw_fd();
+    let device = utils::parse_middleware_options(&mut matches, device, /*loopback=*/ false);
+    let neighbor_cache = NeighborCache::new(BTreeMap::new());
+
+    let local_addr = Ipv6Address::from_parts(&LOCAL_ADDR);
+
+    let ethernet_addr = EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x02]);
+    let ip_addr = IpCidr::new(IpAddress::from(local_addr), 64);
+    let mut ipv6_multicast_storage = [None; 1];
+    let mut iface = InterfaceBuilder::new(device, vec![])
+        .hardware_addr(ethernet_addr.into())
+        .neighbor_cache(neighbor_cache)
+        .ip_addrs([ip_addr])
+        .ipv6_multicast_groups(&mut ipv6_multicast_storage[..])
+        .finalize();
+
+    let now = Instant::now();
+    // Join a multicast group
+    iface
+        .join_multicast_group(Ipv6Address::from_parts(&GROUP), now)
+        .unwrap();
+
+    let udp_rx_buffer = UdpSocketBuffer::new(vec![UdpPacketMetadata::EMPTY; 4], vec![0; 1024]);
+    let udp_tx_buffer = UdpSocketBuffer::new(vec![UdpPacketMetadata::EMPTY], vec![0; 0]);
+    let udp_socket = UdpSocket::new(udp_rx_buffer, udp_tx_buffer);
+    let udp_handle = iface.add_socket(udp_socket);
+
+    loop {
+        let timestamp = Instant::now();
+        match iface.poll(timestamp) {
+            Ok(_) => {}
+            Err(e) => {
+                debug!("poll error: {}", e);
+            }
+        }
+
+        let socket = iface.get_socket::<UdpSocket>(udp_handle);
+        if !socket.is_open() {
+            socket.bind(PORT).unwrap()
+        }
+
+        if socket.can_recv() {
+            socket
+                .recv()
+                .map(|(data, sender)| println!("traffic: {} UDP bytes from {}", data.len(), sender))
+                .unwrap_or_else(|e| println!("Recv UDP error: {:?}", e));
+        }
+
+        phy_wait(fd, iface.poll_delay(timestamp)).expect("wait error");
+    }
+}

--- a/src/iface/interface.rs
+++ b/src/iface/interface.rs
@@ -2858,7 +2858,7 @@ mod test {
         iface_builder.finalize()
     }
 
-    #[cfg(feature = "proto-igmp")]
+    #[cfg(any(feature = "proto-igmp", feature = "proto-ipv6"))]
     fn recv_all(iface: &mut Interface<'_, Loopback>, timestamp: Instant) -> Vec<Vec<u8>> {
         let mut pkts = Vec::new();
         while let Some((rx, _tx)) = iface.device.receive() {

--- a/src/iface/interface.rs
+++ b/src/iface/interface.rs
@@ -2023,7 +2023,6 @@ impl<'a> InterfaceInner<'a> {
             let opt_repr = result?;
             match opt_repr {
                 Ipv6OptionRepr::Pad1 | Ipv6OptionRepr::PadN(_) | Ipv6OptionRepr::RouterAlert(_) => {
-                    ()
                 }
                 Ipv6OptionRepr::Unknown { type_, .. } => {
                     match Ipv6OptionFailureType::from(type_) {
@@ -2511,7 +2510,6 @@ impl<'a> InterfaceInner<'a> {
 
     fn dispatch_ip<Tx: TxToken>(&mut self, tx_token: Tx, packet: IpPacket) -> Result<()> {
         let ip_repr = packet.ip_repr();
-        assert!(!ip_repr.src_addr().is_unspecified());
         assert!(!ip_repr.dst_addr().is_unspecified());
 
         match self.caps.medium {
@@ -3548,7 +3546,7 @@ mod test {
                 &IpAddress::Ipv6(ipv6_packet.src_addr()),
                 &IpAddress::Ipv6(ipv6_packet.dst_addr()),
                 &icmpv6_packet,
-                &checksum_caps,
+                checksum_caps,
             )
             .unwrap();
 

--- a/src/iface/interface.rs
+++ b/src/iface/interface.rs
@@ -3516,7 +3516,7 @@ mod test {
             Ipv6Address::from_parts(&[0xff0e, 0, 0, 0, 0, 0, 0, 0x0017]),
         ];
 
-        let timestamp = Instant::now();
+        let timestamp = Instant::from_millis(0);
 
         for &group in &groups {
             iface.join_multicast_group(group, timestamp).unwrap();

--- a/src/wire/ipv6.rs
+++ b/src/wire/ipv6.rs
@@ -26,17 +26,25 @@ impl Address {
     /// [unspecified address]: https://tools.ietf.org/html/rfc4291#section-2.5.2
     pub const UNSPECIFIED: Address = Address([0x00; 16]);
 
-    /// The link-local [all routers multicast address].
+    /// The link-local [all MLVDv2-capable routers multicast address].
     ///
-    /// [all routers multicast address]: https://tools.ietf.org/html/rfc4291#section-2.7.1
-    pub const LINK_LOCAL_ALL_NODES: Address = Address([
+    /// [all MLVDv2-capable routers multicast address]: https://tools.ietf.org/html/rfc3810#section-11
+    pub const LINK_LOCAL_ALL_MLDV2_ROUTERS: Address = Address([
         0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x01,
+        0x16,
     ]);
 
     /// The link-local [all nodes multicast address].
     ///
     /// [all nodes multicast address]: https://tools.ietf.org/html/rfc4291#section-2.7.1
+    pub const LINK_LOCAL_ALL_NODES: Address = Address([
+        0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x01,
+    ]);
+
+    /// The link-local [all routers multicast address].
+    ///
+    /// [all routers multicast address]: https://tools.ietf.org/html/rfc4291#section-2.7.1
     pub const LINK_LOCAL_ALL_ROUTERS: Address = Address([
         0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x02,

--- a/src/wire/ipv6hopbyhop.rs
+++ b/src/wire/ipv6hopbyhop.rs
@@ -168,6 +168,21 @@ pub struct Repr<'a> {
     pub options: &'a [u8],
 }
 
+impl Repr<'static> {
+    /// The hop-by-hop header containing only an [MLDv2 router alert option].
+    ///
+    /// [MLDv2 router alert option]: https://tools.ietf.org/html/rfc2711#section-2.1
+    pub const MLDV2_ROUTER_ALERT: Self = Self {
+        // MLDv2 packets are always ICMPv6
+        next_header: Protocol::Icmpv6,
+        length: 0,
+        options: &[
+            0x05, 0x02, 0x00, 0x00, // Router alert
+            0x01, 0x00, // PadN(0)
+        ],
+    };
+}
+
 impl<'a> Repr<'a> {
     /// Parse an IPv6 Hop-by-Hop Options Header and return a high-level representation.
     pub fn parse<T>(header: &Header<&'a T>) -> Result<Repr<'a>>

--- a/src/wire/mld.rs
+++ b/src/wire/mld.rs
@@ -435,7 +435,7 @@ impl<'a> Repr<'a> {
                 packet.set_nr_mcast_addr_rcrds(records.len() as u16);
                 let mut payload = packet.payload_mut();
                 for record in *records {
-                    record.emit(&mut AddressRecord::new_unchecked(&mut payload[..]));
+                    record.emit(&mut AddressRecord::new_unchecked(&mut *payload));
                     payload = &mut payload[record.buffer_len()..];
                 }
             }

--- a/src/wire/mld.rs
+++ b/src/wire/mld.rs
@@ -294,6 +294,48 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> AddressRecord<T> {
     }
 }
 
+/// A high level representation of an MLDv2 Listener Report Message Address Record.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct AddressRecordRepr<'a> {
+    pub num_srcs: u16,
+    pub mcast_addr: Ipv6Address,
+    pub record_type: RecordType,
+    pub aux_data_len: u8,
+    pub payload: &'a [u8],
+}
+
+impl<'a> AddressRecordRepr<'a> {
+    /// Parse an MLDv2 address record and return a high-level representation.
+    pub fn parse<T>(record: &AddressRecord<&'a T>) -> Result<Self>
+    where
+        T: AsRef<[u8]> + ?Sized,
+    {
+        Ok(Self {
+            num_srcs: record.num_srcs(),
+            mcast_addr: record.mcast_addr(),
+            record_type: record.record_type(),
+            aux_data_len: record.aux_data_len(),
+            payload: record.payload(),
+        })
+    }
+
+    /// Return the length of a record that will be emitted from this high-level
+    /// representation, not including any payload data.
+    pub fn buffer_len(&self) -> usize {
+        field::RECORD_MCAST_ADDR.end
+    }
+
+    /// Emit a high-level representation into an MLDv2 address record.
+    pub fn emit<T: AsRef<[u8]> + AsMut<[u8]>>(&self, record: &mut AddressRecord<T>) {
+        record.set_record_type(self.record_type);
+        record.set_num_srcs(self.num_srcs);
+        record.set_mcast_addr(self.mcast_addr);
+        record.set_aux_data_len(self.aux_data_len);
+        record.payload_mut().copy_from_slice(self.payload);
+    }
+}
+
 /// A high-level representation of an MLDv2 packet header.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -311,6 +353,7 @@ pub enum Repr<'a> {
         nr_mcast_addr_rcrds: u16,
         data: &'a [u8],
     },
+    ReportRecordReprs(&'a [AddressRecordRepr<'a>]),
 }
 
 impl<'a> Repr<'a> {
@@ -341,7 +384,7 @@ impl<'a> Repr<'a> {
     pub fn buffer_len(&self) -> usize {
         match self {
             Repr::Query { .. } => field::QUERY_NUM_SRCS.end,
-            Repr::Report { .. } => field::NR_MCAST_RCRDS.end,
+            Repr::Report { .. } | Repr::ReportRecordReprs(_) => field::NR_MCAST_RCRDS.end,
         }
     }
 
@@ -384,6 +427,17 @@ impl<'a> Repr<'a> {
                 packet.clear_reserved();
                 packet.set_nr_mcast_addr_rcrds(*nr_mcast_addr_rcrds);
                 packet.payload_mut().copy_from_slice(&data[..]);
+            }
+            Repr::ReportRecordReprs(records) => {
+                packet.set_msg_type(Message::MldReport);
+                packet.set_msg_code(0);
+                packet.clear_reserved();
+                packet.set_nr_mcast_addr_rcrds(records.len() as u16);
+                let mut payload = packet.payload_mut();
+                for record in *records {
+                    record.emit(&mut AddressRecord::new_unchecked(&mut payload[..]));
+                    payload = &mut payload[record.buffer_len()..];
+                }
             }
         }
     }

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -176,7 +176,7 @@ pub use self::ipv6::{
 #[cfg(feature = "proto-ipv6")]
 pub use self::ipv6option::{
     FailureType as Ipv6OptionFailureType, Ipv6Option, Repr as Ipv6OptionRepr,
-    Type as Ipv6OptionType,
+    RouterAlert as Ipv6OptionRouterAlert, Type as Ipv6OptionType,
 };
 
 #[cfg(feature = "proto-ipv6")]
@@ -226,7 +226,10 @@ pub use self::ndiscoption::{
 };
 
 #[cfg(feature = "proto-ipv6")]
-pub use self::mld::{AddressRecord as MldAddressRecord, Repr as MldRepr};
+pub use self::mld::{
+    AddressRecord as MldAddressRecord, AddressRecordRepr as MldAddressRecordRepr,
+    RecordType as MldRecordType, Repr as MldRepr,
+};
 
 pub use self::udp::{Packet as UdpPacket, Repr as UdpRepr, HEADER_LEN as UDP_HEADER_LEN};
 


### PR DESCRIPTION
This is a preliminary and incomplete start to adding support for IPv6 multicast groups. This PR _only_ adds joining groups via sending an initial MLDv2 report packet; it doesn't support resending the change report, leaving groups, responding to queries, etc. I wanted to open this PR first both to keep the review burden lighter and to get any feedback on the implementation that could affect implementing the remaining features.

On that last point, there are a few things in this PR that I'm not thrilled with and would be happy for any suggestions. I think all of them derive from difficulty crafting a fully-formed `IpPacket` to pass to `dispatch_ip()`. For the MLDv2 report, the specific difficulties and paths I took to deal with them were:

1. We are required to set the router alert option in an ipv6 hop-by-hop header, which requires us to be able to craft a packet with a hop-by-hop header in the first place! I added a new case to `IpPacket` (`IpPacket::HopByHopIcmpv6`), but that doesn't feel quite right.
2. `Ipv6HopByHopRepr`'s `options` field requires a borrowed slice. I couldn't see an easy way to get from a pair of `Ipv6OptionRepr`s to a borrowed slice, so I punted on this and defined `Ipv6HopByHopRepr::MLDV2_ROUTER_ALERT` as a constant.
3. Similarly, `MldRepr::Report` requires a borrowed slice for its data (the address records); I couldn't see an easy way to get from an `MldAddressRecordRepr` to that borrowed data, so I added an `MldRepr::ReportRecordReprs` case which holds a slice of `MldAddressRecordRepr`. This definitely seems wrong. It also might be still have similar problems as the borrowed byte slice when we need to craft packets with multiple address records in them.

In addition to the unit tests present, I've tested this locally on a microcontroller running smoltcp, and I've confirmed I can communicate with it via a multicast address through the switch it's connected to, so I'm reasonably confident that what's here is correct (albeit incomplete and a little hacky, as noted above).