### PR TITLE
Return tuntap err instead of unwrap

### DIFF
--- a/src/phy/sys/tuntap_interface.rs
+++ b/src/phy/sys/tuntap_interface.rs
@@ -103,7 +103,7 @@ impl TunTapInterfaceDesc {
                 buffer.len(),
             );
             if len == -1 {
-                Err(io::Error::last_os_error()).unwrap()
+                return Err(io::Error::last_os_error());
             }
             Ok(len as usize)
         }


### PR DESCRIPTION
Ran into a panic today using the `TunTapInterface`, this line turned out to be the culprit. There doesn't appear to be any reason this code should be unwrapping. The `RawSocket` equivalent of this function returns instead of unwrapping.