### PR TITLE
IPv4 packet reassembly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,12 @@ verbose = []
 "phy-tuntap_interface" = ["std", "libc", "medium-ethernet"]
 
 "proto-ipv4" = []
+"proto-ipv4-fragmentation" = ["proto-ipv4"]
 "proto-igmp" = ["proto-ipv4"]
 "proto-dhcpv4" = ["proto-ipv4"]
 "proto-ipv6" = []
 "proto-sixlowpan" = ["proto-ipv6"]
+"proto-sixlowpan-fragmentation" = ["proto-sixlowpan"]
 "proto-dns" = []
 
 "socket" = []
@@ -63,7 +65,8 @@ default = [
   "std", "log", # needed for `cargo test --no-default-features --features default` :/
   "medium-ethernet", "medium-ip", "medium-ieee802154",
   "phy-raw_socket", "phy-tuntap_interface",
-  "proto-ipv4", "proto-igmp", "proto-dhcpv4", "proto-ipv6", "proto-sixlowpan", "proto-dns",
+  "proto-ipv4", "proto-igmp", "proto-dhcpv4", "proto-ipv6", "proto-dns",
+  "proto-ipv4-fragmentation", "proto-sixlowpan-fragmentation",
   "socket-raw", "socket-icmp", "socket-udp", "socket-tcp", "socket-dhcpv4", "socket-dns",
   "async"
 ]
@@ -114,10 +117,11 @@ required-features = ["std", "medium-ethernet", "medium-ip", "phy-tuntap_interfac
 
 [[example]]
 name = "sixlowpan"
-required-features = ["std", "medium-ieee802154", "phy-raw_socket", "proto-sixlowpan", "socket-udp"]
+required-features = ["std", "medium-ieee802154", "phy-raw_socket", "proto-sixlowpan", "proto-sixlowpan-fragmentation", "socket-udp"]
+
 [[example]]
 name = "sixlowpan_benchmark"
-required-features = ["std", "medium-ieee802154", "phy-raw_socket", "proto-sixlowpan", "socket-udp"]
+required-features = ["std", "medium-ieee802154", "phy-raw_socket", "proto-sixlowpan", "proto-sixlowpan-fragmentation", "socket-udp"]
 
 [[example]]
 name = "dns"

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -6,6 +6,11 @@ use std::fmt::Write;
 use std::os::unix::io::AsRawFd;
 use std::str;
 
+#[cfg(any(
+    feature = "proto-sixlowpan-fragmentation",
+    feature = "proto-ipv4-fragmentation"
+))]
+use smoltcp::iface::FragmentsCache;
 use smoltcp::iface::{InterfaceBuilder, NeighborCache, SocketSet};
 use smoltcp::phy::{wait as phy_wait, Device, Medium};
 use smoltcp::socket::{tcp, udp};
@@ -27,8 +32,8 @@ fn main() {
 
     let neighbor_cache = NeighborCache::new(BTreeMap::new());
 
-    let udp_rx_buffer = udp::PacketBuffer::new(vec![udp::PacketMetadata::EMPTY], vec![0; 64]);
-    let udp_tx_buffer = udp::PacketBuffer::new(vec![udp::PacketMetadata::EMPTY], vec![0; 128]);
+    let udp_rx_buffer = udp::PacketBuffer::new(vec![udp::PacketMetadata::EMPTY], vec![0; 65535]);
+    let udp_tx_buffer = udp::PacketBuffer::new(vec![udp::PacketMetadata::EMPTY], vec![0; 65535]);
     let udp_socket = udp::Socket::new(udp_rx_buffer, udp_tx_buffer);
 
     let tcp1_rx_buffer = tcp::SocketBuffer::new(vec![0; 64]);
@@ -56,6 +61,23 @@ fn main() {
 
     let medium = device.capabilities().medium;
     let mut builder = InterfaceBuilder::new().ip_addrs(ip_addrs);
+
+    #[cfg(feature = "proto-ipv4-fragmentation")]
+    {
+        let ipv4_frag_cache = FragmentsCache::new(vec![], BTreeMap::new());
+        builder = builder.ipv4_fragments_cache(ipv4_frag_cache);
+    }
+
+    #[cfg(feature = "proto-sixlowpan-fragmentation")]
+    let mut out_packet_buffer = [0u8; 1280];
+    #[cfg(feature = "proto-sixlowpan-fragmentation")]
+    {
+        let sixlowpan_frag_cache = FragmentsCache::new(vec![], BTreeMap::new());
+        builder = builder
+            .sixlowpan_fragments_cache(sixlowpan_frag_cache)
+            .sixlowpan_out_packet_cache(&mut out_packet_buffer[..]);
+    }
+
     if medium == Medium::Ethernet {
         builder = builder
             .hardware_addr(ethernet_addr.into())

--- a/src/iface/mod.rs
+++ b/src/iface/mod.rs
@@ -4,7 +4,7 @@ The `iface` module deals with the *network interfaces*. It filters incoming fram
 provides lookup and caching of hardware addresses, and handles management packets.
 */
 
-#[cfg(feature = "proto-sixlowpan")]
+#[cfg(any(feature = "proto-ipv4", feature = "proto-sixlowpan"))]
 mod fragmentation;
 mod interface;
 #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
@@ -22,7 +22,7 @@ pub use self::neighbor::Neighbor;
 pub use self::route::{Route, Routes};
 pub use socket_set::{SocketHandle, SocketSet, SocketStorage};
 
-#[cfg(feature = "proto-sixlowpan")]
+#[cfg(any(feature = "proto-ipv4", feature = "proto-sixlowpan"))]
 pub use self::fragmentation::{PacketAssembler, PacketAssemblerSet as FragmentsCache};
 
 pub use self::interface::{Interface, InterfaceBuilder, InterfaceInner as Context};

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -169,8 +169,8 @@ pub use self::ip::{
 
 #[cfg(feature = "proto-ipv4")]
 pub use self::ipv4::{
-    Address as Ipv4Address, Cidr as Ipv4Cidr, Packet as Ipv4Packet, Repr as Ipv4Repr,
-    HEADER_LEN as IPV4_HEADER_LEN, MIN_MTU as IPV4_MIN_MTU,
+    Address as Ipv4Address, Cidr as Ipv4Cidr, Key as Ipv4FragKey, Packet as Ipv4Packet,
+    Repr as Ipv4Repr, HEADER_LEN as IPV4_HEADER_LEN, MIN_MTU as IPV4_MIN_MTU,
 };
 
 #[cfg(feature = "proto-ipv6")]

--- a/src/wire/sixlowpan.rs
+++ b/src/wire/sixlowpan.rs
@@ -359,6 +359,7 @@ pub mod frag {
     }
 
     impl Repr {
+        #[cfg(feature = "proto-sixlowpan-fragmentation")]
         pub(crate) fn set_offset(&mut self, value: u8) {
             match self {
                 Repr::FirstFragment { .. } => (),
@@ -2105,15 +2106,15 @@ mod test {
             .reserve_with_key(&key)
             .unwrap()
             .start(
-                frag.datagram_size() as usize - uncompressed + compressed,
-                Instant::now(),
+                Some(frag.datagram_size() as usize - uncompressed + compressed),
+                Instant::now() + crate::time::Duration::from_secs(60),
                 -((uncompressed - compressed) as isize),
             )
             .unwrap();
         frags_cache
             .get_packet_assembler_mut(&key)
             .unwrap()
-            .add(frag.payload(), 0, Instant::now())
+            .add(frag.payload(), 0)
             .unwrap();
 
         let frame2: &[u8] = &[
@@ -2149,11 +2150,7 @@ mod test {
         frags_cache
             .get_packet_assembler_mut(&key)
             .unwrap()
-            .add(
-                frag.payload(),
-                frag.datagram_offset() as usize * 8,
-                Instant::now(),
-            )
+            .add(frag.payload(), frag.datagram_offset() as usize * 8)
             .unwrap();
 
         let frame3: &[u8] = &[
@@ -2188,11 +2185,7 @@ mod test {
         frags_cache
             .get_packet_assembler_mut(&key)
             .unwrap()
-            .add(
-                frag.payload(),
-                frag.datagram_offset() as usize * 8,
-                Instant::now(),
-            )
+            .add(frag.payload(), frag.datagram_offset() as usize * 8)
             .unwrap();
 
         let assembled_packet = frags_cache.get_assembled_packet(&key).unwrap();


### PR DESCRIPTION
This adds IPv4 packet reassembly. Replacement for #236.

Depends on the fragmentation work of #580. When #580 gets merged I will rebase on master.