### PR TITLE
Error refactor, part 1

### DIFF
--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -13,7 +13,7 @@ use std::thread;
 
 use smoltcp::iface::{InterfaceBuilder, NeighborCache};
 use smoltcp::phy::{wait as phy_wait, Device, Medium};
-use smoltcp::socket::{TcpSocket, TcpSocketBuffer};
+use smoltcp::socket::tcp;
 use smoltcp::time::{Duration, Instant};
 use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr};
 
@@ -85,13 +85,13 @@ fn main() {
 
     let neighbor_cache = NeighborCache::new(BTreeMap::new());
 
-    let tcp1_rx_buffer = TcpSocketBuffer::new(vec![0; 65535]);
-    let tcp1_tx_buffer = TcpSocketBuffer::new(vec![0; 65535]);
-    let tcp1_socket = TcpSocket::new(tcp1_rx_buffer, tcp1_tx_buffer);
+    let tcp1_rx_buffer = tcp::SocketBuffer::new(vec![0; 65535]);
+    let tcp1_tx_buffer = tcp::SocketBuffer::new(vec![0; 65535]);
+    let tcp1_socket = tcp::Socket::new(tcp1_rx_buffer, tcp1_tx_buffer);
 
-    let tcp2_rx_buffer = TcpSocketBuffer::new(vec![0; 65535]);
-    let tcp2_tx_buffer = TcpSocketBuffer::new(vec![0; 65535]);
-    let tcp2_socket = TcpSocket::new(tcp2_rx_buffer, tcp2_tx_buffer);
+    let tcp2_rx_buffer = tcp::SocketBuffer::new(vec![0; 65535]);
+    let tcp2_tx_buffer = tcp::SocketBuffer::new(vec![0; 65535]);
+    let tcp2_socket = tcp::Socket::new(tcp2_rx_buffer, tcp2_tx_buffer);
 
     let ethernet_addr = EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]);
     let ip_addrs = [IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24)];
@@ -119,7 +119,7 @@ fn main() {
         }
 
         // tcp:1234: emit data
-        let socket = iface.get_socket::<TcpSocket>(tcp1_handle);
+        let socket = iface.get_socket::<tcp::Socket>(tcp1_handle);
         if !socket.is_open() {
             socket.listen(1234).unwrap();
         }
@@ -137,7 +137,7 @@ fn main() {
         }
 
         // tcp:1235: sink data
-        let socket = iface.get_socket::<TcpSocket>(tcp2_handle);
+        let socket = iface.get_socket::<tcp::Socket>(tcp2_handle);
         if !socket.is_open() {
             socket.listen(1235).unwrap();
         }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -7,7 +7,7 @@ use std::str::{self, FromStr};
 
 use smoltcp::iface::{InterfaceBuilder, NeighborCache, Routes};
 use smoltcp::phy::{wait as phy_wait, Device, Medium};
-use smoltcp::socket::{TcpSocket, TcpSocketBuffer};
+use smoltcp::socket::tcp;
 use smoltcp::time::Instant;
 use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr, Ipv4Address};
 
@@ -30,9 +30,9 @@ fn main() {
 
     let neighbor_cache = NeighborCache::new(BTreeMap::new());
 
-    let tcp_rx_buffer = TcpSocketBuffer::new(vec![0; 64]);
-    let tcp_tx_buffer = TcpSocketBuffer::new(vec![0; 128]);
-    let tcp_socket = TcpSocket::new(tcp_rx_buffer, tcp_tx_buffer);
+    let tcp_rx_buffer = tcp::SocketBuffer::new(vec![0; 64]);
+    let tcp_tx_buffer = tcp::SocketBuffer::new(vec![0; 128]);
+    let tcp_socket = tcp::Socket::new(tcp_rx_buffer, tcp_tx_buffer);
 
     let ethernet_addr = EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x02]);
     let ip_addrs = [IpCidr::new(IpAddress::v4(192, 168, 69, 2), 24)];
@@ -54,7 +54,7 @@ fn main() {
 
     let tcp_handle = iface.add_socket(tcp_socket);
 
-    let (socket, cx) = iface.get_socket_and_context::<TcpSocket>(tcp_handle);
+    let (socket, cx) = iface.get_socket_and_context::<tcp::Socket>(tcp_handle);
     socket.connect(cx, (address, port), 49500).unwrap();
 
     let mut tcp_active = false;
@@ -67,7 +67,7 @@ fn main() {
             }
         }
 
-        let socket = iface.get_socket::<TcpSocket>(tcp_handle);
+        let socket = iface.get_socket::<tcp::Socket>(tcp_handle);
         if socket.is_active() && !tcp_active {
             debug!("connected");
         } else if !socket.is_active() && tcp_active {

--- a/examples/dhcp_client.rs
+++ b/examples/dhcp_client.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 use std::os::unix::io::AsRawFd;
 
 use smoltcp::iface::{Interface, InterfaceBuilder, NeighborCache, Routes};
-use smoltcp::socket::{Dhcpv4Event, Dhcpv4Socket};
+use smoltcp::socket::dhcpv4;
 use smoltcp::time::Instant;
 use smoltcp::wire::{EthernetAddress, IpCidr, Ipv4Address, Ipv4Cidr};
 use smoltcp::{
@@ -44,7 +44,7 @@ fn main() {
     }
     let mut iface = builder.finalize();
 
-    let mut dhcp_socket = Dhcpv4Socket::new();
+    let mut dhcp_socket = dhcpv4::Socket::new();
 
     // Set a ridiculously short max lease time to show DHCP renews work properly.
     // This will cause the DHCP client to start renewing after 5 seconds, and give up the
@@ -60,10 +60,10 @@ fn main() {
             debug!("poll error: {}", e);
         }
 
-        let event = iface.get_socket::<Dhcpv4Socket>(dhcp_handle).poll();
+        let event = iface.get_socket::<dhcpv4::Socket>(dhcp_handle).poll();
         match event {
             None => {}
-            Some(Dhcpv4Event::Configured(config)) => {
+            Some(dhcpv4::Event::Configured(config)) => {
                 debug!("DHCP config acquired!");
 
                 debug!("IP address:      {}", config.address);
@@ -83,7 +83,7 @@ fn main() {
                     }
                 }
             }
-            Some(Dhcpv4Event::Deconfigured) => {
+            Some(dhcpv4::Event::Deconfigured) => {
                 debug!("DHCP lost config!");
                 set_ipv4_addr(&mut iface, Ipv4Cidr::new(Ipv4Address::UNSPECIFIED, 0));
                 iface.routes_mut().remove_default_ipv4_route();

--- a/examples/dns.rs
+++ b/examples/dns.rs
@@ -10,12 +10,11 @@ mod utils;
 use smoltcp::iface::{InterfaceBuilder, NeighborCache, Routes};
 use smoltcp::phy::Device;
 use smoltcp::phy::{wait as phy_wait, Medium};
-use smoltcp::socket::dns;
+use smoltcp::socket::dns::{self, GetQueryResultError};
 use smoltcp::time::Instant;
 use smoltcp::wire::{
     EthernetAddress, HardwareAddress, IpAddress, IpCidr, Ipv4Address, Ipv6Address,
 };
-use smoltcp::Error;
 use std::collections::BTreeMap;
 use std::os::unix::io::AsRawFd;
 
@@ -90,7 +89,7 @@ fn main() {
                 println!("Query done: {:?}", addrs);
                 break;
             }
-            Err(Error::Exhausted) => {} // not done yet
+            Err(GetQueryResultError::Pending) => {} // not done yet
             Err(e) => panic!("query failed: {:?}", e),
         }
 

--- a/examples/dns.rs
+++ b/examples/dns.rs
@@ -10,7 +10,7 @@ mod utils;
 use smoltcp::iface::{InterfaceBuilder, NeighborCache, Routes};
 use smoltcp::phy::Device;
 use smoltcp::phy::{wait as phy_wait, Medium};
-use smoltcp::socket::DnsSocket;
+use smoltcp::socket::dns;
 use smoltcp::time::Instant;
 use smoltcp::wire::{
     EthernetAddress, HardwareAddress, IpAddress, IpCidr, Ipv4Address, Ipv6Address,
@@ -39,7 +39,7 @@ fn main() {
         Ipv4Address::new(8, 8, 4, 4).into(),
         Ipv4Address::new(8, 8, 8, 8).into(),
     ];
-    let dns_socket = DnsSocket::new(servers, vec![]);
+    let dns_socket = dns::Socket::new(servers, vec![]);
 
     let ethernet_addr = EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x02]);
     let src_ipv6 = IpAddress::v6(0xfdaa, 0, 0, 0, 0, 0, 0, 1);
@@ -68,7 +68,7 @@ fn main() {
 
     let dns_handle = iface.add_socket(dns_socket);
 
-    let (socket, cx) = iface.get_socket_and_context::<DnsSocket>(dns_handle);
+    let (socket, cx) = iface.get_socket_and_context::<dns::Socket>(dns_handle);
     let query = socket.start_query(cx, name).unwrap();
 
     loop {
@@ -83,7 +83,7 @@ fn main() {
         }
 
         match iface
-            .get_socket::<DnsSocket>(dns_handle)
+            .get_socket::<dns::Socket>(dns_handle)
             .get_query_result(query)
         {
             Ok(addrs) => {

--- a/examples/httpclient.rs
+++ b/examples/httpclient.rs
@@ -8,7 +8,7 @@ use url::Url;
 
 use smoltcp::iface::{InterfaceBuilder, NeighborCache, Routes};
 use smoltcp::phy::{wait as phy_wait, Device, Medium};
-use smoltcp::socket::{TcpSocket, TcpSocketBuffer};
+use smoltcp::socket::tcp;
 use smoltcp::time::Instant;
 use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr, Ipv4Address, Ipv6Address};
 
@@ -30,9 +30,9 @@ fn main() {
 
     let neighbor_cache = NeighborCache::new(BTreeMap::new());
 
-    let tcp_rx_buffer = TcpSocketBuffer::new(vec![0; 1024]);
-    let tcp_tx_buffer = TcpSocketBuffer::new(vec![0; 1024]);
-    let tcp_socket = TcpSocket::new(tcp_rx_buffer, tcp_tx_buffer);
+    let tcp_rx_buffer = tcp::SocketBuffer::new(vec![0; 1024]);
+    let tcp_tx_buffer = tcp::SocketBuffer::new(vec![0; 1024]);
+    let tcp_socket = tcp::Socket::new(tcp_rx_buffer, tcp_tx_buffer);
 
     let ethernet_addr = EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x02]);
     let ip_addrs = [
@@ -76,7 +76,7 @@ fn main() {
             }
         }
 
-        let (socket, cx) = iface.get_socket_and_context::<TcpSocket>(tcp_handle);
+        let (socket, cx) = iface.get_socket_and_context::<tcp::Socket>(tcp_handle);
 
         state = match state {
             State::Connect if !socket.is_active() => {

--- a/examples/loopback.rs
+++ b/examples/loopback.rs
@@ -11,7 +11,7 @@ use log::{debug, error, info};
 
 use smoltcp::iface::{InterfaceBuilder, NeighborCache};
 use smoltcp::phy::{Loopback, Medium};
-use smoltcp::socket::{TcpSocket, TcpSocketBuffer};
+use smoltcp::socket::tcp;
 use smoltcp::time::{Duration, Instant};
 use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr};
 
@@ -100,17 +100,17 @@ fn main() {
         // when stack overflows.
         static mut TCP_SERVER_RX_DATA: [u8; 1024] = [0; 1024];
         static mut TCP_SERVER_TX_DATA: [u8; 1024] = [0; 1024];
-        let tcp_rx_buffer = TcpSocketBuffer::new(unsafe { &mut TCP_SERVER_RX_DATA[..] });
-        let tcp_tx_buffer = TcpSocketBuffer::new(unsafe { &mut TCP_SERVER_TX_DATA[..] });
-        TcpSocket::new(tcp_rx_buffer, tcp_tx_buffer)
+        let tcp_rx_buffer = tcp::SocketBuffer::new(unsafe { &mut TCP_SERVER_RX_DATA[..] });
+        let tcp_tx_buffer = tcp::SocketBuffer::new(unsafe { &mut TCP_SERVER_TX_DATA[..] });
+        tcp::Socket::new(tcp_rx_buffer, tcp_tx_buffer)
     };
 
     let client_socket = {
         static mut TCP_CLIENT_RX_DATA: [u8; 1024] = [0; 1024];
         static mut TCP_CLIENT_TX_DATA: [u8; 1024] = [0; 1024];
-        let tcp_rx_buffer = TcpSocketBuffer::new(unsafe { &mut TCP_CLIENT_RX_DATA[..] });
-        let tcp_tx_buffer = TcpSocketBuffer::new(unsafe { &mut TCP_CLIENT_TX_DATA[..] });
-        TcpSocket::new(tcp_rx_buffer, tcp_tx_buffer)
+        let tcp_rx_buffer = tcp::SocketBuffer::new(unsafe { &mut TCP_CLIENT_RX_DATA[..] });
+        let tcp_tx_buffer = tcp::SocketBuffer::new(unsafe { &mut TCP_CLIENT_TX_DATA[..] });
+        tcp::Socket::new(tcp_rx_buffer, tcp_tx_buffer)
     };
 
     let server_handle = iface.add_socket(server_socket);
@@ -127,7 +127,7 @@ fn main() {
             }
         }
 
-        let mut socket = iface.get_socket::<TcpSocket>(server_handle);
+        let mut socket = iface.get_socket::<tcp::Socket>(server_handle);
         if !socket.is_active() && !socket.is_listening() {
             if !did_listen {
                 debug!("listening");
@@ -145,7 +145,7 @@ fn main() {
             done = true;
         }
 
-        let (mut socket, cx) = iface.get_socket_and_context::<TcpSocket>(client_handle);
+        let (mut socket, cx) = iface.get_socket_and_context::<tcp::Socket>(client_handle);
         if !socket.is_open() {
             if !did_connect {
                 debug!("connecting");

--- a/examples/multicast.rs
+++ b/examples/multicast.rs
@@ -6,9 +6,7 @@ use std::os::unix::io::AsRawFd;
 
 use smoltcp::iface::{InterfaceBuilder, NeighborCache};
 use smoltcp::phy::wait as phy_wait;
-use smoltcp::socket::{
-    RawPacketMetadata, RawSocket, RawSocketBuffer, UdpPacketMetadata, UdpSocket, UdpSocketBuffer,
-};
+use smoltcp::socket::{raw, udp};
 use smoltcp::time::Instant;
 use smoltcp::wire::{
     EthernetAddress, IgmpPacket, IgmpRepr, IpAddress, IpCidr, IpProtocol, IpVersion, Ipv4Address,
@@ -50,10 +48,10 @@ fn main() {
         .unwrap();
 
     // Must fit at least one IGMP packet
-    let raw_rx_buffer = RawSocketBuffer::new(vec![RawPacketMetadata::EMPTY; 2], vec![0; 512]);
+    let raw_rx_buffer = raw::PacketBuffer::new(vec![raw::PacketMetadata::EMPTY; 2], vec![0; 512]);
     // Will not send IGMP
-    let raw_tx_buffer = RawSocketBuffer::new(vec![], vec![]);
-    let raw_socket = RawSocket::new(
+    let raw_tx_buffer = raw::PacketBuffer::new(vec![], vec![]);
+    let raw_socket = raw::Socket::new(
         IpVersion::Ipv4,
         IpProtocol::Igmp,
         raw_rx_buffer,
@@ -62,10 +60,10 @@ fn main() {
     let raw_handle = iface.add_socket(raw_socket);
 
     // Must fit mDNS payload of at least one packet
-    let udp_rx_buffer = UdpSocketBuffer::new(vec![UdpPacketMetadata::EMPTY; 4], vec![0; 1024]);
+    let udp_rx_buffer = udp::PacketBuffer::new(vec![udp::PacketMetadata::EMPTY; 4], vec![0; 1024]);
     // Will not send mDNS
-    let udp_tx_buffer = UdpSocketBuffer::new(vec![UdpPacketMetadata::EMPTY], vec![0; 0]);
-    let udp_socket = UdpSocket::new(udp_rx_buffer, udp_tx_buffer);
+    let udp_tx_buffer = udp::PacketBuffer::new(vec![udp::PacketMetadata::EMPTY], vec![0; 0]);
+    let udp_socket = udp::Socket::new(udp_rx_buffer, udp_tx_buffer);
     let udp_handle = iface.add_socket(udp_socket);
 
     loop {
@@ -77,7 +75,7 @@ fn main() {
             }
         }
 
-        let socket = iface.get_socket::<RawSocket>(raw_handle);
+        let socket = iface.get_socket::<raw::Socket>(raw_handle);
 
         if socket.can_recv() {
             // For display purposes only - normally we wouldn't process incoming IGMP packets
@@ -94,7 +92,7 @@ fn main() {
             }
         }
 
-        let socket = iface.get_socket::<UdpSocket>(udp_handle);
+        let socket = iface.get_socket::<udp::Socket>(udp_handle);
         if !socket.is_open() {
             socket.bind(MDNS_PORT).unwrap()
         }

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -11,7 +11,7 @@ use std::str::FromStr;
 use smoltcp::iface::{InterfaceBuilder, NeighborCache, Routes};
 use smoltcp::phy::wait as phy_wait;
 use smoltcp::phy::Device;
-use smoltcp::socket::{IcmpEndpoint, IcmpPacketMetadata, IcmpSocket, IcmpSocketBuffer};
+use smoltcp::socket::icmp;
 use smoltcp::wire::{
     EthernetAddress, Icmpv4Packet, Icmpv4Repr, Icmpv6Packet, Icmpv6Repr, IpAddress, IpCidr,
     Ipv4Address, Ipv6Address,
@@ -108,9 +108,9 @@ fn main() {
 
     let remote_addr = address;
 
-    let icmp_rx_buffer = IcmpSocketBuffer::new(vec![IcmpPacketMetadata::EMPTY], vec![0; 256]);
-    let icmp_tx_buffer = IcmpSocketBuffer::new(vec![IcmpPacketMetadata::EMPTY], vec![0; 256]);
-    let icmp_socket = IcmpSocket::new(icmp_rx_buffer, icmp_tx_buffer);
+    let icmp_rx_buffer = icmp::PacketBuffer::new(vec![icmp::PacketMetadata::EMPTY], vec![0; 256]);
+    let icmp_tx_buffer = icmp::PacketBuffer::new(vec![icmp::PacketMetadata::EMPTY], vec![0; 256]);
+    let icmp_socket = icmp::Socket::new(icmp_rx_buffer, icmp_tx_buffer);
 
     let ethernet_addr = EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x02]);
     let src_ipv6 = IpAddress::v6(0xfdaa, 0, 0, 0, 0, 0, 0, 1);
@@ -156,9 +156,9 @@ fn main() {
         }
 
         let timestamp = Instant::now();
-        let socket = iface.get_socket::<IcmpSocket>(icmp_handle);
+        let socket = iface.get_socket::<icmp::Socket>(icmp_handle);
         if !socket.is_open() {
-            socket.bind(IcmpEndpoint::Ident(ident)).unwrap();
+            socket.bind(icmp::Endpoint::Ident(ident)).unwrap();
             send_at = timestamp;
         }
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -8,8 +8,7 @@ use std::str;
 
 use smoltcp::iface::{InterfaceBuilder, NeighborCache};
 use smoltcp::phy::{wait as phy_wait, Device, Medium};
-use smoltcp::socket::{TcpSocket, TcpSocketBuffer};
-use smoltcp::socket::{UdpPacketMetadata, UdpSocket, UdpSocketBuffer};
+use smoltcp::socket::{tcp, udp};
 use smoltcp::time::{Duration, Instant};
 use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr};
 
@@ -27,25 +26,25 @@ fn main() {
 
     let neighbor_cache = NeighborCache::new(BTreeMap::new());
 
-    let udp_rx_buffer = UdpSocketBuffer::new(vec![UdpPacketMetadata::EMPTY], vec![0; 64]);
-    let udp_tx_buffer = UdpSocketBuffer::new(vec![UdpPacketMetadata::EMPTY], vec![0; 128]);
-    let udp_socket = UdpSocket::new(udp_rx_buffer, udp_tx_buffer);
+    let udp_rx_buffer = udp::PacketBuffer::new(vec![udp::PacketMetadata::EMPTY], vec![0; 64]);
+    let udp_tx_buffer = udp::PacketBuffer::new(vec![udp::PacketMetadata::EMPTY], vec![0; 128]);
+    let udp_socket = udp::Socket::new(udp_rx_buffer, udp_tx_buffer);
 
-    let tcp1_rx_buffer = TcpSocketBuffer::new(vec![0; 64]);
-    let tcp1_tx_buffer = TcpSocketBuffer::new(vec![0; 128]);
-    let tcp1_socket = TcpSocket::new(tcp1_rx_buffer, tcp1_tx_buffer);
+    let tcp1_rx_buffer = tcp::SocketBuffer::new(vec![0; 64]);
+    let tcp1_tx_buffer = tcp::SocketBuffer::new(vec![0; 128]);
+    let tcp1_socket = tcp::Socket::new(tcp1_rx_buffer, tcp1_tx_buffer);
 
-    let tcp2_rx_buffer = TcpSocketBuffer::new(vec![0; 64]);
-    let tcp2_tx_buffer = TcpSocketBuffer::new(vec![0; 128]);
-    let tcp2_socket = TcpSocket::new(tcp2_rx_buffer, tcp2_tx_buffer);
+    let tcp2_rx_buffer = tcp::SocketBuffer::new(vec![0; 64]);
+    let tcp2_tx_buffer = tcp::SocketBuffer::new(vec![0; 128]);
+    let tcp2_socket = tcp::Socket::new(tcp2_rx_buffer, tcp2_tx_buffer);
 
-    let tcp3_rx_buffer = TcpSocketBuffer::new(vec![0; 65535]);
-    let tcp3_tx_buffer = TcpSocketBuffer::new(vec![0; 65535]);
-    let tcp3_socket = TcpSocket::new(tcp3_rx_buffer, tcp3_tx_buffer);
+    let tcp3_rx_buffer = tcp::SocketBuffer::new(vec![0; 65535]);
+    let tcp3_tx_buffer = tcp::SocketBuffer::new(vec![0; 65535]);
+    let tcp3_socket = tcp::Socket::new(tcp3_rx_buffer, tcp3_tx_buffer);
 
-    let tcp4_rx_buffer = TcpSocketBuffer::new(vec![0; 65535]);
-    let tcp4_tx_buffer = TcpSocketBuffer::new(vec![0; 65535]);
-    let tcp4_socket = TcpSocket::new(tcp4_rx_buffer, tcp4_tx_buffer);
+    let tcp4_rx_buffer = tcp::SocketBuffer::new(vec![0; 65535]);
+    let tcp4_tx_buffer = tcp::SocketBuffer::new(vec![0; 65535]);
+    let tcp4_socket = tcp::Socket::new(tcp4_rx_buffer, tcp4_tx_buffer);
 
     let ethernet_addr = EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]);
     let ip_addrs = [
@@ -80,7 +79,7 @@ fn main() {
         }
 
         // udp:6969: respond "hello"
-        let socket = iface.get_socket::<UdpSocket>(udp_handle);
+        let socket = iface.get_socket::<udp::Socket>(udp_handle);
         if !socket.is_open() {
             socket.bind(6969).unwrap()
         }
@@ -106,7 +105,7 @@ fn main() {
         }
 
         // tcp:6969: respond "hello"
-        let socket = iface.get_socket::<TcpSocket>(tcp1_handle);
+        let socket = iface.get_socket::<tcp::Socket>(tcp1_handle);
         if !socket.is_open() {
             socket.listen(6969).unwrap();
         }
@@ -119,7 +118,7 @@ fn main() {
         }
 
         // tcp:6970: echo with reverse
-        let socket = iface.get_socket::<TcpSocket>(tcp2_handle);
+        let socket = iface.get_socket::<tcp::Socket>(tcp2_handle);
         if !socket.is_open() {
             socket.listen(6970).unwrap()
         }
@@ -161,7 +160,7 @@ fn main() {
         }
 
         // tcp:6971: sinkhole
-        let socket = iface.get_socket::<TcpSocket>(tcp3_handle);
+        let socket = iface.get_socket::<tcp::Socket>(tcp3_handle);
         if !socket.is_open() {
             socket.listen(6971).unwrap();
             socket.set_keep_alive(Some(Duration::from_millis(1000)));
@@ -182,7 +181,7 @@ fn main() {
         }
 
         // tcp:6972: fountain
-        let socket = iface.get_socket::<TcpSocket>(tcp4_handle);
+        let socket = iface.get_socket::<tcp::Socket>(tcp4_handle);
         if !socket.is_open() {
             socket.listen(6972).unwrap()
         }

--- a/examples/sixlowpan.rs
+++ b/examples/sixlowpan.rs
@@ -49,7 +49,7 @@ use std::str;
 
 use smoltcp::iface::{InterfaceBuilder, NeighborCache};
 use smoltcp::phy::{wait as phy_wait, Medium, RawSocket};
-use smoltcp::socket::{UdpPacketMetadata, UdpSocket, UdpSocketBuffer};
+use smoltcp::socket::udp;
 use smoltcp::time::Instant;
 use smoltcp::wire::{Ieee802154Pan, IpAddress, IpCidr};
 
@@ -68,9 +68,9 @@ fn main() {
 
     let neighbor_cache = NeighborCache::new(BTreeMap::new());
 
-    let udp_rx_buffer = UdpSocketBuffer::new(vec![UdpPacketMetadata::EMPTY], vec![0; 64]);
-    let udp_tx_buffer = UdpSocketBuffer::new(vec![UdpPacketMetadata::EMPTY], vec![0; 128]);
-    let udp_socket = UdpSocket::new(udp_rx_buffer, udp_tx_buffer);
+    let udp_rx_buffer = udp::PacketBuffer::new(vec![udp::PacketMetadata::EMPTY], vec![0; 64]);
+    let udp_tx_buffer = udp::PacketBuffer::new(vec![udp::PacketMetadata::EMPTY], vec![0; 128]);
+    let udp_socket = udp::Socket::new(udp_rx_buffer, udp_tx_buffer);
 
     let ieee802154_addr = smoltcp::wire::Ieee802154Address::Extended([
         0x1a, 0x0b, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42,
@@ -100,7 +100,7 @@ fn main() {
         }
 
         // udp:6969: respond "hello"
-        let socket = iface.get_socket::<UdpSocket>(udp_handle);
+        let socket = iface.get_socket::<udp::Socket>(udp_handle);
         if !socket.is_open() {
             socket.bind(6969).unwrap()
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,3 +252,9 @@ impl fmt::Display for Error {
         }
     }
 }
+
+impl From<wire::Error> for Error {
+    fn from(_: wire::Error) -> Self {
+        Error::Malformed
+    }
+}

--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -110,7 +110,7 @@ pub enum Event {
 }
 
 #[derive(Debug)]
-pub struct Dhcpv4Socket {
+pub struct Socket {
     /// State of the DHCP client.
     state: ClientState,
     /// Set to true on config/state change, cleared back to false by the `config` function.
@@ -131,11 +131,11 @@ pub struct Dhcpv4Socket {
 /// The socket acquires an IP address configuration through DHCP autonomously.
 /// You must query the configuration with `.poll()` after every call to `Interface::poll()`,
 /// and apply the configuration to the `Interface`.
-impl Dhcpv4Socket {
+impl Socket {
     /// Create a DHCPv4 socket
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
-        Dhcpv4Socket {
+        Socket {
             state: ClientState::Discovering(DiscoverState {
                 retry_at: Instant::from_millis(0),
             }),
@@ -561,12 +561,12 @@ mod test {
     // Helper functions
 
     struct TestSocket {
-        socket: Dhcpv4Socket,
+        socket: Socket,
         cx: Context<'static>,
     }
 
     impl Deref for TestSocket {
-        type Target = Dhcpv4Socket;
+        type Target = Socket;
         fn deref(&self) -> &Self::Target {
             &self.socket
         }
@@ -797,7 +797,7 @@ mod test {
     // Tests
 
     fn socket() -> TestSocket {
-        let mut s = Dhcpv4Socket::new();
+        let mut s = Socket::new();
         assert_eq!(s.poll(), Some(Event::Deconfigured));
         TestSocket {
             socket: s,

--- a/src/socket/dns.rs
+++ b/src/socket/dns.rs
@@ -4,7 +4,7 @@ use core::task::Waker;
 use heapless::Vec;
 use managed::ManagedSlice;
 
-use crate::socket::{Context, PollAt, Socket};
+use crate::socket::{Context, PollAt};
 use crate::time::{Duration, Instant};
 use crate::wire::dns::{Flags, Opcode, Packet, Question, Rcode, Record, RecordData, Repr, Type};
 use crate::wire::{self, IpAddress, IpProtocol, IpRepr, UdpRepr};
@@ -78,7 +78,7 @@ pub struct QueryHandle(usize);
 /// A UDP socket is bound to a specific endpoint, and owns transmit and receive
 /// packet buffers.
 #[derive(Debug)]
-pub struct DnsSocket<'a> {
+pub struct Socket<'a> {
     servers: Vec<IpAddress, MAX_SERVER_COUNT>,
     queries: ManagedSlice<'a, Option<DnsQuery>>,
 
@@ -86,17 +86,17 @@ pub struct DnsSocket<'a> {
     hop_limit: Option<u8>,
 }
 
-impl<'a> DnsSocket<'a> {
+impl<'a> Socket<'a> {
     /// Create a DNS socket.
     ///
     /// # Panics
     ///
     /// Panics if `servers.len() > MAX_SERVER_COUNT`
-    pub fn new<Q>(servers: &[IpAddress], queries: Q) -> DnsSocket<'a>
+    pub fn new<Q>(servers: &[IpAddress], queries: Q) -> Socket<'a>
     where
         Q: Into<ManagedSlice<'a, Option<DnsQuery>>>,
     {
-        DnsSocket {
+        Socket {
             servers: Vec::from_slice(servers).unwrap(),
             queries: queries.into(),
             hop_limit: None,
@@ -499,12 +499,6 @@ impl<'a> DnsSocket<'a> {
             })
             .min()
             .unwrap_or(PollAt::Ingress)
-    }
-}
-
-impl<'a> From<DnsSocket<'a>> for Socket<'a> {
-    fn from(val: DnsSocket<'a>) -> Self {
-        Socket::Dns(val)
     }
 }
 

--- a/src/socket/dns.rs
+++ b/src/socket/dns.rs
@@ -7,7 +7,7 @@ use managed::ManagedSlice;
 use crate::socket::{Context, PollAt, Socket};
 use crate::time::{Duration, Instant};
 use crate::wire::dns::{Flags, Opcode, Packet, Question, Rcode, Record, RecordData, Repr, Type};
-use crate::wire::{IpAddress, IpProtocol, IpRepr, UdpRepr};
+use crate::wire::{self, IpAddress, IpProtocol, IpRepr, UdpRepr};
 use crate::{Error, Result};
 
 #[cfg(feature = "async")]
@@ -509,9 +509,9 @@ impl<'a> From<DnsSocket<'a>> for Socket<'a> {
 }
 
 fn eq_names<'a>(
-    mut a: impl Iterator<Item = Result<&'a [u8]>>,
-    mut b: impl Iterator<Item = Result<&'a [u8]>>,
-) -> Result<bool> {
+    mut a: impl Iterator<Item = wire::Result<&'a [u8]>>,
+    mut b: impl Iterator<Item = wire::Result<&'a [u8]>>,
+) -> wire::Result<bool> {
     loop {
         match (a.next(), b.next()) {
             // Handle errors
@@ -537,7 +537,7 @@ fn eq_names<'a>(
 
 fn copy_name<'a, const N: usize>(
     dest: &mut Vec<u8, N>,
-    name: impl Iterator<Item = Result<&'a [u8]>>,
+    name: impl Iterator<Item = wire::Result<&'a [u8]>>,
 ) -> Result<()> {
     dest.truncate(0);
 

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -15,33 +15,20 @@ use crate::iface::Context;
 use crate::time::Instant;
 
 #[cfg(feature = "socket-dhcpv4")]
-mod dhcpv4;
+pub mod dhcpv4;
 #[cfg(feature = "socket-dns")]
-mod dns;
+pub mod dns;
 #[cfg(feature = "socket-icmp")]
-mod icmp;
+pub mod icmp;
 #[cfg(feature = "socket-raw")]
-mod raw;
+pub mod raw;
 #[cfg(feature = "socket-tcp")]
-mod tcp;
+pub mod tcp;
 #[cfg(feature = "socket-udp")]
-mod udp;
+pub mod udp;
 
 #[cfg(feature = "async")]
 mod waker;
-
-#[cfg(feature = "socket-dhcpv4")]
-pub use self::dhcpv4::{Config as Dhcpv4Config, Dhcpv4Socket, Event as Dhcpv4Event};
-#[cfg(feature = "socket-dns")]
-pub use self::dns::{DnsQuery, DnsSocket, QueryHandle as DnsQueryHandle};
-#[cfg(feature = "socket-icmp")]
-pub use self::icmp::{Endpoint as IcmpEndpoint, IcmpPacketMetadata, IcmpSocket, IcmpSocketBuffer};
-#[cfg(feature = "socket-raw")]
-pub use self::raw::{RawPacketMetadata, RawSocket, RawSocketBuffer};
-#[cfg(feature = "socket-tcp")]
-pub use self::tcp::{SocketBuffer as TcpSocketBuffer, State as TcpState, TcpSocket};
-#[cfg(feature = "socket-udp")]
-pub use self::udp::{UdpPacketMetadata, UdpSocket, UdpSocketBuffer};
 
 #[cfg(feature = "async")]
 pub(crate) use self::waker::WakerRegistration;
@@ -62,7 +49,7 @@ pub(crate) enum PollAt {
 ///
 /// This enumeration abstracts the various types of sockets based on the IP protocol.
 /// To downcast a `Socket` value to a concrete socket, use the [AnySocket] trait,
-/// e.g. to get `UdpSocket`, call `UdpSocket::downcast(socket)`.
+/// e.g. to get `udp::Socket`, call `udp::Socket::downcast(socket)`.
 ///
 /// It is usually more convenient to use [SocketSet::get] instead.
 ///
@@ -71,17 +58,17 @@ pub(crate) enum PollAt {
 #[derive(Debug)]
 pub enum Socket<'a> {
     #[cfg(feature = "socket-raw")]
-    Raw(RawSocket<'a>),
+    Raw(raw::Socket<'a>),
     #[cfg(feature = "socket-icmp")]
-    Icmp(IcmpSocket<'a>),
+    Icmp(icmp::Socket<'a>),
     #[cfg(feature = "socket-udp")]
-    Udp(UdpSocket<'a>),
+    Udp(udp::Socket<'a>),
     #[cfg(feature = "socket-tcp")]
-    Tcp(TcpSocket<'a>),
+    Tcp(tcp::Socket<'a>),
     #[cfg(feature = "socket-dhcpv4")]
-    Dhcpv4(Dhcpv4Socket),
+    Dhcpv4(dhcpv4::Socket),
     #[cfg(feature = "socket-dns")]
-    Dns(DnsSocket<'a>),
+    Dns(dns::Socket<'a>),
 }
 
 impl<'a> Socket<'a> {
@@ -128,14 +115,14 @@ macro_rules! from_socket {
 }
 
 #[cfg(feature = "socket-raw")]
-from_socket!(RawSocket<'a>, Raw);
+from_socket!(raw::Socket<'a>, Raw);
 #[cfg(feature = "socket-icmp")]
-from_socket!(IcmpSocket<'a>, Icmp);
+from_socket!(icmp::Socket<'a>, Icmp);
 #[cfg(feature = "socket-udp")]
-from_socket!(UdpSocket<'a>, Udp);
+from_socket!(udp::Socket<'a>, Udp);
 #[cfg(feature = "socket-tcp")]
-from_socket!(TcpSocket<'a>, Tcp);
+from_socket!(tcp::Socket<'a>, Tcp);
 #[cfg(feature = "socket-dhcpv4")]
-from_socket!(Dhcpv4Socket, Dhcpv4);
+from_socket!(dhcpv4::Socket, Dhcpv4);
 #[cfg(feature = "socket-dns")]
-from_socket!(DnsSocket<'a>, Dns);
+from_socket!(dns::Socket<'a>, Dns);

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -326,7 +326,7 @@ impl Display for Tuple {
 /// accept several connections, as many sockets must be allocated, or any new connection
 /// attempts will be reset.
 #[derive(Debug)]
-pub struct TcpSocket<'a> {
+pub struct Socket<'a> {
     state: State,
     timer: Timer,
     rtte: RttEstimator,
@@ -401,10 +401,10 @@ pub struct TcpSocket<'a> {
 
 const DEFAULT_MSS: usize = 536;
 
-impl<'a> TcpSocket<'a> {
+impl<'a> Socket<'a> {
     #[allow(unused_comparisons)] // small usize platforms always pass rx_capacity check
     /// Create a socket using the given buffers.
-    pub fn new<T>(rx_buffer: T, tx_buffer: T) -> TcpSocket<'a>
+    pub fn new<T>(rx_buffer: T, tx_buffer: T) -> Socket<'a>
     where
         T: Into<SocketBuffer<'a>>,
     {
@@ -420,7 +420,7 @@ impl<'a> TcpSocket<'a> {
         }
         let rx_cap_log2 = mem::size_of::<usize>() * 8 - rx_capacity.leading_zeros() as usize;
 
-        TcpSocket {
+        Socket {
             state: State::Closed,
             timer: Timer::new(),
             rtte: RttEstimator::default(),
@@ -2224,7 +2224,7 @@ impl<'a> TcpSocket<'a> {
     }
 }
 
-impl<'a> fmt::Write for TcpSocket<'a> {
+impl<'a> fmt::Write for Socket<'a> {
     fn write_str(&mut self, slice: &str) -> fmt::Result {
         let slice = slice.as_bytes();
         if self.send_slice(slice) == Ok(slice.len()) {
@@ -2344,12 +2344,12 @@ mod test {
     // =========================================================================================//
 
     struct TestSocket {
-        socket: TcpSocket<'static>,
+        socket: Socket<'static>,
         cx: Context<'static>,
     }
 
     impl Deref for TestSocket {
-        type Target = TcpSocket<'static>;
+        type Target = Socket<'static>;
         fn deref(&self) -> &Self::Target {
             &self.socket
         }
@@ -2465,7 +2465,7 @@ mod test {
     fn socket_with_buffer_sizes(tx_len: usize, rx_len: usize) -> TestSocket {
         let rx_buffer = SocketBuffer::new(vec![0; rx_len]);
         let tx_buffer = SocketBuffer::new(vec![0; tx_len]);
-        let mut socket = TcpSocket::new(rx_buffer, tx_buffer);
+        let mut socket = Socket::new(rx_buffer, tx_buffer);
         socket.set_ack_delay(None);
         let cx = Context::mock();
         TestSocket { socket, cx }

--- a/src/storage/assembler.rs
+++ b/src/storage/assembler.rs
@@ -192,7 +192,7 @@ impl Assembler {
     }
 
     /// Add a new contiguous range to the assembler, and return `Ok(bool)`,
-    /// or return `Err(())` if too many discontiguities are already recorded.
+    /// or return `Err(TooManyHolesError)` if too many discontiguities are already recorded.
     /// Returns `Ok(true)` when there was an overlap.
     pub fn add(&mut self, mut offset: usize, mut size: usize) -> Result<bool, TooManyHolesError> {
         let mut index = 0;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -19,3 +19,13 @@ pub use self::ring_buffer::RingBuffer;
 pub trait Resettable {
     fn reset(&mut self);
 }
+
+/// Error returned when enqueuing into a full buffer.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Full;
+
+/// Error returned when dequeuing from an empty buffer.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Empty;

--- a/src/wire/arp.rs
+++ b/src/wire/arp.rs
@@ -1,7 +1,7 @@
 use byteorder::{ByteOrder, NetworkEndian};
 use core::fmt;
 
-use crate::{Error, Result};
+use super::{Error, Result};
 
 pub use super::EthernetProtocol as Protocol;
 
@@ -80,7 +80,7 @@ impl<T: AsRef<[u8]>> Packet<T> {
     }
 
     /// Ensure that no accessor method will panic if called.
-    /// Returns `Err(Error::Truncated)` if the buffer is too short.
+    /// Returns `Err(Error)` if the buffer is too short.
     ///
     /// The result of this check is invalidated by calling [set_hardware_len] or
     /// [set_protocol_len].
@@ -91,9 +91,9 @@ impl<T: AsRef<[u8]>> Packet<T> {
     pub fn check_len(&self) -> Result<()> {
         let len = self.buffer.as_ref().len();
         if len < field::OPER.end {
-            Err(Error::Truncated)
+            Err(Error)
         } else if len < field::TPA(self.hardware_len(), self.protocol_len()).end {
-            Err(Error::Truncated)
+            Err(Error)
         } else {
             Ok(())
         }
@@ -269,7 +269,7 @@ pub enum Repr {
 
 impl Repr {
     /// Parse an Address Resolution Protocol packet and return a high-level representation,
-    /// or return `Err(Error::Unrecognized)` if the packet is not recognized.
+    /// or return `Err(Error)` if the packet is not recognized.
     pub fn parse<T: AsRef<[u8]>>(packet: &Packet<T>) -> Result<Repr> {
         match (
             packet.hardware_type(),
@@ -284,7 +284,7 @@ impl Repr {
                 target_hardware_addr: EthernetAddress::from_bytes(packet.target_hardware_addr()),
                 target_protocol_addr: Ipv4Address::from_bytes(packet.target_protocol_addr()),
             }),
-            _ => Err(Error::Unrecognized),
+            _ => Err(Error),
         }
     }
 

--- a/src/wire/ethernet.rs
+++ b/src/wire/ethernet.rs
@@ -1,7 +1,7 @@
 use byteorder::{ByteOrder, NetworkEndian};
 use core::fmt;
 
-use crate::{Error, Result};
+use super::{Error, Result};
 
 enum_with_unknown! {
     /// Ethernet protocol type.
@@ -115,11 +115,11 @@ impl<T: AsRef<[u8]>> Frame<T> {
     }
 
     /// Ensure that no accessor method will panic if called.
-    /// Returns `Err(Error::Truncated)` if the buffer is too short.
+    /// Returns `Err(Error)` if the buffer is too short.
     pub fn check_len(&self) -> Result<()> {
         let len = self.buffer.as_ref().len();
         if len < HEADER_LEN {
-            Err(Error::Truncated)
+            Err(Error)
         } else {
             Ok(())
         }

--- a/src/wire/ieee802154.rs
+++ b/src/wire/ieee802154.rs
@@ -2,9 +2,8 @@ use core::fmt;
 
 use byteorder::{ByteOrder, LittleEndian};
 
+use super::{Error, Result};
 use crate::wire::ipv6::Address as Ipv6Address;
-use crate::Error;
-use crate::Result;
 
 enum_with_unknown! {
     /// IEEE 802.15.4 frame type.
@@ -238,22 +237,22 @@ impl<T: AsRef<[u8]>> Frame<T> {
         packet.check_len()?;
 
         if matches!(packet.dst_addressing_mode(), AddressingMode::Unknown(_)) {
-            return Err(Error::Malformed);
+            return Err(Error);
         }
 
         if matches!(packet.src_addressing_mode(), AddressingMode::Unknown(_)) {
-            return Err(Error::Malformed);
+            return Err(Error);
         }
 
         Ok(packet)
     }
 
     /// Ensure that no accessor method will panic if called.
-    /// Returns `Err(Error::Truncated)` if the buffer is too short.
+    /// Returns `Err(Error)` if the buffer is too short.
     pub fn check_len(&self) -> Result<()> {
         // We need at least 3 bytes
         if self.buffer.as_ref().len() < 3 {
-            return Err(Error::Truncated);
+            return Err(Error);
         }
 
         let mut offset = field::ADDRESSING.start + 2;
@@ -267,7 +266,7 @@ impl<T: AsRef<[u8]>> Frame<T> {
         }
 
         if offset > self.buffer.as_ref().len() {
-            return Err(Error::Truncated);
+            return Err(Error);
         }
 
         Ok(())

--- a/src/wire/igmp.rs
+++ b/src/wire/igmp.rs
@@ -1,9 +1,9 @@
 use byteorder::{ByteOrder, NetworkEndian};
 use core::fmt;
 
+use super::{Error, Result};
 use crate::time::Duration;
 use crate::wire::ip::checksum;
-use crate::{Error, Result};
 
 use crate::wire::Ipv4Address;
 
@@ -69,11 +69,11 @@ impl<T: AsRef<[u8]>> Packet<T> {
     }
 
     /// Ensure that no accessor method will panic if called.
-    /// Returns `Err(Error::Truncated)` if the buffer is too short.
+    /// Returns `Err(Error)` if the buffer is too short.
     pub fn check_len(&self) -> Result<()> {
         let len = self.buffer.as_ref().len();
         if len < field::GROUP_ADDRESS.end as usize {
-            Err(Error::Truncated)
+            Err(Error)
         } else {
             Ok(())
         }
@@ -208,7 +208,7 @@ impl Repr {
         // Check if the address is 0.0.0.0 or multicast
         let addr = packet.group_addr();
         if !addr.is_unspecified() && !addr.is_multicast() {
-            return Err(Error::Malformed);
+            return Err(Error);
         }
 
         // construct a packet based on the Type field
@@ -241,7 +241,7 @@ impl Repr {
                     version: IgmpVersion::Version1,
                 })
             }
-            _ => Err(Error::Unrecognized),
+            _ => Err(Error),
         }
     }
 

--- a/src/wire/ip.rs
+++ b/src/wire/ip.rs
@@ -1,12 +1,12 @@
 use core::convert::From;
 use core::fmt;
 
+use super::{Error, Result};
 use crate::phy::ChecksumCapabilities;
 #[cfg(feature = "proto-ipv4")]
 use crate::wire::{Ipv4Address, Ipv4Cidr, Ipv4Packet, Ipv4Repr};
 #[cfg(feature = "proto-ipv6")]
 use crate::wire::{Ipv6Address, Ipv6Cidr, Ipv6Packet, Ipv6Repr};
-use crate::{Error, Result};
 
 /// Internet protocol version.
 #[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
@@ -22,14 +22,14 @@ impl Version {
     /// Return the version of an IP packet stored in the provided buffer.
     ///
     /// This function never returns `Ok(IpVersion::Unspecified)`; instead,
-    /// unknown versions result in `Err(Error::Unrecognized)`.
+    /// unknown versions result in `Err(Error)`.
     pub fn of_packet(data: &[u8]) -> Result<Version> {
         match data[0] >> 4 {
             #[cfg(feature = "proto-ipv4")]
             4 => Ok(Version::Ipv4),
             #[cfg(feature = "proto-ipv6")]
             6 => Ok(Version::Ipv6),
-            _ => Err(Error::Unrecognized),
+            _ => Err(Error),
         }
     }
 }

--- a/src/wire/ipv6fragment.rs
+++ b/src/wire/ipv6fragment.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Result};
+use super::{Error, Result};
 use core::fmt;
 
 use byteorder::{ByteOrder, NetworkEndian};
@@ -51,13 +51,13 @@ impl<T: AsRef<[u8]>> Header<T> {
     }
 
     /// Ensure that no accessor method will panic if called.
-    /// Returns `Err(Error::Truncated)` if the buffer is too short.
+    /// Returns `Err(Error)` if the buffer is too short.
     pub fn check_len(&self) -> Result<()> {
         let data = self.buffer.as_ref();
         let len = data.len();
 
         if len < field::IDENT.end {
-            Err(Error::Truncated)
+            Err(Error)
         } else {
             Ok(())
         }
@@ -226,7 +226,7 @@ mod test {
     fn test_check_len() {
         // less than 8 bytes
         assert_eq!(
-            Err(Error::Truncated),
+            Err(Error),
             Header::new_unchecked(&BYTES_HEADER_MORE_FRAG[..7]).check_len()
         );
         // valid

--- a/src/wire/ipv6option.rs
+++ b/src/wire/ipv6option.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Result};
+use super::{Error, Result};
 use core::fmt;
 
 enum_with_unknown! {
@@ -103,7 +103,7 @@ impl<T: AsRef<[u8]>> Ipv6Option<T> {
     }
 
     /// Ensure that no accessor method will panic if called.
-    /// Returns `Err(Error::Truncated)` if the buffer is too short.
+    /// Returns `Err(Error)` if the buffer is too short.
     ///
     /// The result of this check is invalidated by calling [set_data_len].
     ///
@@ -113,7 +113,7 @@ impl<T: AsRef<[u8]>> Ipv6Option<T> {
         let len = data.len();
 
         if len < field::LENGTH {
-            return Err(Error::Truncated);
+            return Err(Error);
         }
 
         if self.option_type() == Type::Pad1 {
@@ -121,13 +121,13 @@ impl<T: AsRef<[u8]>> Ipv6Option<T> {
         }
 
         if len == field::LENGTH {
-            return Err(Error::Truncated);
+            return Err(Error);
         }
 
         let df = field::DATA(data[field::LENGTH]);
 
         if len < df.end {
-            return Err(Error::Truncated);
+            return Err(Error);
         }
 
         Ok(())
@@ -362,7 +362,7 @@ mod test {
         let bytes = [0u8];
         // zero byte buffer
         assert_eq!(
-            Err(Error::Truncated),
+            Err(Error),
             Ipv6Option::new_unchecked(&bytes[..0]).check_len()
         );
         // pad1
@@ -373,7 +373,7 @@ mod test {
 
         // padn with truncated data
         assert_eq!(
-            Err(Error::Truncated),
+            Err(Error),
             Ipv6Option::new_unchecked(&IPV6OPTION_BYTES_PADN[..2]).check_len()
         );
         // padn
@@ -384,11 +384,11 @@ mod test {
 
         // unknown option type with truncated data
         assert_eq!(
-            Err(Error::Truncated),
+            Err(Error),
             Ipv6Option::new_unchecked(&IPV6OPTION_BYTES_UNKNOWN[..4]).check_len()
         );
         assert_eq!(
-            Err(Error::Truncated),
+            Err(Error),
             Ipv6Option::new_unchecked(&IPV6OPTION_BYTES_UNKNOWN[..1]).check_len()
         );
         // unknown type
@@ -436,7 +436,7 @@ mod test {
         assert_eq!(opt.option_type(), Type::Unknown(255));
 
         // unrecognized option without length and data
-        assert_eq!(Ipv6Option::new_checked(&bytes), Err(Error::Truncated));
+        assert_eq!(Ipv6Option::new_checked(&bytes), Err(Error));
     }
 
     #[test]
@@ -533,7 +533,7 @@ mod test {
                         ..
                     }),
                 ) => continue,
-                (6, Err(Error::Truncated)) => continue,
+                (6, Err(Error)) => continue,
                 (i, res) => panic!("Unexpected option `{:?}` at index {}", res, i),
             }
         }

--- a/src/wire/ipv6routing.rs
+++ b/src/wire/ipv6routing.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Result};
+use super::{Error, Result};
 use core::fmt;
 
 use crate::wire::IpProtocol as Protocol;
@@ -158,7 +158,7 @@ impl<T: AsRef<[u8]>> Header<T> {
     }
 
     /// Ensure that no accessor method will panic if called.
-    /// Returns `Err(Error::Truncated)` if the buffer is too short.
+    /// Returns `Err(Error)` if the buffer is too short.
     ///
     /// The result of this check is invalidated by calling [set_header_len].
     ///
@@ -166,11 +166,11 @@ impl<T: AsRef<[u8]>> Header<T> {
     pub fn check_len(&self) -> Result<()> {
         let len = self.buffer.as_ref().len();
         if len < field::MIN_HEADER_SIZE {
-            return Err(Error::Truncated);
+            return Err(Error);
         }
 
         if len < field::DATA(self.header_len()).end as usize {
-            return Err(Error::Truncated);
+            return Err(Error);
         }
 
         Ok(())
@@ -444,7 +444,7 @@ impl<'a> Repr<'a> {
                 addresses: header.addresses(),
             }),
 
-            _ => Err(Error::Unrecognized),
+            _ => Err(Error),
         }
     }
 
@@ -588,31 +588,13 @@ mod test {
     #[test]
     fn test_check_len() {
         // less than min header size
-        assert_eq!(
-            Err(Error::Truncated),
-            Header::new(&BYTES_TYPE2[..3]).check_len()
-        );
-        assert_eq!(
-            Err(Error::Truncated),
-            Header::new(&BYTES_SRH_FULL[..3]).check_len()
-        );
-        assert_eq!(
-            Err(Error::Truncated),
-            Header::new(&BYTES_SRH_ELIDED[..3]).check_len()
-        );
+        assert_eq!(Err(Error), Header::new(&BYTES_TYPE2[..3]).check_len());
+        assert_eq!(Err(Error), Header::new(&BYTES_SRH_FULL[..3]).check_len());
+        assert_eq!(Err(Error), Header::new(&BYTES_SRH_ELIDED[..3]).check_len());
         // less than specified length field
-        assert_eq!(
-            Err(Error::Truncated),
-            Header::new(&BYTES_TYPE2[..23]).check_len()
-        );
-        assert_eq!(
-            Err(Error::Truncated),
-            Header::new(&BYTES_SRH_FULL[..39]).check_len()
-        );
-        assert_eq!(
-            Err(Error::Truncated),
-            Header::new(&BYTES_SRH_ELIDED[..11]).check_len()
-        );
+        assert_eq!(Err(Error), Header::new(&BYTES_TYPE2[..23]).check_len());
+        assert_eq!(Err(Error), Header::new(&BYTES_SRH_FULL[..39]).check_len());
+        assert_eq!(Err(Error), Header::new(&BYTES_SRH_ELIDED[..11]).check_len());
         // valid
         assert_eq!(Ok(()), Header::new(&BYTES_TYPE2[..]).check_len());
         assert_eq!(Ok(()), Header::new(&BYTES_SRH_FULL[..]).check_len());

--- a/src/wire/mld.rs
+++ b/src/wire/mld.rs
@@ -6,9 +6,9 @@
 
 use byteorder::{ByteOrder, NetworkEndian};
 
+use super::{Error, Result};
 use crate::wire::icmpv6::{field, Message, Packet};
 use crate::wire::Ipv6Address;
-use crate::{Error, Result};
 
 enum_with_unknown! {
     /// MLDv2 Multicast Listener Report Record Type. See [RFC 3810 § 5.2.12] for
@@ -192,7 +192,7 @@ impl<T: AsRef<[u8]>> AddressRecord<T> {
     pub fn check_len(&self) -> Result<()> {
         let len = self.buffer.as_ref().len();
         if len < field::RECORD_MCAST_ADDR.end {
-            Err(Error::Truncated)
+            Err(Error)
         } else {
             Ok(())
         }
@@ -333,7 +333,7 @@ impl<'a> Repr<'a> {
                 nr_mcast_addr_rcrds: packet.nr_mcast_addr_rcrds(),
                 data: packet.payload(),
             }),
-            _ => Err(Error::Unrecognized),
+            _ => Err(Error),
         }
     }
 

--- a/src/wire/ndisc.rs
+++ b/src/wire/ndisc.rs
@@ -1,6 +1,7 @@
 use bitflags::bitflags;
 use byteorder::{ByteOrder, NetworkEndian};
 
+use super::{Error, Result};
 use crate::time::Duration;
 use crate::wire::icmpv6::{field, Message, Packet};
 use crate::wire::Ipv6Address;
@@ -8,7 +9,6 @@ use crate::wire::RawHardwareAddress;
 use crate::wire::{Ipv6Packet, Ipv6Repr};
 use crate::wire::{NdiscOption, NdiscOptionRepr, NdiscOptionType};
 use crate::wire::{NdiscPrefixInformation, NdiscRedirectedHeader};
-use crate::{Error, Result};
 
 bitflags! {
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -237,7 +237,7 @@ impl<'a> Repr<'a> {
                     match opt.option_type() {
                         NdiscOptionType::SourceLinkLayerAddr => Some(opt.link_layer_addr()),
                         _ => {
-                            return Err(Error::Unrecognized);
+                            return Err(Error);
                         }
                     }
                 } else {
@@ -256,7 +256,7 @@ impl<'a> Repr<'a> {
                         NdiscOptionRepr::Mtu(val) => mtu = Some(val),
                         NdiscOptionRepr::PrefixInformation(info) => prefix_info = Some(info),
                         _ => {
-                            return Err(Error::Unrecognized);
+                            return Err(Error);
                         }
                     }
                     offset += opt.buffer_len();
@@ -278,7 +278,7 @@ impl<'a> Repr<'a> {
                     match opt.option_type() {
                         NdiscOptionType::SourceLinkLayerAddr => Some(opt.link_layer_addr()),
                         _ => {
-                            return Err(Error::Unrecognized);
+                            return Err(Error);
                         }
                     }
                 } else {
@@ -295,7 +295,7 @@ impl<'a> Repr<'a> {
                     match opt.option_type() {
                         NdiscOptionType::TargetLinkLayerAddr => Some(opt.link_layer_addr()),
                         _ => {
-                            return Err(Error::Unrecognized);
+                            return Err(Error);
                         }
                     }
                 } else {
@@ -319,7 +319,7 @@ impl<'a> Repr<'a> {
                         }
                         NdiscOptionType::RedirectedHeader => {
                             if opt.data_len() < 6 {
-                                return Err(Error::Truncated);
+                                return Err(Error);
                             } else {
                                 let ip_packet =
                                     Ipv6Packet::new_unchecked(&opt.data()[offset + 8..]);
@@ -333,7 +333,7 @@ impl<'a> Repr<'a> {
                             }
                         }
                         _ => {
-                            return Err(Error::Unrecognized);
+                            return Err(Error);
                         }
                     }
                 }
@@ -344,7 +344,7 @@ impl<'a> Repr<'a> {
                     redirected_hdr,
                 })
             }
-            _ => Err(Error::Unrecognized),
+            _ => Err(Error),
         }
     }
 

--- a/src/wire/tcp.rs
+++ b/src/wire/tcp.rs
@@ -1,10 +1,10 @@
 use byteorder::{ByteOrder, NetworkEndian};
 use core::{cmp, fmt, i32, ops};
 
+use super::{Error, Result};
 use crate::phy::ChecksumCapabilities;
 use crate::wire::ip::checksum;
 use crate::wire::{IpAddress, IpProtocol};
-use crate::{Error, Result};
 
 /// A TCP sequence number.
 ///
@@ -128,8 +128,8 @@ impl<T: AsRef<[u8]>> Packet<T> {
     }
 
     /// Ensure that no accessor method will panic if called.
-    /// Returns `Err(Error::Truncated)` if the buffer is too short.
-    /// Returns `Err(Error::Malformed)` if the header length field has a value smaller
+    /// Returns `Err(Error)` if the buffer is too short.
+    /// Returns `Err(Error)` if the header length field has a value smaller
     /// than the minimal header length.
     ///
     /// The result of this check is invalidated by calling [set_header_len].
@@ -138,13 +138,11 @@ impl<T: AsRef<[u8]>> Packet<T> {
     pub fn check_len(&self) -> Result<()> {
         let len = self.buffer.as_ref().len();
         if len < field::URGENT.end {
-            Err(Error::Truncated)
+            Err(Error)
         } else {
             let header_len = self.header_len() as usize;
-            if len < header_len {
-                Err(Error::Truncated)
-            } else if header_len < field::URGENT.end {
-                Err(Error::Malformed)
+            if len < header_len || header_len < field::URGENT.end {
+                Err(Error)
             } else {
                 Ok(())
             }
@@ -608,7 +606,7 @@ pub enum TcpOption<'a> {
 impl<'a> TcpOption<'a> {
     pub fn parse(buffer: &'a [u8]) -> Result<(&'a [u8], TcpOption<'a>)> {
         let (length, option);
-        match *buffer.get(0).ok_or(Error::Truncated)? {
+        match *buffer.get(0).ok_or(Error)? {
             field::OPT_END => {
                 length = 1;
                 option = TcpOption::EndOfList;
@@ -618,21 +616,21 @@ impl<'a> TcpOption<'a> {
                 option = TcpOption::NoOperation;
             }
             kind => {
-                length = *buffer.get(1).ok_or(Error::Truncated)? as usize;
-                let data = buffer.get(2..length).ok_or(Error::Truncated)?;
+                length = *buffer.get(1).ok_or(Error)? as usize;
+                let data = buffer.get(2..length).ok_or(Error)?;
                 match (kind, length) {
                     (field::OPT_END, _) | (field::OPT_NOP, _) => unreachable!(),
                     (field::OPT_MSS, 4) => {
                         option = TcpOption::MaxSegmentSize(NetworkEndian::read_u16(data))
                     }
-                    (field::OPT_MSS, _) => return Err(Error::Malformed),
+                    (field::OPT_MSS, _) => return Err(Error),
                     (field::OPT_WS, 3) => option = TcpOption::WindowScale(data[0]),
-                    (field::OPT_WS, _) => return Err(Error::Malformed),
+                    (field::OPT_WS, _) => return Err(Error),
                     (field::OPT_SACKPERM, 2) => option = TcpOption::SackPermitted,
-                    (field::OPT_SACKPERM, _) => return Err(Error::Malformed),
+                    (field::OPT_SACKPERM, _) => return Err(Error),
                     (field::OPT_SACKRNG, n) => {
                         if n < 10 || (n - 2) % 8 != 0 {
-                            return Err(Error::Malformed);
+                            return Err(Error);
                         }
                         if n > 26 {
                             // It's possible for a remote to send 4 SACK blocks, but extremely rare.
@@ -801,14 +799,14 @@ impl<'a> Repr<'a> {
     {
         // Source and destination ports must be present.
         if packet.src_port() == 0 {
-            return Err(Error::Malformed);
+            return Err(Error);
         }
         if packet.dst_port() == 0 {
-            return Err(Error::Malformed);
+            return Err(Error);
         }
         // Valid checksum is expected.
         if checksum_caps.tcp.rx() && !packet.verify_checksum(src_addr, dst_addr) {
-            return Err(Error::Checksum);
+            return Err(Error);
         }
 
         let control = match (packet.syn(), packet.fin(), packet.rst(), packet.psh()) {
@@ -817,7 +815,7 @@ impl<'a> Repr<'a> {
             (true, false, false, _) => Control::Syn,
             (false, true, false, _) => Control::Fin,
             (false, false, true, _) => Control::Rst,
-            _ => return Err(Error::Malformed),
+            _ => return Err(Error),
         };
         let ack_number = match packet.ack() {
             true => Some(packet.ack_number()),
@@ -1157,7 +1155,7 @@ mod test {
     #[cfg(feature = "proto-ipv4")]
     fn test_truncated() {
         let packet = Packet::new_unchecked(&PACKET_BYTES[..23]);
-        assert_eq!(packet.check_len(), Err(Error::Truncated));
+        assert_eq!(packet.check_len(), Err(Error));
     }
 
     #[test]
@@ -1165,7 +1163,7 @@ mod test {
         let mut bytes = vec![0; 20];
         let mut packet = Packet::new_unchecked(&mut bytes);
         packet.set_header_len(10);
-        assert_eq!(packet.check_len(), Err(Error::Malformed));
+        assert_eq!(packet.check_len(), Err(Error));
     }
 
     #[cfg(feature = "proto-ipv4")]
@@ -1277,14 +1275,11 @@ mod test {
 
     #[test]
     fn test_malformed_tcp_options() {
-        assert_eq!(TcpOption::parse(&[]), Err(Error::Truncated));
-        assert_eq!(TcpOption::parse(&[0xc]), Err(Error::Truncated));
-        assert_eq!(
-            TcpOption::parse(&[0xc, 0x05, 0x01, 0x02]),
-            Err(Error::Truncated)
-        );
-        assert_eq!(TcpOption::parse(&[0xc, 0x01]), Err(Error::Truncated));
-        assert_eq!(TcpOption::parse(&[0x2, 0x02]), Err(Error::Malformed));
-        assert_eq!(TcpOption::parse(&[0x3, 0x02]), Err(Error::Malformed));
+        assert_eq!(TcpOption::parse(&[]), Err(Error));
+        assert_eq!(TcpOption::parse(&[0xc]), Err(Error));
+        assert_eq!(TcpOption::parse(&[0xc, 0x05, 0x01, 0x02]), Err(Error));
+        assert_eq!(TcpOption::parse(&[0xc, 0x01]), Err(Error));
+        assert_eq!(TcpOption::parse(&[0x2, 0x02]), Err(Error));
+        assert_eq!(TcpOption::parse(&[0x3, 0x02]), Err(Error));
     }
 }


### PR DESCRIPTION
Currently `smoltcp` has a single `Error` enum used everywhere. All methods can return all error variants, but in practice they only return some. For example TCP recv can only return `Finished` or `Illegal`, it will never return any of the other 17 possible variants. 

This makes error handling in user code much harder, because you have to check docs for which errors can actually happen.

Goal is
- Make every method return an error enum with only the errors relevant to that function.
- Remove smoltcp::Error

Also, it's likely this will improve code size a bit.