### PR TITLE
Fix 6LoWPAN address compression

### DIFF
--- a/src/wire/sixlowpan.rs
+++ b/src/wire/sixlowpan.rs
@@ -910,7 +910,7 @@ pub mod iphc {
         ) -> usize {
             self.set_cid_field(0);
             self.set_sac_field(0);
-            self.set_sam_field(0b11);
+            self.set_sam_field(0b00);
             let src = src_addr.as_bytes();
             if src_addr == ipv6::Address::UNSPECIFIED {
                 self.set_sac_field(1);
@@ -958,6 +958,7 @@ pub mod iphc {
                 }
             } else {
                 // We cannot elide anything.
+                self.set_sam_field(0b00);
                 self.set_field(idx, src);
                 idx += 16;
             }


### PR DESCRIPTION
Should fix #629. The `Source Address Mode (SAM)` in the 6LoWPAN `IPHC` header was set to `Compress` (`0b11`), while it should have been `Inline` (`0b00`) when we inline the full IPv6 address.