### PR TITLE
Fixes 6LoWPAN fragmentation

### DIFF
--- a/src/wire/sixlowpan.rs
+++ b/src/wire/sixlowpan.rs
@@ -365,14 +365,6 @@ pub mod frag {
     }
 
     impl Repr {
-        #[cfg(feature = "proto-sixlowpan-fragmentation")]
-        pub(crate) fn set_offset(&mut self, value: u8) {
-            match self {
-                Repr::FirstFragment { .. } => (),
-                Repr::Fragment { offset, .. } => *offset = value,
-            }
-        }
-
         /// Parse a 6LoWPAN Fragment header.
         pub fn parse<T: AsRef<[u8]>>(packet: &Packet<T>) -> Result<Self> {
             let size = packet.datagram_size();


### PR DESCRIPTION
The calculation for the fragment sizes was wrong. This commit seems to
fix the calculation. This replaces #641.

It is a first step of improving the fragment size calculation (still really error-prone) and should be improved in future PRs.