### PR TITLE
dns: fix label-length validation

### DIFF
--- a/src/socket/dns.rs
+++ b/src/socket/dns.rs
@@ -178,7 +178,7 @@ impl<'a> DnsSocket<'a> {
         let mut raw_name: Vec<u8, MAX_NAME_LEN> = Vec::new();
 
         for s in name.split(|&c| c == b'.') {
-            if s.len() > 255 {
+            if s.len() > 63 {
                 net_trace!("invalid name: too long label");
                 return Err(Error::Illegal);
             }


### PR DESCRIPTION
The label length is represented by a single byte with the two most-significant bits reserved, which gives a maximum length of 63.