### PR TITLE
Modify `poll_at` for 6LoWPAN outgoing fragments

### DIFF
--- a/src/wire/sixlowpan.rs
+++ b/src/wire/sixlowpan.rs
@@ -910,7 +910,6 @@ pub mod iphc {
         ) -> usize {
             self.set_cid_field(0);
             self.set_sac_field(0);
-            self.set_sam_field(0b00);
             let src = src_addr.as_bytes();
             if src_addr == ipv6::Address::UNSPECIFIED {
                 self.set_sac_field(1);


### PR DESCRIPTION
When there are still 6LoWPAN fragments to be transmitted, `poll_at` should return `Some(Instant::from_millis(0))`.