### PR TITLE
Select correct source addr in the UDP socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - No unreleased changes.
 
+## [0.8.1] - 2022-05-12
+
+- Remove unused `rand_core` dep. ([#589](https://github.com/smoltcp-rs/smoltcp/pull/589))
+- Use socklen_t instead of u32 for RawSocket bind() parameter. Fixes build on 32bit Android. ([#593](https://github.com/smoltcp-rs/smoltcp/pull/593))
+- Propagate phy::RawSocket send errors to caller ([#588](https://github.com/smoltcp-rs/smoltcp/pull/588))
+- Fix Interface set_hardware_addr, get_hardware_addr for ieee802154/6lowpan. ([#584](https://github.com/smoltcp-rs/smoltcp/pull/584))
+
 ## [0.8.0] - 2021-12-11
 
 - Minimum Supported Rust Version (MSRV) **bumped** from 1.40 to 1.56
@@ -133,6 +140,7 @@ only processed when directed to the 255.255.255.255 address. ([377](https://gith
 - Simplify lifetime parameters of sockets, SocketSet, EthernetInterface ([410](https://github.com/smoltcp-rs/smoltcp/pull/410), [413](https://github.com/smoltcp-rs/smoltcp/pull/413))
 
 [Unreleased]: https://github.com/smoltcp-rs/smoltcp/compare/v0.7.0...HEAD
+[0.8.1]: https://github.com/smoltcp-rs/smoltcp/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/smoltcp-rs/smoltcp/compare/v0.7.0...v0.8.0
 [0.7.5]: https://github.com/smoltcp-rs/smoltcp/compare/v0.7.4...v0.7.5
 [0.7.4]: https://github.com/smoltcp-rs/smoltcp/compare/v0.7.3...v0.7.4

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -639,9 +639,6 @@ impl<'a> TcpSocket<'a> {
         self.tx_buffer.clear();
         self.rx_buffer.clear();
         self.rx_fin_received = false;
-        self.keep_alive = None;
-        self.timeout = None;
-        self.hop_limit = None;
         self.listen_address = IpAddress::default();
         self.local_endpoint = IpEndpoint::default();
         self.remote_endpoint = IpEndpoint::default();
@@ -655,11 +652,8 @@ impl<'a> TcpSocket<'a> {
         self.remote_win_shift = rx_cap_log2.saturating_sub(16) as u8;
         self.remote_mss = DEFAULT_MSS;
         self.remote_last_ts = None;
-        self.ack_delay = Some(ACK_DELAY_DEFAULT);
         self.ack_delay_timer = AckDelayTimer::Idle;
         self.challenge_ack_timer = Instant::from_secs(0);
-
-        self.nagle = true;
 
         #[cfg(feature = "async")]
         {
@@ -6360,6 +6354,11 @@ mod test {
             }),
             Ok(())
         );
+
+        // assert that user-configurable settings are kept,
+        // see https://github.com/smoltcp-rs/smoltcp/issues/601.
+        s.reset();
+        assert_eq!(s.hop_limit(), Some(0x2a));
     }
 
     #[test]

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -230,7 +230,8 @@ impl<'a> UdpSocket<'a> {
     ///
     /// See also [send](#method.send).
     pub fn send_slice(&mut self, data: &[u8], remote_endpoint: IpEndpoint) -> Result<()> {
-        self.send(data.len(), remote_endpoint)?.copy_from_slice(data);
+        self.send(data.len(), remote_endpoint)?
+            .copy_from_slice(data);
         Ok(())
     }
 

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -207,20 +207,20 @@ impl<'a> UdpSocket<'a> {
     /// `Err(Error::Unaddressable)` if local or remote port, or remote address are unspecified,
     /// and `Err(Error::Truncated)` if there is not enough transmit buffer capacity
     /// to ever send this packet.
-    pub fn send(&mut self, size: usize, endpoint: IpEndpoint) -> Result<&mut [u8]> {
+    pub fn send(&mut self, size: usize, remote_endpoint: IpEndpoint) -> Result<&mut [u8]> {
         if self.endpoint.port == 0 {
             return Err(Error::Unaddressable);
         }
-        if !endpoint.is_specified() {
+        if !remote_endpoint.is_specified() {
             return Err(Error::Unaddressable);
         }
 
-        let payload_buf = self.tx_buffer.enqueue(size, endpoint)?;
+        let payload_buf = self.tx_buffer.enqueue(size, remote_endpoint)?;
 
         net_trace!(
             "udp:{}:{}: buffer to send {} octets",
             self.endpoint,
-            endpoint,
+            remote_endpoint,
             size
         );
         Ok(payload_buf)
@@ -229,8 +229,8 @@ impl<'a> UdpSocket<'a> {
     /// Enqueue a packet to be sent to a given remote endpoint, and fill it from a slice.
     ///
     /// See also [send](#method.send).
-    pub fn send_slice(&mut self, data: &[u8], endpoint: IpEndpoint) -> Result<()> {
-        self.send(data.len(), endpoint)?.copy_from_slice(data);
+    pub fn send_slice(&mut self, data: &[u8], remote_endpoint: IpEndpoint) -> Result<()> {
+        self.send(data.len(), remote_endpoint)?.copy_from_slice(data);
         Ok(())
     }
 
@@ -239,15 +239,15 @@ impl<'a> UdpSocket<'a> {
     ///
     /// This function returns `Err(Error::Exhausted)` if the receive buffer is empty.
     pub fn recv(&mut self) -> Result<(&[u8], IpEndpoint)> {
-        let (endpoint, payload_buf) = self.rx_buffer.dequeue()?;
+        let (remote_endpoint, payload_buf) = self.rx_buffer.dequeue()?;
 
         net_trace!(
             "udp:{}:{}: receive {} buffered octets",
             self.endpoint,
-            endpoint,
+            remote_endpoint,
             payload_buf.len()
         );
-        Ok((payload_buf, endpoint))
+        Ok((payload_buf, remote_endpoint))
     }
 
     /// Dequeue a packet received from a remote endpoint, copy the payload into the given slice,
@@ -318,7 +318,7 @@ impl<'a> UdpSocket<'a> {
 
         let size = payload.len();
 
-        let endpoint = IpEndpoint {
+        let remote_endpoint = IpEndpoint {
             addr: ip_repr.src_addr(),
             port: repr.src_port,
         };
@@ -331,13 +331,13 @@ impl<'a> UdpSocket<'a> {
         }
 
         self.rx_buffer
-            .enqueue(size, endpoint)?
+            .enqueue(size, remote_endpoint)?
             .copy_from_slice(payload);
 
         net_trace!(
             "udp:{}:{}: receiving {} octets",
             self.endpoint,
-            endpoint,
+            remote_endpoint,
             size
         );
 
@@ -359,7 +359,7 @@ impl<'a> UdpSocket<'a> {
                 net_trace!(
                     "udp:{}:{}: sending {} octets",
                     endpoint,
-                    endpoint,
+                    remote_endpoint,
                     payload_buf.len()
                 );
 

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -327,7 +327,7 @@ impl<'a> UdpSocket<'a> {
         // If local address is not provided, choose it automatically.
         if self.endpoint.addr.is_unspecified() {
             self.endpoint.addr = cx
-                .get_source_address(endpoint.addr)
+                .get_source_address(remote_endpoint.addr)
                 .ok_or(Error::Unaddressable)?;
         }
 

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -322,6 +322,14 @@ impl<'a> UdpSocket<'a> {
             addr: ip_repr.src_addr(),
             port: repr.src_port,
         };
+
+        // If local address is not provided, choose it automatically.
+        if self.endpoint.addr.is_unspecified() {
+            self.endpoint.addr = cx
+                .get_source_address(endpoint.addr)
+                .ok_or(Error::Unaddressable)?;
+        }
+
         self.rx_buffer
             .enqueue(size, endpoint)?
             .copy_from_slice(payload);


### PR DESCRIPTION
Fixes issue where UDP source address is `UNSPECIFIED`. I saw that this method was used in the TCP socket.
