### PR TITLE
Fix `defmt` problems

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.53.0
+          toolchain: 1.60.0
           override: true
           components: clippy
       - uses: actions-rs/clippy-check@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,10 @@ jobs:
   check:
     runs-on: ubuntu-20.04
     continue-on-error: ${{ matrix.rust == 'nightly' }}
+    env:
+      # Set DEFMT_LOG to trace so that all net_{error, .., trace} messages
+      # are actually compiled and verified
+      DEFMT_LOG: "trace"
     strategy:
       matrix:
         # Test on stable, MSRV, and nightly.
@@ -75,6 +79,7 @@ jobs:
           # These feature sets cannot run tests, so we only check they build.
           - medium-ip medium-ethernet medium-ieee802154 proto-ipv6 proto-ipv6 proto-igmp proto-dhcpv4 socket-raw socket-udp socket-tcp socket-icmp socket-dns async
           - defmt medium-ip medium-ethernet proto-ipv6 proto-ipv6 proto-igmp proto-dhcpv4 socket-raw socket-udp socket-tcp socket-icmp socket-dns async
+          - defmt alloc medium-ip medium-ethernet proto-ipv6 proto-ipv6 proto-igmp proto-dhcpv4 socket-raw socket-udp socket-tcp socket-icmp socket-dns async
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         # Failure is permitted on nightly.
         rust:
           - stable
-          - 1.56.0
+          - 1.60.0
           - nightly
 
         features:
@@ -68,7 +68,7 @@ jobs:
         # Failure is permitted on nightly.
         rust:
           - stable
-          - 1.56.0
+          - 1.60.0
           - nightly
 
         features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove IpVersion::Unspecified
 - Remove IpAddress::Unspecified
 - When sending packets with a raw socket, the source IP address is sent unmodified (it was previously replaced with the interface's address if it was unspecified).
+- Fix enable `defmt/alloc` if `alloc` or `std` is enabled.
+- Minimum Supported Rust Version (MSRV) **bumped** from 1.56 to 1.60
 
 ## [0.8.1] - 2022-05-12
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ rand = "0.8"
 url = "2.0"
 
 [features]
-std = ["managed/std"]
-alloc = ["managed/alloc"]
+std = ["managed/std", "defmt?/alloc"]
+alloc = ["managed/alloc", "defmt?/alloc"]
 verbose = []
 "medium-ethernet" = ["socket"]
 "medium-ip" = ["socket"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ include complicated compile-time computations, such as macro or type tricks, eve
 at cost of performance degradation.
 
 _smoltcp_ does not need heap allocation *at all*, is [extensively documented][docs],
-and compiles on stable Rust 1.56 and later.
+and compiles on stable Rust 1.60 and later.
 
 _smoltcp_ achieves [~Gbps of throughput](#examplesbenchmarkrs) when tested against
 the Linux TCP stack in loopback mode.

--- a/src/iface/fragmentation.rs
+++ b/src/iface/fragmentation.rs
@@ -17,6 +17,7 @@ pub struct PacketAssembler<'a> {
 }
 
 /// Holds the state of the assembling of one packet.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq)]
 enum AssemblerState {
     NotInit,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 //!
 //! # Minimum Supported Rust Version (MSRV)
 //!
-//! This crate is guaranteed to compile on stable Rust 1.56 and up with any valid set of features.
+//! This crate is guaranteed to compile on stable Rust 1.60 and up with any valid set of features.
 //! It *might* compile on older versions but that may change in any new patch release.
 //!
 //! The exception is when using the `defmt` feature, in which case `defmt`'s MSRV applies, which


### PR DESCRIPTION
The missing derive broke a `net_debug!` print when compiled with `DEFMT_LOG=debug`

[This one](https://github.com/smoltcp-rs/smoltcp/blob/a6f6a6142f0040bbe2e3fbccbb869e5c675710ad/src/iface/fragmentation.rs#L181), to be specific, when compiling with (something similar to) `DEFMT_LOG=debug cargo c --features socket-raw,socket-udp,medium-ethernet,proto-ipv4,defmt --no-default-features`

Additionally, `--features defmt,alloc` didn't work. Enabling `defmt/alloc` when `alloc` is enabled fixes that.