### PR TITLE
Make `send_with` on UDP, raw, and ICMP sockets fallible.

### DIFF
--- a/src/socket/icmp.rs
+++ b/src/socket/icmp.rs
@@ -318,7 +318,6 @@ impl<'a> Socket<'a> {
     pub fn send_with<F, E>(
         &mut self,
         at_least: usize,
-        request: usize,
         endpoint: IpAddress,
         f: F,
     ) -> Result<Result<usize, E>, SendError>
@@ -331,7 +330,7 @@ impl<'a> Socket<'a> {
 
         let res = self
             .tx_buffer
-            .enqueue_with(at_least, request, endpoint, f)
+            .enqueue_with(at_least, endpoint, f)
             .map_err(|_| SendError::BufferFull)?;
 
         if let Ok(size) = res {

--- a/src/socket/icmp.rs
+++ b/src/socket/icmp.rs
@@ -310,7 +310,7 @@ impl<'a> Socket<'a> {
         Ok(packet_buf)
     }
 
-    /// Enqueue a packet to be send to a given remote endpoint and pass the buffer
+    /// Enqueue a packet to be sent to a given address and pass the buffer
     /// to the provided closure. The closure then returns the either size of the data written
     /// into the buffer or an error. If an error is returned, no packet is enqueued.
     ///

--- a/src/socket/icmp.rs
+++ b/src/socket/icmp.rs
@@ -310,31 +310,35 @@ impl<'a> Socket<'a> {
         Ok(packet_buf)
     }
 
-    /// Enqueue a packet to be send to a given remote address and pass the buffer
-    /// to the provided closure. The closure then returns the size of the data written
-    /// into the buffer.
+    /// Enqueue a packet to be send to a given remote endpoint and pass the buffer
+    /// to the provided closure. The closure then returns the either size of the data written
+    /// into the buffer or an error. If an error is returned, no packet is enqueued.
     ///
     /// Also see [send](#method.send).
-    pub fn send_with<F>(
+    pub fn send_with<F, E>(
         &mut self,
-        max_size: usize,
+        at_least: usize,
+        request: usize,
         endpoint: IpAddress,
         f: F,
-    ) -> Result<usize, SendError>
+    ) -> Result<Result<usize, E>, SendError>
     where
-        F: FnOnce(&mut [u8]) -> usize,
+        F: FnOnce(&mut [u8]) -> Result<usize, E>,
     {
         if endpoint.is_unspecified() {
             return Err(SendError::Unaddressable);
         }
 
-        let size = self
+        let res = self
             .tx_buffer
-            .enqueue_with_infallible(max_size, endpoint, f)
+            .enqueue_with(at_least, request, endpoint, f)
             .map_err(|_| SendError::BufferFull)?;
 
-        net_trace!("icmp:{}: buffer to send {} octets", endpoint, size);
-        Ok(size)
+        if let Ok(size) = res {
+            net_trace!("icmp:{}: buffer to send {} octets", endpoint, size);
+        }
+
+        Ok(res)
     }
 
     /// Enqueue a packet to be sent to a given remote address, and fill it from a slice.

--- a/src/socket/raw.rs
+++ b/src/socket/raw.rs
@@ -188,7 +188,7 @@ impl<'a> Socket<'a> {
         Ok(packet_buf)
     }
 
-    /// Enqueue a packet to be send to a given remote endpoint and pass the buffer
+    /// Enqueue a packet to be sent and pass the buffer
     /// to the provided closure. The closure then returns the either size of the data written
     /// into the buffer or an error. If an error is returned, no packet is enqueued.
     ///

--- a/src/socket/raw.rs
+++ b/src/socket/raw.rs
@@ -193,18 +193,13 @@ impl<'a> Socket<'a> {
     /// into the buffer or an error. If an error is returned, no packet is enqueued.
     ///
     /// Also see [send](#method.send).
-    pub fn send_with<F, E>(
-        &mut self,
-        at_least: usize,
-        request: usize,
-        f: F,
-    ) -> Result<Result<usize, E>, SendError>
+    pub fn send_with<F, E>(&mut self, at_least: usize, f: F) -> Result<Result<usize, E>, SendError>
     where
         F: FnOnce(&mut [u8]) -> Result<usize, E>,
     {
         let res = self
             .tx_buffer
-            .enqueue_with(at_least, request, (), f)
+            .enqueue_with(at_least, (), f)
             .map_err(|_| SendError::BufferFull)?;
 
         if let Ok(size) = res {

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -266,7 +266,6 @@ impl<'a> Socket<'a> {
     pub fn send_with<F, E>(
         &mut self,
         at_least: usize,
-        request: usize,
         remote_endpoint: IpEndpoint,
         f: F,
     ) -> Result<Result<usize, E>, SendError>
@@ -285,7 +284,7 @@ impl<'a> Socket<'a> {
 
         let res = self
             .tx_buffer
-            .enqueue_with(at_least, request, remote_endpoint, f)
+            .enqueue_with(at_least, remote_endpoint, f)
             .map_err(|_| SendError::BufferFull)?;
 
         if let Ok(size) = res {

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -258,7 +258,7 @@ impl<'a> Socket<'a> {
         Ok(payload_buf)
     }
 
-    /// Enqueue a packet to be send to a given remote endpoint and pass the buffer
+    /// Enqueue a packet to be sent to a given remote endpoint and pass the buffer
     /// to the provided closure. The closure then returns the either size of the data written
     /// into the buffer or an error. If an error is returned, no packet is enqueued.
     ///

--- a/src/storage/packet_buffer.rs
+++ b/src/storage/packet_buffer.rs
@@ -71,9 +71,6 @@ impl<'a, H> PacketBuffer<'a, H> {
         self.metadata_ring.is_full()
     }
 
-    // There is currently no enqueue_with() because of the complexity of managing padding
-    // in case of failure.
-
     /// Enqueue a single packet with the given header into the buffer, and
     /// return a reference to its payload, or return `Err(Full)`
     /// if the buffer is full.


### PR DESCRIPTION
This PR adds `enqueue_with` to the `PacketBuffer` type that supports allocating a buffer in a fallible manner. If the provided closure returns an `Err`, then the changes to the payload and metadata rings are rolled back.

Also, the `send_with` function available on UDP, raw, and ICMP sockets has been changed slightly to allow for fallible closures.