### PR TITLE
Resolve unspecified source address in IP dispatching

### DIFF
--- a/src/iface/interface.rs
+++ b/src/iface/interface.rs
@@ -2416,7 +2416,15 @@ impl<'a> InterfaceInner<'a> {
     }
 
     fn dispatch_ip<Tx: TxToken>(&mut self, tx_token: Tx, packet: IpPacket) -> Result<()> {
-        let ip_repr = packet.ip_repr();
+        let mut ip_repr = packet.ip_repr();
+
+        if ip_repr.src_addr().is_unspecified() {
+            ip_repr.set_src_addr(
+                self.get_source_address(ip_repr.dst_addr())
+                    .ok_or(Error::Unaddressable)?,
+            );
+        }
+
         assert!(!ip_repr.src_addr().is_unspecified());
         assert!(!ip_repr.dst_addr().is_unspecified());
 

--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -635,8 +635,6 @@ mod test {
     macro_rules! send {
         ($socket:ident, $repr:expr) =>
             (send!($socket, time 0, $repr));
-        ($socket:ident, $repr:expr, $result:expr) =>
-            (send!($socket, time 0, $repr, $result));
         ($socket:ident, time $time:expr, $repr:expr) =>
             (send!($socket, time $time, $repr, Ok(( ))));
         ($socket:ident, time $time:expr, $repr:expr, $result:expr) =>

--- a/src/wire/ip.rs
+++ b/src/wire/ip.rs
@@ -562,6 +562,22 @@ impl Repr {
                 payload_len,
                 hop_limit,
             }),
+            #[cfg(feature = "proto-ipv4")]
+            (Address::Unspecified, Address::Ipv4(dst_addr)) => Self::Ipv4(Ipv4Repr {
+                src_addr: Ipv4Address::UNSPECIFIED,
+                dst_addr,
+                next_header,
+                payload_len,
+                hop_limit,
+            }),
+            #[cfg(feature = "proto-ipv6")]
+            (Address::Unspecified, Address::Ipv6(dst_addr)) => Self::Ipv6(Ipv6Repr {
+                src_addr: Ipv6Address::UNSPECIFIED,
+                dst_addr,
+                next_header,
+                payload_len,
+                hop_limit,
+            }),
             _ => panic!("IP version mismatch: src={:?} dst={:?}", src_addr, dst_addr),
         }
     }
@@ -583,6 +599,21 @@ impl Repr {
             Repr::Ipv4(repr) => Address::Ipv4(repr.src_addr),
             #[cfg(feature = "proto-ipv6")]
             Repr::Ipv6(repr) => Address::Ipv6(repr.src_addr),
+        }
+    }
+
+    /// Set the source address.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the IP representation and the address don't have the same IP version.
+    pub(crate) fn set_src_addr(&mut self, src_addr: Address) {
+        match (self, src_addr) {
+            #[cfg(feature = "proto-ipv4")]
+            (Repr::Ipv4(repr), Address::Ipv4(addr)) => repr.src_addr = addr,
+            #[cfg(feature = "proto-ipv6")]
+            (Repr::Ipv6(repr), Address::Ipv6(addr)) => repr.src_addr = addr,
+            _ => panic!("source IP address does not match IP packet version"),
         }
     }
 


### PR DESCRIPTION
`IpRepr::new` now also accepts unspecified source addresses. `dispatch_ip` now checks if the source address is unspecified and tries to resolve it.

This fixes #613 and #599.