### PR TITLE
Add send_with to udp, raw, and icmp sockets

### DIFF
--- a/src/iface/socket_meta.rs
+++ b/src/iface/socket_meta.rs
@@ -1,19 +1,21 @@
 use super::SocketHandle;
-use crate::socket::PollAt;
-use crate::time::{Duration, Instant};
-use crate::wire::IpAddress;
+use crate::{
+    socket::PollAt,
+    time::{Duration, Instant},
+    wire::IpAddress,
+};
 
 /// Neighbor dependency.
 ///
-/// This enum tracks whether the socket should be polled based on the neighbor it is
-/// going to send packets to.
+/// This enum tracks whether the socket should be polled based on the neighbor
+/// it is going to send packets to.
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 enum NeighborState {
     /// Socket can be polled immediately.
     Active,
-    /// Socket should not be polled until either `silent_until` passes or `neighbor` appears
-    /// in the neighbor cache.
+    /// Socket should not be polled until either `silent_until` passes or
+    /// `neighbor` appears in the neighbor cache.
     Waiting {
         neighbor: IpAddress,
         silent_until: Instant,
@@ -29,7 +31,8 @@ impl Default for NeighborState {
 /// Network socket metadata.
 ///
 /// This includes things that only external (to the socket, that is) code
-/// is interested in, but which are more conveniently stored inside the socket itself.
+/// is interested in, but which are more conveniently stored inside the socket
+/// itself.
 #[derive(Debug, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct Meta {
@@ -41,8 +44,8 @@ pub(crate) struct Meta {
 }
 
 impl Meta {
-    /// Minimum delay between neighbor discovery requests for this particular socket,
-    /// in milliseconds.
+    /// Minimum delay between neighbor discovery requests for this particular
+    /// socket, in milliseconds.
     ///
     /// See also `iface::NeighborCache::SILENT_TIME`.
     pub(crate) const DISCOVERY_SILENT_TIME: Duration = Duration::from_millis(1_000);

--- a/src/socket/raw.rs
+++ b/src/socket/raw.rs
@@ -188,6 +188,31 @@ impl<'a> Socket<'a> {
         Ok(packet_buf)
     }
 
+    /// Enqueue a packet to be send and pass the buffer to the provided closure.
+    /// The closure then returns the size of the data written into the buffer.
+    ///
+    /// Also see [send](#method.send).
+    pub fn send_with<F>(&mut self, max_size: usize, f: F) -> Result<&mut [u8]>
+    where
+        F: FnOnce(&mut [u8]) -> usize,
+    {
+        let (size, packet_buf) = self
+            .tx_buffer
+            .enqueue_with_infallible(max_size, (), |data| {
+                let size = f(data);
+                (size, &mut data[..size])
+            })?;
+
+        net_trace!(
+            "raw:{}:{}: buffer to send {} octets",
+            self.ip_version,
+            self.ip_protocol,
+            size
+        );
+
+        Ok(packet_buf)
+    }
+
     /// Enqueue a packet to send, and fill it from a slice.
     ///
     /// See also [send](#method.send).

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -268,7 +268,7 @@ impl<'a> Socket<'a> {
         max_size: usize,
         remote_endpoint: IpEndpoint,
         f: F,
-    ) -> Result<&mut [u8], SendError>
+    ) -> Result<usize, SendError>
     where
         F: FnOnce(&mut [u8]) -> usize,
     {
@@ -282,12 +282,9 @@ impl<'a> Socket<'a> {
             return Err(SendError::Unaddressable);
         }
 
-        let (size, payload_buf) = self
+        let size = self
             .tx_buffer
-            .enqueue_with_infallible(max_size, remote_endpoint, |data| {
-                let size = f(data);
-                (size, &mut data[..size])
-            })
+            .enqueue_with_infallible(max_size, remote_endpoint, f)
             .map_err(|_| SendError::BufferFull)?;
 
         net_trace!(
@@ -296,7 +293,7 @@ impl<'a> Socket<'a> {
             remote_endpoint,
             size
         );
-        Ok(payload_buf)
+        Ok(size)
     }
 
     /// Enqueue a packet to be sent to a given remote endpoint, and fill it from a slice.


### PR DESCRIPTION
This PR adds a `send_with` method to raw, UDP, and ICMP sockets. These methods enable reserving a packet buffer with a greater size than you need, and then shrinking the size once you know it.

```rust
pub fn send_with<F>(
        &mut self,
        max_size: usize,
        remote_endpoint: IpEndpoint,
        f: F,
    ) -> Result<usize>
    where
        F: FnOnce(&mut [u8]) -> usize,
    { ... }
```

The closure passed to `send_with` should return the size actually written to the supplied buffer.

Internally, this PR adds a `enqueue_with_infallible` method to `PacketBuffer`. While a fallible `enqueue_with` is noted to be extremely complex in a comment on the `enqueue` method, an infallible one is much less complicated. Still, I'd appreciate some more eyes on it to make sure I didn't screw up the logic.
