### PR TITLE
Add additional DHCP configurability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
+rust-toolchain
+.history
 Cargo.lock
 *.pcap

--- a/src/iface/interface.rs
+++ b/src/iface/interface.rs
@@ -348,6 +348,7 @@ let iface = InterfaceBuilder::new(device, vec![])
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg(feature = "medium-ethernet")]
+#[allow(clippy::large_enum_variant)]
 enum EthernetPacket<'a> {
     #[cfg(feature = "proto-ipv4")]
     Arp(ArpRepr),

--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -8,7 +8,7 @@ use crate::wire::{
     DhcpMessageType, DhcpPacket, DhcpRepr, IpAddress, IpProtocol, Ipv4Address, Ipv4Cidr, Ipv4Repr,
     UdpRepr, DHCP_CLIENT_PORT, DHCP_MAX_DNS_SERVER_COUNT, DHCP_SERVER_PORT, UDP_HEADER_LEN,
 };
-use crate::wire::{DhcpOptionsRepr, HardwareAddress};
+use crate::wire::{DhcpOptionsBuffer, HardwareAddress};
 
 #[cfg(feature = "async")]
 use super::WakerRegistration;
@@ -37,7 +37,7 @@ pub struct Config<'a> {
     /// Bootfile name
     pub bootfile: Option<&'a str>,
     /// Received DHCP options
-    pub options: Option<DhcpOptionsRepr<&'a [u8]>>,
+    pub options: Option<DhcpOptionsBuffer<&'a [u8]>>,
 }
 
 /// Information on how to reach a DHCP server.
@@ -153,9 +153,9 @@ pub struct Socket<'a> {
     /// A buffer for the bootfile name to be written to.
     bootfile_name_buffer: Option<(usize, &'a mut [u8])>,
     /// A buffer contains options additional to be added to outgoing DHCP packets.
-    outbox_options: Option<DhcpOptionsRepr<&'a [u8]>>,
+    outbox_options: Option<DhcpOptionsBuffer<&'a [u8]>>,
     /// A buffer to be filled with options from incoming DHCP packets.
-    inbox_options: Option<DhcpOptionsRepr<&'a mut [u8]>>,
+    inbox_options: Option<DhcpOptionsBuffer<&'a mut [u8]>>,
     /// A buffer containing all requested
     parameter_request_list: Option<&'a [u8]>,
 
@@ -197,12 +197,12 @@ impl<'a> Socket<'a> {
     }
 
     /// Set the outgoing options buffer.
-    pub fn set_outgoing_options_buffer(&mut self, options_buffer: DhcpOptionsRepr<&'a [u8]>) {
+    pub fn set_outgoing_options_buffer(&mut self, options_buffer: DhcpOptionsBuffer<&'a [u8]>) {
         self.outbox_options = Some(options_buffer);
     }
 
     /// Set the incoming options buffer.
-    pub fn set_incoming_options_buffer(&mut self, options_buffer: DhcpOptionsRepr<&'a mut [u8]>) {
+    pub fn set_incoming_options_buffer(&mut self, options_buffer: DhcpOptionsBuffer<&'a mut [u8]>) {
         self.inbox_options = Some(options_buffer);
     }
 

--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -509,7 +509,6 @@ impl<'a> Dhcpv4Socket<'a> {
             max_size: Some((cx.ip_mtu() - MAX_IPV4_HEADER_LEN - UDP_HEADER_LEN) as u16),
             lease_duration: None,
             dns_servers: None,
-            time_offset: None,
             options: self.outbox_options,
         };
 
@@ -843,7 +842,6 @@ mod test {
         dns_servers: None,
         max_size: None,
         lease_duration: None,
-        time_offset: None,
         options: None,
     };
 

--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -206,8 +206,13 @@ impl<'a> Socket<'a> {
         self.inbox_options = Some(options_buffer);
     }
 
+    /// Set the buffer in which the bootfile name is stored.
+    pub fn set_bootfile_name_buffer(&mut self, bootfile_buffer: &'a mut [u8]) {
+        self.bootfile_name_buffer = Some((0, bootfile_buffer));
+    }
+
     /// Set the parameter request list.
-    /// 
+    ///
     /// This should contain at least `OPT_SUBNET_MASK` (`1`), `OPT_ROUTER` (`3`), and `OPT_DOMAIN_NAME_SERVER` (`6`).
     pub fn set_parameter_request_list(&mut self, parameter_request_list: &'a [u8]) {
         self.parameter_request_list = Some(parameter_request_list);

--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -191,30 +191,26 @@ impl<'a> Socket<'a> {
         }
     }
 
-    /// Create a DHCPv4 socket with retry and DHCP option configuration.
-    pub fn with_config(
-        retry_config: RetryConfig,
-        bootfile_name_buffer: Option<&'a mut [u8]>,
-        outbox_options: Option<DhcpOptionsRepr<&'a [u8]>>,
-        inbox_options: Option<DhcpOptionsRepr<&'a mut [u8]>>,
-        parameter_request_list: Option<&'a [u8]>,
-    ) -> Self {
-        Socket {
-            state: ClientState::Discovering(DiscoverState {
-                retry_at: Instant::from_millis(0),
-            }),
-            config_changed: true,
-            transaction_id: 1,
-            max_lease_duration: None,
-            retry_config: retry_config,
-            ignore_naks: false,
-            bootfile_name_buffer: bootfile_name_buffer.map(|b| (0, b)),
-            outbox_options,
-            inbox_options,
-            parameter_request_list,
-            #[cfg(feature = "async")]
-            waker: WakerRegistration::new(),
-        }
+    /// Set the retry/timeouts configuration.
+    pub fn set_retry_config(&mut self, config: RetryConfig) {
+        self.retry_config = config;
+    }
+
+    /// Set the outgoing options buffer.
+    pub fn set_outgoing_options_buffer(&mut self, options_buffer: DhcpOptionsRepr<&'a [u8]>) {
+        self.outbox_options = Some(options_buffer);
+    }
+
+    /// Set the incoming options buffer.
+    pub fn set_incoming_options_buffer(&mut self, options_buffer: DhcpOptionsRepr<&'a mut [u8]>) {
+        self.inbox_options = Some(options_buffer);
+    }
+
+    /// Set the parameter request list.
+    /// 
+    /// This should contain at least `OPT_SUBNET_MASK` (`1`), `OPT_ROUTER` (`3`), and `OPT_DOMAIN_NAME_SERVER` (`6`).
+    pub fn set_parameter_request_list(&mut self, parameter_request_list: &'a [u8]) {
+        self.parameter_request_list = Some(parameter_request_list);
     }
 
     /// Get the configured max lease duration.

--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -402,6 +402,9 @@ impl Dhcpv4Socket {
         let mut dhcp_repr = DhcpRepr {
             message_type: DhcpMessageType::Discover,
             transaction_id: next_transaction_id,
+            secs: 0,
+            sname: None,
+            boot_file: None,
             client_hardware_address: ethernet_addr,
             client_ip: Ipv4Address::UNSPECIFIED,
             your_ip: Ipv4Address::UNSPECIFIED,
@@ -417,6 +420,11 @@ impl Dhcpv4Socket {
             max_size: Some((cx.ip_mtu() - MAX_IPV4_HEADER_LEN - UDP_HEADER_LEN) as u16),
             lease_duration: None,
             dns_servers: None,
+            time_offset: None,
+            client_arch_list: None,
+            client_interface_id: None,
+            client_machine_id: None,
+            vendor_class_id: None,
         };
 
         let udp_repr = UdpRepr {
@@ -710,6 +718,9 @@ mod test {
     const DHCP_DEFAULT: DhcpRepr = DhcpRepr {
         message_type: DhcpMessageType::Unknown(99),
         transaction_id: TXID,
+        secs: 0,
+        sname: None,
+        boot_file: None,
         client_hardware_address: MY_MAC,
         client_ip: Ipv4Address::UNSPECIFIED,
         your_ip: Ipv4Address::UNSPECIFIED,
@@ -725,6 +736,11 @@ mod test {
         dns_servers: None,
         max_size: None,
         lease_duration: None,
+        time_offset: None,
+        client_arch_list: None,
+        client_interface_id: None,
+        client_machine_id: None,
+        vendor_class_id: None,
     };
 
     const DHCP_DISCOVER: DhcpRepr = DhcpRepr {

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -29,8 +29,7 @@ mod waker;
 
 #[cfg(feature = "socket-dhcpv4")]
 pub use self::dhcpv4::{
-    Config as Dhcpv4Config, Dhcpv4Socket, Event as Dhcpv4Event, PxeBuffers as Dhcpv4PxeBuffers,
-    RetryConfig as Dhcpv4RetryConfig,
+    Config as Dhcpv4Config, Dhcpv4Socket, Event as Dhcpv4Event, RetryConfig as Dhcpv4RetryConfig,
 };
 #[cfg(feature = "socket-icmp")]
 pub use self::icmp::{Endpoint as IcmpEndpoint, IcmpPacketMetadata, IcmpSocket, IcmpSocketBuffer};

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -29,7 +29,9 @@ mod udp;
 mod waker;
 
 #[cfg(feature = "socket-dhcpv4")]
-pub use self::dhcpv4::{Config as Dhcpv4Config, Dhcpv4Socket, Event as Dhcpv4Event};
+pub use self::dhcpv4::{
+    Config as Dhcpv4Config, Dhcpv4Socket, Event as Dhcpv4Event, PxeBuffers as Dhcpv4PxeBuffers,
+};
 #[cfg(feature = "socket-icmp")]
 pub use self::icmp::{Endpoint as IcmpEndpoint, IcmpPacketMetadata, IcmpSocket, IcmpSocketBuffer};
 #[cfg(feature = "socket-raw")]
@@ -75,7 +77,7 @@ pub enum Socket<'a> {
     #[cfg(feature = "socket-tcp")]
     Tcp(TcpSocket<'a>),
     #[cfg(feature = "socket-dhcpv4")]
-    Dhcpv4(Dhcpv4Socket),
+    Dhcpv4(Dhcpv4Socket<'a>),
 }
 
 impl<'a> Socket<'a> {
@@ -128,4 +130,4 @@ from_socket!(UdpSocket<'a>, Udp);
 #[cfg(feature = "socket-tcp")]
 from_socket!(TcpSocket<'a>, Tcp);
 #[cfg(feature = "socket-dhcpv4")]
-from_socket!(Dhcpv4Socket, Dhcpv4);
+from_socket!(Dhcpv4Socket<'a>, Dhcpv4);

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -1,15 +1,28 @@
-//! Communication between endpoints.
-//!
-//! The `socket` module deals with *network endpoints* and *buffering*.
-//! It provides interfaces for accessing buffers of data, and protocol state
-//! machines for filling and emptying these buffers.
-//!
-//! The programming interface implemented here differs greatly from the common
-//! Berkeley socket interface. Specifically, in the Berkeley interface the
-//! buffering is implicit: the operating system decides on the good size for a
-//! buffer and manages it. The interface implemented by this module uses
-//! explicit buffering: you decide on the good size for a buffer, allocate it,
-//! and let the networking stack use it.
+/*! Communication between endpoints.
+ //! Communication between endpoints.
+ //!
+ //! The `socket` module deals with *network endpoints* and *buffering*.
+ //! It provides interfaces for accessing buffers of data, and protocol state
+ //! machines for filling and emptying these buffers.
+ //!
+ //! The programming interface implemented here differs greatly from the common
+ //! Berkeley socket interface. Specifically, in the Berkeley interface the
+ //! buffering is implicit: the operating system decides on the good size for a
+ //! buffer and manages it. The interface implemented by this module uses
+ //! explicit buffering: you decide on the good size for a buffer, allocate it,
+ //! and let the networking stack use it.
+
+The `socket` module deals with *network endpoints* and *buffering*.
+It provides interfaces for accessing buffers of data, and protocol state machines
+for filling and emptying these buffers.
+
+The programming interface implemented here differs greatly from the common Berkeley socket
+interface. Specifically, in the Berkeley interface the buffering is implicit:
+the operating system decides on the good size for a buffer and manages it.
+The interface implemented by this module uses explicit buffering: you decide on the good
+size for a buffer, allocate it, and let the networking stack use it.
+*/
+
 
 use crate::{iface::Context, time::Instant};
 

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -1,17 +1,4 @@
 /*! Communication between endpoints.
- //! Communication between endpoints.
- //!
- //! The `socket` module deals with *network endpoints* and *buffering*.
- //! It provides interfaces for accessing buffers of data, and protocol state
- //! machines for filling and emptying these buffers.
- //!
- //! The programming interface implemented here differs greatly from the common
- //! Berkeley socket interface. Specifically, in the Berkeley interface the
- //! buffering is implicit: the operating system decides on the good size for a
- //! buffer and manages it. The interface implemented by this module uses
- //! explicit buffering: you decide on the good size for a buffer, allocate it,
- //! and let the networking stack use it.
-
 The `socket` module deals with *network endpoints* and *buffering*.
 It provides interfaces for accessing buffers of data, and protocol state machines
 for filling and emptying these buffers.

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -1,18 +1,17 @@
-/*! Communication between endpoints.
+//! Communication between endpoints.
+//!
+//! The `socket` module deals with *network endpoints* and *buffering*.
+//! It provides interfaces for accessing buffers of data, and protocol state
+//! machines for filling and emptying these buffers.
+//!
+//! The programming interface implemented here differs greatly from the common
+//! Berkeley socket interface. Specifically, in the Berkeley interface the
+//! buffering is implicit: the operating system decides on the good size for a
+//! buffer and manages it. The interface implemented by this module uses
+//! explicit buffering: you decide on the good size for a buffer, allocate it,
+//! and let the networking stack use it.
 
-The `socket` module deals with *network endpoints* and *buffering*.
-It provides interfaces for accessing buffers of data, and protocol state machines
-for filling and emptying these buffers.
-
-The programming interface implemented here differs greatly from the common Berkeley socket
-interface. Specifically, in the Berkeley interface the buffering is implicit:
-the operating system decides on the good size for a buffer and manages it.
-The interface implemented by this module uses explicit buffering: you decide on the good
-size for a buffer, allocate it, and let the networking stack use it.
-*/
-
-use crate::iface::Context;
-use crate::time::Instant;
+use crate::{iface::Context, time::Instant};
 
 #[cfg(feature = "socket-dhcpv4")]
 mod dhcpv4;
@@ -31,6 +30,7 @@ mod waker;
 #[cfg(feature = "socket-dhcpv4")]
 pub use self::dhcpv4::{
     Config as Dhcpv4Config, Dhcpv4Socket, Event as Dhcpv4Event, PxeBuffers as Dhcpv4PxeBuffers,
+    RetryConfig as Dhcpv4RetryConfig,
 };
 #[cfg(feature = "socket-icmp")]
 pub use self::icmp::{Endpoint as IcmpEndpoint, IcmpPacketMetadata, IcmpSocket, IcmpSocketBuffer};
@@ -58,9 +58,10 @@ pub(crate) enum PollAt {
 
 /// A network socket.
 ///
-/// This enumeration abstracts the various types of sockets based on the IP protocol.
-/// To downcast a `Socket` value to a concrete socket, use the [AnySocket] trait,
-/// e.g. to get `UdpSocket`, call `UdpSocket::downcast(socket)`.
+/// This enumeration abstracts the various types of sockets based on the IP
+/// protocol. To downcast a `Socket` value to a concrete socket, use the
+/// [AnySocket] trait, e.g. to get `UdpSocket`, call
+/// `UdpSocket::downcast(socket)`.
 ///
 /// It is usually more convenient to use [SocketSet::get] instead.
 ///

--- a/src/wire/dhcpv4.rs
+++ b/src/wire/dhcpv4.rs
@@ -458,8 +458,8 @@ impl<T: AsRef<[u8]>> Packet<T> {
     /// Returns the transaction ID.
     ///
     /// The transaction ID (called `xid` in the specification) is a random number used to
-     /// associate messages and responses between client and server. The number is chosen by
-     /// the client.
+    /// associate messages and responses between client and server. The number is chosen by
+    /// the client.
     pub fn transaction_id(&self) -> u32 {
         let field = &self.buffer.as_ref()[field::XID];
         NetworkEndian::read_u32(field)

--- a/src/wire/dhcpv4.rs
+++ b/src/wire/dhcpv4.rs
@@ -278,8 +278,7 @@ impl<'a> DhcpOption<'a> {
     }
 }
 
-/// A read/write wrapper around a Dynamic Host Configuration Protocol packet
-/// buffer.
+/// A read/write wrapper around a Dynamic Host Configuration Protocol packet buffer.
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Packet<T: AsRef<[u8]>> {
@@ -458,16 +457,15 @@ impl<T: AsRef<[u8]>> Packet<T> {
 
     /// Returns the transaction ID.
     ///
-    /// The transaction ID (called `xid` in the specification) is a random
-    /// number used to associate messages and responses between client and
-    /// server. The number is chosen by the client.
+    /// The transaction ID (called `xid` in the specification) is a random number used to
+     /// associate messages and responses between client and server. The number is chosen by
+     /// the client.
     pub fn transaction_id(&self) -> u32 {
         let field = &self.buffer.as_ref()[field::XID];
         NetworkEndian::read_u32(field)
     }
 
-    /// Returns the hardware address of the client (called `chaddr` in the
-    /// specification).
+    /// Returns the hardware address of the client (called `chaddr` in the specification).
     ///
     /// Only ethernet is supported by `smoltcp`, so this functions returns
     /// an `EthernetAddress`.
@@ -478,16 +476,15 @@ impl<T: AsRef<[u8]>> Packet<T> {
 
     /// Returns the value of the `hops` field.
     ///
-    /// The `hops` field is set to zero by clients and optionally used by relay
-    /// agents.
+    /// The `hops` field is set to zero by clients and optionally used by relay agents.
     pub fn hops(&self) -> u8 {
         self.buffer.as_ref()[field::HOPS]
     }
 
     /// Returns the value of the `secs` field.
     ///
-    /// The secs field is filled by clients and describes the number of seconds
-    /// elapsed since client began process.
+    /// The secs field is filled by clients and describes the number of seconds elapsed
+    /// since client began process.
     pub fn secs(&self) -> u16 {
         let field = &self.buffer.as_ref()[field::SECS];
         NetworkEndian::read_u16(field)
@@ -503,10 +500,9 @@ impl<T: AsRef<[u8]>> Packet<T> {
 
     /// Returns the Ipv4 address of the client, zero if not set.
     ///
-    /// This corresponds to the `ciaddr` field in the DHCP specification.
-    /// According to it, this field is “only filled in if client is in
-    /// `BOUND`, `RENEW` or `REBINDING` state and can respond to ARP
-    /// requests”.
+    /// This corresponds to the `ciaddr` field in the DHCP specification. According to it,
+    /// this field is “only filled in if client is in `BOUND`, `RENEW` or `REBINDING` state
+    /// and can respond to ARP requests”.
     pub fn client_ip(&self) -> Ipv4Address {
         let field = &self.buffer.as_ref()[field::CIADDR];
         Ipv4Address::from_bytes(field)
@@ -569,12 +565,11 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Packet<&'a T> {
 }
 
 impl<T: AsRef<[u8]> + AsMut<[u8]>> Packet<T> {
-    /// Sets the optional `sname` (“server name”) and `file` (“boot file name”)
-    /// fields to zero.
+    /// Sets the optional `sname` (“server name”) and `file` (“boot file name”) fields to zero.
     ///
-    /// The fields are not commonly used, so we set their value always to zero.
-    /// **This method must be called when creating a packet, otherwise the
-    /// emitted values for these fields are undefined!**
+    /// The fields are not commonly used, so we set their value always to zero. **This method
+    /// must be called when creating a packet, otherwise the emitted values for these fields
+    /// are undefined!**
     pub fn set_sname_and_boot_file_to_zero(&mut self) {
         let data = self.buffer.as_mut();
         for byte in &mut data[field::SNAME] {
@@ -617,17 +612,16 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Packet<T> {
 
     /// Sets the hardware address length.
     ///
-    /// Only ethernet is supported, so this field should be set to the value
-    /// `6`.
+    /// Only ethernet is supported, so this field should be set to the value `6`.
     pub fn set_hardware_len(&mut self, value: u8) {
         self.buffer.as_mut()[field::HLEN] = value;
     }
 
     /// Sets the transaction ID.
     ///
-    /// The transaction ID (called `xid` in the specification) is a random
-    /// number used to associate messages and responses between client and
-    /// server. The number is chosen by the client.
+    /// The transaction ID (called `xid` in the specification) is a random number used to
+    /// associate messages and responses between client and server. The number is chosen by
+    /// the client.
     pub fn set_transaction_id(&mut self, value: u32) {
         let field = &mut self.buffer.as_mut()[field::XID];
         NetworkEndian::write_u32(field, value)
@@ -646,16 +640,15 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Packet<T> {
 
     /// Sets the hops field.
     ///
-    /// The `hops` field is set to zero by clients and optionally used by relay
-    /// agents.
+    /// The `hops` field is set to zero by clients and optionally used by relay agents.
     pub fn set_hops(&mut self, value: u8) {
         self.buffer.as_mut()[field::HOPS] = value;
     }
 
     /// Sets the `secs` field.
     ///
-    /// The secs field is filled by clients and describes the number of seconds
-    /// elapsed since client began process.
+    /// The secs field is filled by clients and describes the number of seconds elapsed
+    /// since client began process.
     pub fn set_secs(&mut self, value: u16) {
         let field = &mut self.buffer.as_mut()[field::SECS];
         NetworkEndian::write_u16(field, value);
@@ -671,10 +664,9 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Packet<T> {
 
     /// Sets the Ipv4 address of the client.
     ///
-    /// This corresponds to the `ciaddr` field in the DHCP specification.
-    /// According to it, this field is “only filled in if client is in
-    /// `BOUND`, `RENEW` or `REBINDING` state and can respond to ARP
-    /// requests”.
+    /// This corresponds to the `ciaddr` field in the DHCP specification. According to it,
+    /// this field is “only filled in if client is in `BOUND`, `RENEW` or `REBINDING` state
+    /// and can respond to ARP requests”.
     pub fn set_client_ip(&mut self, value: Ipv4Address) {
         let field = &mut self.buffer.as_mut()[field::CIADDR];
         field.copy_from_slice(value.as_bytes());
@@ -753,28 +745,28 @@ impl<'a, T: AsRef<[u8]> + AsMut<[u8]> + ?Sized> Packet<&'a mut T> {
 /// +---------------------------------------------------------------+
 /// ```
 ///
-/// It is assumed that the access layer is Ethernet, so `htype` (the field
-/// representing the hardware address type) is always set to `1`, and `hlen`
-/// (which represents the hardware address length) is set to `6`.
+/// It is assumed that the access layer is Ethernet, so `htype` (the field representing the
+/// hardware address type) is always set to `1`, and `hlen` (which represents the hardware address
+/// length) is set to `6`.
 ///
 /// The `options` field has a variable length.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Repr<'a> {
-    /// This field is also known as `op` in the RFC. It indicates the type of
-    /// DHCP message this packet represents.
+    /// This field is also known as `op` in the RFC. It indicates the type of DHCP message this
+    /// packet represents.
     pub message_type: MessageType,
-    /// This field is also known as `xid` in the RFC. It is a random number
-    /// chosen by the client, used by the client and server to associate
-    /// messages and responses between a client and a server.
+    /// This field is also known as `xid` in the RFC. It is a random number chosen by the client,
+    /// used by the client and server to associate messages and responses between a client and a
+    /// server.
     pub transaction_id: u32,
     /// seconds elapsed since client began address acquisition or renewal
     /// process the DHCPREQUEST message MUST use the same value in the DHCP
     /// message header's 'secs' field and be sent to the same IP broadcast
     /// address as the original DHCPDISCOVER message.
     pub secs: u16,
-    /// This field is also known as `chaddr` in the RFC and for networks where
-    /// the access layer is ethernet, it is the client MAC address.
+    /// This field is also known as `chaddr` in the RFC and for networks where the access layer is
+     /// ethernet, it is the client MAC address.
     pub client_hardware_address: EthernetAddress,
     /// This field is also known as `ciaddr` in the RFC. It is only filled in if
     /// client is in BOUND, RENEW or REBINDING state and can respond to ARP
@@ -782,9 +774,8 @@ pub struct Repr<'a> {
     pub client_ip: Ipv4Address,
     /// This field is also known as `yiaddr` in the RFC.
     pub your_ip: Ipv4Address,
-    /// This field is also known as `siaddr` in the RFC. It may be set by the
-    /// server in DHCPOFFER and DHCPACK messages, and represent the address
-    /// of the next server to use in bootstrap.
+    /// This field is also known as `siaddr` in the RFC. It may be set by the server in DHCPOFFER
+    /// and DHCPACK messages, and represent the address of the next server to use in bootstrap.
     pub server_ip: Ipv4Address,
     /// Boot file name, null terminated string; "generic"
     /// name or null in DHCPDISCOVER, fully qualified
@@ -795,45 +786,37 @@ pub struct Repr<'a> {
     pub router: Option<Ipv4Address>,
     /// This field comes from a corresponding DhcpOption.
     pub subnet_mask: Option<Ipv4Address>,
-    /// This field is also known as `giaddr` in the RFC. In order to allow DHCP
-    /// clients on subnets not directly served by DHCP servers to
-    /// communicate with DHCP servers, DHCP relay agents can be installed on
-    /// these subnets. The DHCP client broadcasts on the local link; the relay
-    /// agent receives the broadcast and transmits it to one or more DHCP
-    /// servers using unicast. The relay agent stores its own IP address in
-    /// the `relay_agent_ip` field of the DHCP packet. The DHCP server uses
-    /// the `relay_agent_ip` to determine the subnet on which the relay agent
-    /// received the broadcast, and allocates an IP address on that subnet. When
-    /// the DHCP server replies to the client, it sends the reply to the
-    /// `relay_agent_ip` address, again using unicast. The relay agent then
-    /// retransmits the response on the local network
+    /// This field is also known as `giaddr` in the RFC. In order to allow DHCP clients on subnets
+    /// not directly served by DHCP servers to communicate with DHCP servers, DHCP relay agents can
+    /// be installed on these subnets. The DHCP client broadcasts on the local link; the relay
+    /// agent receives the broadcast and transmits it to one or more DHCP servers using unicast.
+    /// The relay agent stores its own IP address in the `relay_agent_ip` field of the DHCP packet.
+    /// The DHCP server uses the `relay_agent_ip` to determine the subnet on which the relay agent
+    /// received the broadcast, and allocates an IP address on that subnet. When the DHCP server
+    /// replies to the client, it sends the reply to the `relay_agent_ip` address, again using
+    /// unicast. The relay agent then retransmits the response on the local network
     pub relay_agent_ip: Ipv4Address,
-    /// Broadcast flags. It can be set in DHCPDISCOVER, DHCPINFORM and
-    /// DHCPREQUEST message if the client requires the response to be
-    /// broadcasted.
+    /// Broadcast flags. It can be set in DHCPDISCOVER, DHCPINFORM and DHCPREQUEST message if the
+    /// client requires the response to be broadcasted.
     pub broadcast: bool,
-    /// The "requested IP address" option. It can be used by clients in
-    /// DHCPREQUEST or DHCPDISCOVER messages, or by servers in DHCPDECLINE
-    /// messages.
+    /// The "requested IP address" option. It can be used by clients in DHCPREQUEST or DHCPDISCOVER
+    /// messages, or by servers in DHCPDECLINE messages.
     pub requested_ip: Option<Ipv4Address>,
     /// The "client identifier" option.
     ///
-    /// The 'client identifier' is an opaque key, not to be interpreted by the
-    /// server; for example, the 'client identifier' may contain a hardware
-    /// address, identical to the contents of the 'chaddr' field, or it may
-    /// contain another type of identifier, such as a DNS name.  The 'client
-    /// identifier' chosen by a DHCP client MUST be unique to that client within
-    /// the subnet to which the client is attached. If the client uses a
-    /// 'client identifier' in one message, it MUST use that same identifier
-    /// in all subsequent messages, to ensure that all servers
+    /// The 'client identifier' is an opaque key, not to be interpreted by the server; for example,
+    /// the 'client identifier' may contain a hardware address, identical to the contents of the
+    /// 'chaddr' field, or it may contain another type of identifier, such as a DNS name.  The
+    /// 'client identifier' chosen by a DHCP client MUST be unique to that client within the subnet
+    /// to which the client is attached. If the client uses a 'client identifier' in one message,
+    /// it MUST use that same identifier in all subsequent messages, to ensure that all servers
     /// correctly identify the client.
     pub client_identifier: Option<EthernetAddress>,
-    /// The "server identifier" option. It is used both to identify a DHCP
-    /// server in a DHCP message and as a destination address from clients
-    /// to servers.
+    /// The "server identifier" option. It is used both to identify a DHCP server
+    /// in a DHCP message and as a destination address from clients to servers.
     pub server_identifier: Option<Ipv4Address>,
-    /// The parameter request list informs the server about which configuration
-    /// parameters the client is interested in.
+    /// The parameter request list informs the server about which configuration parameters
+    /// the client is interested in.
     pub parameter_request_list: Option<&'a [u8]>,
     /// DNS servers
     pub dns_servers: Option<[Option<Ipv4Address>; MAX_DNS_SERVER_COUNT]>,
@@ -848,8 +831,7 @@ pub struct Repr<'a> {
 }
 
 impl<'a> Repr<'a> {
-    /// Return the length of a packet that will be emitted from this high-level
-    /// representation.
+    /// Return the length of a packet that will be emitted from this high-level representation.
     pub fn buffer_len(&self) -> usize {
         let mut len = field::OPTIONS.start;
         // message type and end-of-options options
@@ -1454,8 +1436,8 @@ mod test {
         let packet = Packet::new_unchecked(ACK_LEASE_TIME_BYTES);
         let repr = Repr::parse(&packet).unwrap();
 
-        // Verify that the lease time in the ACK is properly parsed. The packet contains
-        // a lease duration of 598s.
+        // Verify that the lease time in the ACK is properly parsed. The packet contains a lease
+        // duration of 598s.
         assert_eq!(repr.lease_duration, Some(598));
     }
 }

--- a/src/wire/dhcpv4.rs
+++ b/src/wire/dhcpv4.rs
@@ -90,22 +90,34 @@ impl<T: AsRef<[u8]>> DhcpOptionsBuffer<T> {
                 buf = new_buf;
                 Some(option)
             }
-        }).filter(|opt| !matches!(
-            opt,
-            DhcpOption::EndOfList
-            | DhcpOption::Pad
-            | DhcpOption::MessageType(_)
-            | DhcpOption::RequestedIp(_)
-            | DhcpOption::ClientIdentifier(_)
-            | DhcpOption::ServerIdentifier(_)
-            | DhcpOption::Router(_)
-            | DhcpOption::SubnetMask(_)
-            | DhcpOption::MaximumDhcpMessageSize(_)
-            | DhcpOption::IpLeaseTime(_)
-            | DhcpOption::Other { kind: field::OPT_PARAMETER_REQUEST_LIST, .. }
-            | DhcpOption::Other { kind: field::OPT_DOMAIN_NAME_SERVER, .. }
-            | DhcpOption::Other { kind: field::OPT_BOOTFILE_NAME, .. }
-        ))
+        })
+        .filter(|opt| {
+            !matches!(
+                opt,
+                DhcpOption::EndOfList
+                    | DhcpOption::Pad
+                    | DhcpOption::MessageType(_)
+                    | DhcpOption::RequestedIp(_)
+                    | DhcpOption::ClientIdentifier(_)
+                    | DhcpOption::ServerIdentifier(_)
+                    | DhcpOption::Router(_)
+                    | DhcpOption::SubnetMask(_)
+                    | DhcpOption::MaximumDhcpMessageSize(_)
+                    | DhcpOption::IpLeaseTime(_)
+                    | DhcpOption::Other {
+                        kind: field::OPT_PARAMETER_REQUEST_LIST,
+                        ..
+                    }
+                    | DhcpOption::Other {
+                        kind: field::OPT_DOMAIN_NAME_SERVER,
+                        ..
+                    }
+                    | DhcpOption::Other {
+                        kind: field::OPT_BOOTFILE_NAME,
+                        ..
+                    }
+            )
+        })
     }
 
     pub fn buffer_len(&self) -> usize {

--- a/src/wire/dhcpv4.rs
+++ b/src/wire/dhcpv4.rs
@@ -1332,7 +1332,12 @@ mod test {
             server_identifier: None,
             parameter_request_list: Some(&[1, 3, 6, 42]),
             dns_servers: None,
-            options: None,
+            options: Some(DhcpOptionsBuffer {
+                buffer: &[
+                    53, 1, 1, 61, 7, 1, 0, 11, 130, 1, 252, 66, 50, 4, 0, 0, 0, 0, 57, 2, 5, 220,
+                    55, 4, 1, 3, 6, 42, 255, 0, 0, 0, 0, 0, 0, 0,
+                ],
+            }),
         }
     }
 

--- a/src/wire/dhcpv4.rs
+++ b/src/wire/dhcpv4.rs
@@ -60,12 +60,12 @@ impl MessageType {
 /// A buffer for DHCP options.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct DhcpOptionsRepr<T> {
+pub struct DhcpOptionsBuffer<T> {
     /// The underlying buffer, directly from the DHCP packet representation.
     buffer: T,
 }
 
-impl<T: AsRef<[u8]>> DhcpOptionsRepr<T> {
+impl<T: AsRef<[u8]>> DhcpOptionsBuffer<T> {
     pub fn new(buffer: T) -> Self {
         Self { buffer }
     }
@@ -86,9 +86,9 @@ impl<T: AsRef<[u8]>> DhcpOptionsRepr<T> {
     }
 }
 
-impl<T: AsMut<[u8]> + AsRef<[u8]>> DhcpOptionsRepr<T> {
-    pub fn as_slice(&self) -> DhcpOptionsRepr<&[u8]> {
-        DhcpOptionsRepr {
+impl<T: AsMut<[u8]> + AsRef<[u8]>> DhcpOptionsBuffer<T> {
+    pub fn as_slice(&self) -> DhcpOptionsBuffer<&[u8]> {
+        DhcpOptionsBuffer {
             buffer: self.buffer.as_ref(),
         }
     }
@@ -826,7 +826,7 @@ pub struct Repr<'a> {
     /// When returned from [`Repr::parse`], this field contains all DHCP options
     /// present in that packet. However, when calling [`Repr::emit`], this field
     /// should contain only additional DHCP options not known to smoltcp.
-    pub options: Option<DhcpOptionsRepr<&'a [u8]>>,
+    pub options: Option<DhcpOptionsBuffer<&'a [u8]>>,
 }
 
 impl<'a> Repr<'a> {
@@ -996,7 +996,7 @@ impl<'a> Repr<'a> {
             max_size,
             lease_duration,
             message_type: message_type?,
-            options: Some(DhcpOptionsRepr {
+            options: Some(DhcpOptionsBuffer {
                 buffer: all_options,
             }),
         })

--- a/src/wire/dhcpv4.rs
+++ b/src/wire/dhcpv4.rs
@@ -67,12 +67,7 @@ pub struct DhcpOptionsBuffer<T> {
 
 impl<T: AsRef<[u8]>> PartialEq for DhcpOptionsBuffer<T> {
     fn eq(&self, other: &Self) -> bool {
-        let mut lhs = self.parse();
-        let mut rhs = other.parse();
-        (&mut lhs).zip(&mut rhs).all(|(a, b)| a == b)
-        // Verify that both iterators are spent.
-        && lhs.next().is_none()
-        && rhs.next().is_none()
+        self.buffer.as_ref()[..self.len] == other.buffer.as_ref()[..other.len]
     }
 }
 impl<T: AsRef<[u8]>> Eq for DhcpOptionsBuffer<T> {}

--- a/src/wire/dhcpv4.rs
+++ b/src/wire/dhcpv4.rs
@@ -766,11 +766,10 @@ pub struct Repr<'a> {
     /// address as the original DHCPDISCOVER message.
     pub secs: u16,
     /// This field is also known as `chaddr` in the RFC and for networks where the access layer is
-     /// ethernet, it is the client MAC address.
+    /// ethernet, it is the client MAC address.
     pub client_hardware_address: EthernetAddress,
-    /// This field is also known as `ciaddr` in the RFC. It is only filled in if
-    /// client is in BOUND, RENEW or REBINDING state and can respond to ARP
-    /// requests.
+    /// This field is also known as `ciaddr` in the RFC. It is only filled in if client is in
+    /// BOUND, RENEW or REBINDING state and can respond to ARP requests.
     pub client_ip: Ipv4Address,
     /// This field is also known as `yiaddr` in the RFC.
     pub your_ip: Ipv4Address,

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -243,7 +243,7 @@ pub use self::tcp::{
 
 #[cfg(feature = "proto-dhcpv4")]
 pub use self::dhcpv4::{
-    DhcpOption, DhcpOptionsRepr, Flags as DhcpFlags, MessageType as DhcpMessageType,
+    DhcpOption, DhcpOptionsBuffer, Flags as DhcpFlags, MessageType as DhcpMessageType,
     OpCode as DhcpOpCode, Packet as DhcpPacket, Repr as DhcpRepr, CLIENT_PORT as DHCP_CLIENT_PORT,
     MAX_DNS_SERVER_COUNT as DHCP_MAX_DNS_SERVER_COUNT, SERVER_PORT as DHCP_SERVER_PORT,
 };

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -238,10 +238,10 @@ pub use self::tcp::{
 
 #[cfg(feature = "proto-dhcpv4")]
 pub use self::dhcpv4::{
-    ClientArchType as PxeArchType, DhcpOption, Flags as DhcpFlags, MachineId as PxeMachineId,
-    MessageType as DhcpMessageType, NetworkInterfaceType as PxeInterfaceType,
-    NetworkInterfaceVersion as PxeInterfaceVersion, OpCode as DhcpOpCode, Packet as DhcpPacket,
-    Repr as DhcpRepr, CLIENT_PORT as DHCP_CLIENT_PORT,
+    ClientArchType as PxeArchType, DhcpOption, DhcpOptionsRepr, Flags as DhcpFlags,
+    MachineId as PxeMachineId, MessageType as DhcpMessageType,
+    NetworkInterfaceType as PxeInterfaceType, NetworkInterfaceVersion as PxeInterfaceVersion,
+    OpCode as DhcpOpCode, Packet as DhcpPacket, Repr as DhcpRepr, CLIENT_PORT as DHCP_CLIENT_PORT,
     MAX_DNS_SERVER_COUNT as DHCP_MAX_DNS_SERVER_COUNT, SERVER_PORT as DHCP_SERVER_PORT,
 };
 

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -239,9 +239,9 @@ pub use self::tcp::{
 #[cfg(feature = "proto-dhcpv4")]
 pub use self::dhcpv4::{
     ClientArchType as PxeArchType, DhcpOption, Flags as DhcpFlags, MachineId as PxeMachineId,
-    MachineIdType as PxeMachineIdType, MessageType as DhcpMessageType,
-    NetworkInterfaceType as PxeInterfaceType, NetworkInterfaceVersion as PxeInterfaceVersion,
-    OpCode as DhcpOpCode, Packet as DhcpPacket, Repr as DhcpRepr, CLIENT_PORT as DHCP_CLIENT_PORT,
+    MessageType as DhcpMessageType, NetworkInterfaceType as PxeInterfaceType,
+    NetworkInterfaceVersion as PxeInterfaceVersion, OpCode as DhcpOpCode, Packet as DhcpPacket,
+    Repr as DhcpRepr, CLIENT_PORT as DHCP_CLIENT_PORT,
     MAX_DNS_SERVER_COUNT as DHCP_MAX_DNS_SERVER_COUNT, SERVER_PORT as DHCP_SERVER_PORT,
 };
 

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -238,9 +238,11 @@ pub use self::tcp::{
 
 #[cfg(feature = "proto-dhcpv4")]
 pub use self::dhcpv4::{
-    MessageType as DhcpMessageType, Packet as DhcpPacket, Repr as DhcpRepr,
-    CLIENT_PORT as DHCP_CLIENT_PORT, MAX_DNS_SERVER_COUNT as DHCP_MAX_DNS_SERVER_COUNT,
-    SERVER_PORT as DHCP_SERVER_PORT,
+    ClientArchType as PxeArchType, DhcpOption, Flags as DhcpFlags, MachineId as PxeMachineId,
+    MachineIdType as PxeMachineIdType, MessageType as DhcpMessageType,
+    NetworkInterfaceType as PxeInterfaceType, NetworkInterfaceVersion as PxeInterfaceVersion,
+    OpCode as DhcpOpCode, Packet as DhcpPacket, Repr as DhcpRepr, CLIENT_PORT as DHCP_CLIENT_PORT,
+    MAX_DNS_SERVER_COUNT as DHCP_MAX_DNS_SERVER_COUNT, SERVER_PORT as DHCP_SERVER_PORT,
 };
 
 /// Representation of an hardware address, such as an Ethernet address or an IEEE802.15.4 address.

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -238,9 +238,7 @@ pub use self::tcp::{
 
 #[cfg(feature = "proto-dhcpv4")]
 pub use self::dhcpv4::{
-    ClientArchType as PxeArchType, DhcpOption, DhcpOptionsRepr, Flags as DhcpFlags,
-    MachineId as PxeMachineId, MessageType as DhcpMessageType,
-    NetworkInterfaceType as PxeInterfaceType, NetworkInterfaceVersion as PxeInterfaceVersion,
+    DhcpOption, DhcpOptionsRepr, Flags as DhcpFlags, MessageType as DhcpMessageType,
     OpCode as DhcpOpCode, Packet as DhcpPacket, Repr as DhcpRepr, CLIENT_PORT as DHCP_CLIENT_PORT,
     MAX_DNS_SERVER_COUNT as DHCP_MAX_DNS_SERVER_COUNT, SERVER_PORT as DHCP_SERVER_PORT,
 };


### PR DESCRIPTION
This PR is based on @Luis-Hebendanz's fork of smoltcp that adds some initial support for PXE to DHCP sockets.

From there, I've generalized it, removing most PXE specific code, but allowing users to send and receive custom DHCP options.
