### PR TITLE
fix mtu calculation for raw_socket

### DIFF
--- a/src/phy/raw_socket.rs
+++ b/src/phy/raw_socket.rs
@@ -43,7 +43,7 @@ impl RawSocket {
         Ok(RawSocket {
             medium,
             lower: Rc::new(RefCell::new(lower)),
-            mtu: mtu,
+            mtu,
         })
     }
 }

--- a/src/phy/sys/raw_socket.rs
+++ b/src/phy/sys/raw_socket.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::phy::Medium;
-use crate::wire::EthernetFrame;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::{io, mem};
 
@@ -48,11 +47,7 @@ impl RawSocketDesc {
     }
 
     pub fn interface_mtu(&mut self) -> io::Result<usize> {
-        // SIOCGIFMTU returns the IP MTU (typically 1500 bytes.)
-        // smoltcp counts the entire Ethernet packet in the MTU, so add the Ethernet header size to it.
-        let ip_mtu =
-            ifreq_ioctl(self.lower, &mut self.ifreq, imp::SIOCGIFMTU).map(|mtu| mtu as usize)?;
-        Ok(ip_mtu + EthernetFrame::<&[u8]>::header_len())
+        ifreq_ioctl(self.lower, &mut self.ifreq, imp::SIOCGIFMTU).map(|mtu| mtu as usize)
     }
 
     pub fn bind_interface(&mut self) -> io::Result<()> {


### PR DESCRIPTION
Previously, the Ethernet frame header size was added twice to the MTU of the `RawSocket`.
The first time in `interface_mtu` and a second time after calling `interface_mtu` in the raw socket `new` function.
I removed the one in the `interface_mtu` function.