### PR TITLE
Bugfix in benchmark example

### DIFF
--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -81,8 +81,6 @@ fn main() {
         _ => panic!("invalid mode"),
     };
 
-    thread::spawn(move || client(mode));
-
     let neighbor_cache = NeighborCache::new(BTreeMap::new());
 
     let tcp1_rx_buffer = TcpSocketBuffer::new(vec![0; 65535]);
@@ -107,6 +105,7 @@ fn main() {
     let tcp1_handle = iface.add_socket(tcp1_socket);
     let tcp2_handle = iface.add_socket(tcp2_socket);
     let default_timeout = Some(Duration::from_millis(1000));
+    thread::spawn(move || client(mode));
 
     let mut processed = 0;
     while !CLIENT_DONE.load(Ordering::SeqCst) {


### PR DESCRIPTION
fixed race condition bug in benchmark example, client thread could be spawned before configuration was complete, resulting in a "ConnectionRefused" error in around 75% of runs on my multithreaded machine