### PR TITLE
Make the packet fragmentation cache timeout user configurable

### DIFF
--- a/src/iface/interface.rs
+++ b/src/iface/interface.rs
@@ -399,8 +399,8 @@ let iface = builder.finalize(&mut device);
     }
 
     #[cfg(feature = "proto-sixlowpan-fragmentation")]
-    pub fn sixlowpan_fragments_cache_timeout(mut self, sec: u64) -> Self {
-        self.sixlowpan_fragments_cache_timeout = Duration::from_secs(sec);
+    pub fn sixlowpan_fragments_cache_timeout(mut self, timeout: Duration) -> Self {
+        self.sixlowpan_fragments_cache_timeout = timeout;
         self
     }
 

--- a/src/iface/interface.rs
+++ b/src/iface/interface.rs
@@ -1665,7 +1665,7 @@ impl<'a> InterfaceInner<'a> {
                             frag.datagram_size() as usize - uncompressed_header_size
                                 + compressed_header_size
                         ),
-                        self.now + Duration::from_secs(60),
+                        self.now + Duration::from_secs(5),
                         -((uncompressed_header_size - compressed_header_size) as isize),
                     ));
                 }

--- a/src/iface/interface.rs
+++ b/src/iface/interface.rs
@@ -400,6 +400,9 @@ let iface = builder.finalize(&mut device);
 
     #[cfg(feature = "proto-sixlowpan-fragmentation")]
     pub fn sixlowpan_fragments_cache_timeout(mut self, timeout: Duration) -> Self {
+        if timeout > Duration::from_secs(60) {
+            net_debug!("RFC 4944 specifies that the reassembly timeout MUST be set to a maximum of 60 seconds");
+        }
         self.sixlowpan_fragments_cache_timeout = timeout;
         self
     }


### PR DESCRIPTION
60 seconds is a really long time to hold onto these fragments. Since I'm working on a memory constrained microcontroller I can only have so fragmented packets in flight at a given point and it's not uncommon to miss a fragment and then be unable to receive any fragments until this evicts.