### PR TITLE
Remove IpAddress::Unspecified, assign src addr in sockets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- No unreleased changes.
+- Remove IpRepr::Unspecified (#579)
+- Remove IpVersion::Unspecified
+- Remove IpAddress::Unspecified
+- When sending packets with a raw socket, the source IP address is sent unmodified (it was previously replaced with the interface's address if it was unspecified).
 
 ## [0.8.1] - 2022-05-12
 

--- a/README.md
+++ b/README.md
@@ -276,6 +276,14 @@ sudo ip link set br0 up
 sudo dhcpcd br0
 ```
 
+To tear down:
+
+```
+sudo killall dhcpcd
+sudo ip link set br0 down
+sudo brctl delbr br0
+```
+
 ### Fault injection
 
 In order to demonstrate the response of _smoltcp_ to adverse network conditions, all examples

--- a/examples/loopback.rs
+++ b/examples/loopback.rs
@@ -150,11 +150,7 @@ fn main() {
             if !did_connect {
                 debug!("connecting");
                 socket
-                    .connect(
-                        cx,
-                        (IpAddress::v4(127, 0, 0, 1), 1234),
-                        (IpAddress::Unspecified, 65000),
-                    )
+                    .connect(cx, (IpAddress::v4(127, 0, 0, 1), 1234), 65000)
                     .unwrap();
                 did_connect = true;
             }

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -195,7 +195,6 @@ fn main() {
                         &device_caps.checksum,
                     );
                 }
-                _ => unimplemented!(),
             }
 
             waiting_queue.insert(seq_no, timestamp);
@@ -239,7 +238,6 @@ fn main() {
                         received
                     );
                 }
-                _ => unimplemented!(),
             }
         }
 

--- a/src/iface/route.rs
+++ b/src/iface/route.rs
@@ -134,7 +134,6 @@ impl<'a> Routes<'a> {
             IpAddress::Ipv4(addr) => IpCidr::Ipv4(Ipv4Cidr::new(*addr, 32)),
             #[cfg(feature = "proto-ipv6")]
             IpAddress::Ipv6(addr) => IpCidr::Ipv6(Ipv6Cidr::new(*addr, 128)),
-            _ => unimplemented!(),
         };
 
         for (prefix, route) in self

--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -635,8 +635,6 @@ mod test {
     macro_rules! send {
         ($socket:ident, $repr:expr) =>
             (send!($socket, time 0, $repr));
-        ($socket:ident, $repr:expr, $result:expr) =>
-            (send!($socket, time 0, $repr, $result));
         ($socket:ident, time $time:expr, $repr:expr) =>
             (send!($socket, time $time, $repr, Ok(( ))));
         ($socket:ident, time $time:expr, $repr:expr, $result:expr) =>

--- a/src/socket/raw.rs
+++ b/src/socket/raw.rs
@@ -277,7 +277,6 @@ impl<'a> RawSocket<'a> {
                     let ipv6_repr = Ipv6Repr::parse(&packet)?;
                     Ok((IpRepr::Ipv6(ipv6_repr), packet.payload()))
                 }
-                IpVersion::Unspecified => unreachable!(),
             }
         }
 

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -106,7 +106,7 @@ impl RttEstimator {
     fn sample(&mut self, new_rtt: u32) {
         // "Congestion Avoidance and Control", Van Jacobson, Michael J. Karels, 1988
         self.rtt = (self.rtt * 7 + new_rtt + 7) / 8;
-        let diff = (self.rtt as i32 - new_rtt as i32).abs() as u32;
+        let diff = (self.rtt as i32 - new_rtt as i32).unsigned_abs();
         self.deviation = (self.deviation * 3 + diff + 3) / 4;
 
         self.rto_count = 0;

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -300,7 +300,7 @@ impl<'a> UdpSocket<'a> {
         if self.endpoint.port != repr.dst_port {
             return false;
         }
-        if !self.endpoint.addr.is_none()
+        if self.endpoint.addr.is_some()
             && self.endpoint.addr != Some(ip_repr.dst_addr())
             && !ip_repr.dst_addr().is_broadcast()
             && !ip_repr.dst_addr().is_multicast()

--- a/src/time.rs
+++ b/src/time.rs
@@ -164,7 +164,7 @@ impl ops::Sub<Instant> for Instant {
     type Output = Duration;
 
     fn sub(self, rhs: Instant) -> Duration {
-        Duration::from_micros((self.micros - rhs.micros).abs() as u64)
+        Duration::from_micros((self.micros - rhs.micros).unsigned_abs())
     }
 }
 

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -157,8 +157,9 @@ pub use self::ieee802154::{
 };
 
 pub use self::ip::{
-    Address as IpAddress, Cidr as IpCidr, Endpoint as IpEndpoint, Protocol as IpProtocol,
-    Repr as IpRepr, Version as IpVersion,
+    Address as IpAddress, Cidr as IpCidr, Endpoint as IpEndpoint,
+    ListenEndpoint as IpListenEndpoint, Protocol as IpProtocol, Repr as IpRepr,
+    Version as IpVersion,
 };
 
 #[cfg(feature = "proto-ipv4")]


### PR DESCRIPTION
Continue work started in #579, with the goal of "remove unspecified variants from wire".

"unspecified" variants are bad, they've been a source of bugs in the past. The issue with them is that 
depending on the context it may or may not make sense for the value to be unspecified.
It's better to not have them, and then use Option only where the value can really be unspecified.

This removes lots of `Address::Unspecified => unreachable!()` and similar match arms, which shows the 
unreachable variant was actively unwanted in many places.

This fixes the "unspecified src addr" panic:

- Picking src addr is now the resposibility of the sockets, not the interface. All sockets now emit IpReprs with properly assigned src addr.
- Removed the `assert!(!ip_repr.src_addr().is_unspecified());`. This assert is WRONG even if
  now sockets pick the source address, because there ARE cases where we indeed want to send a
  packet with zero src addr, for example in DHCP.

fixes #613
fixes #599
