### PR TITLE
Add additional DHCP configurability (try two)

### DIFF
--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -352,9 +352,12 @@ impl<'a> Socket<'a> {
                 }
             }
             (ClientState::Renewing(state), DhcpMessageType::Ack) => {
-                if let Some((config, renew_at, expires_at)) =
-                    Self::parse_ack(cx.now(), &dhcp_repr, self.max_lease_duration, state.config.server)
-                {
+                if let Some((config, renew_at, expires_at)) = Self::parse_ack(
+                    cx.now(),
+                    &dhcp_repr,
+                    self.max_lease_duration,
+                    state.config.server,
+                ) {
                     state.renew_at = renew_at;
                     state.expires_at = expires_at;
                     if state.config != config {
@@ -625,7 +628,10 @@ impl<'a> Socket<'a> {
                 address: state.config.address,
                 router: state.config.router,
                 dns_servers: state.config.dns_servers,
-                packet: self.receive_packet_buffer.as_deref().map(DhcpPacket::new_unchecked),
+                packet: self
+                    .receive_packet_buffer
+                    .as_deref()
+                    .map(DhcpPacket::new_unchecked),
             }))
         } else {
             self.config_changed = false;

--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -3,7 +3,7 @@ use core::task::Waker;
 
 use crate::iface::Context;
 use crate::time::{Duration, Instant};
-use crate::wire::dhcpv4::field as dhcpv4_field;
+use crate::wire::dhcpv4::{field as dhcpv4_field, DhcpOptionsBuffer};
 use crate::wire::HardwareAddress;
 use crate::wire::{
     DhcpMessageType, DhcpPacket, DhcpRepr, IpAddress, IpProtocol, Ipv4Address, Ipv4Cidr, Ipv4Repr,
@@ -15,18 +15,9 @@ use super::WakerRegistration;
 
 use super::PollAt;
 
-const DISCOVER_TIMEOUT: Duration = Duration::from_secs(10);
-
-// timeout doubles every 2 tries.
-// total time 5 + 5 + 10 + 10 + 20 = 50s
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
-const REQUEST_RETRIES: u16 = 5;
-
-const MIN_RENEW_TIMEOUT: Duration = Duration::from_secs(60);
-
 const DEFAULT_LEASE_DURATION: Duration = Duration::from_secs(120);
 
-const PARAMETER_REQUEST_LIST: &[u8] = &[
+const DEFAULT_PARAMETER_REQUEST_LIST: &[u8] = &[
     dhcpv4_field::OPT_SUBNET_MASK,
     dhcpv4_field::OPT_ROUTER,
     dhcpv4_field::OPT_DOMAIN_NAME_SERVER,
@@ -35,7 +26,10 @@ const PARAMETER_REQUEST_LIST: &[u8] = &[
 /// IPv4 configuration data provided by the DHCP server.
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Config {
+pub struct Config<'a> {
+    /// Information on how to reach the DHCP server that responded with DHCP
+    /// configuration.
+    pub server: ServerInfo,
     /// IP address
     pub address: Ipv4Cidr,
     /// Router address, also known as default gateway. Does not necessarily
@@ -43,17 +37,19 @@ pub struct Config {
     pub router: Option<Ipv4Address>,
     /// DNS servers
     pub dns_servers: [Option<Ipv4Address>; DHCP_MAX_DNS_SERVER_COUNT],
+    /// Received DHCP packet
+    pub packet: Option<DhcpPacket<&'a [u8]>>,
 }
 
 /// Information on how to reach a DHCP server.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-struct ServerInfo {
+pub struct ServerInfo {
     /// IP address to use as destination in outgoing packets
-    address: Ipv4Address,
+    pub address: Ipv4Address,
     /// Server identifier to use in outgoing packets. Usually equal to server_address,
     /// but may differ in some situations (eg DHCP relays)
-    identifier: Ipv4Address,
+    pub identifier: Ipv4Address,
 }
 
 #[derive(Debug)]
@@ -79,10 +75,8 @@ struct RequestState {
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct RenewState {
-    /// Server that gave us the lease
-    server: ServerInfo,
     /// Active network config
-    config: Config,
+    config: Config<'static>,
 
     /// Renew timer. When reached, we will start attempting
     /// to renew this lease with the DHCP server.
@@ -104,18 +98,40 @@ enum ClientState {
     Renewing(RenewState),
 }
 
+/// Timeout and retry configuration.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct RetryConfig {
+    pub discover_timeout: Duration,
+    /// The REQUEST timeout doubles every 2 tries.
+    pub initial_request_timeout: Duration,
+    pub request_retries: u16,
+    pub min_renew_timeout: Duration,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            discover_timeout: Duration::from_secs(10),
+            initial_request_timeout: Duration::from_secs(5),
+            request_retries: 5,
+            min_renew_timeout: Duration::from_secs(60),
+        }
+    }
+}
+
 /// Return value for the `Dhcpv4Socket::poll` function
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum Event {
+pub enum Event<'a> {
     /// Configuration has been lost (for example, the lease has expired)
     Deconfigured,
     /// Configuration has been newly acquired, or modified.
-    Configured(Config),
+    Configured(Config<'a>),
 }
 
 #[derive(Debug)]
-pub struct Socket {
+pub struct Socket<'a> {
     /// State of the DHCP client.
     state: ClientState,
     /// Set to true on config/state change, cleared back to false by the `config` function.
@@ -127,8 +143,19 @@ pub struct Socket {
     /// Useful to react faster to IP configuration changes and to test whether renews work correctly.
     max_lease_duration: Option<Duration>,
 
+    retry_config: RetryConfig,
+
     /// Ignore NAKs.
     ignore_naks: bool,
+
+    /// A buffer contains options additional to be added to outgoing DHCP
+    /// packets.
+    outgoing_options: Option<DhcpOptionsBuffer<&'a [u8]>>,
+    /// A buffer containing all requested parameters.
+    parameter_request_list: Option<&'a [u8]>,
+
+    /// Incoming DHCP packets are copied into this buffer, overwriting the previous.
+    receive_packet_buffer: Option<&'a mut [u8]>,
 
     /// Waker registration
     #[cfg(feature = "async")]
@@ -140,7 +167,7 @@ pub struct Socket {
 /// The socket acquires an IP address configuration through DHCP autonomously.
 /// You must query the configuration with `.poll()` after every call to `Interface::poll()`,
 /// and apply the configuration to the `Interface`.
-impl Socket {
+impl<'a> Socket<'a> {
     /// Create a DHCPv4 socket
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
@@ -151,10 +178,37 @@ impl Socket {
             config_changed: true,
             transaction_id: 1,
             max_lease_duration: None,
+            retry_config: RetryConfig::default(),
             ignore_naks: false,
+            outgoing_options: None,
+            parameter_request_list: None,
+            receive_packet_buffer: None,
             #[cfg(feature = "async")]
             waker: WakerRegistration::new(),
         }
+    }
+
+    /// Set the retry/timeouts configuration.
+    pub fn set_retry_config(&mut self, config: RetryConfig) {
+        self.retry_config = config;
+    }
+
+    /// Set the outgoing options buffer.
+    pub fn set_outgoing_options_buffer(&mut self, options_buffer: DhcpOptionsBuffer<&'a [u8]>) {
+        self.outgoing_options = Some(options_buffer);
+    }
+
+    /// Set the buffer into which incoming DHCP packets are copied into.
+    pub fn set_receive_packet_buffer(&mut self, buffer: &'a mut [u8]) {
+        self.receive_packet_buffer = Some(buffer);
+    }
+
+    /// Set the parameter request list.
+    ///
+    /// This should contain at least `OPT_SUBNET_MASK` (`1`), `OPT_ROUTER`
+    /// (`3`), and `OPT_DOMAIN_NAME_SERVER` (`6`).
+    pub fn set_parameter_request_list(&mut self, parameter_request_list: &'a [u8]) {
+        self.parameter_request_list = Some(parameter_request_list);
     }
 
     /// Get the configured max lease duration.
@@ -256,6 +310,13 @@ impl Socket {
             dhcp_repr
         );
 
+        // Copy over the payload into the receive packet buffer.
+        if let Some(buffer) = self.receive_packet_buffer.as_mut() {
+            if let Some(buffer) = buffer.get_mut(..payload.len()) {
+                buffer.copy_from_slice(payload);
+            }
+        }
+
         match (&mut self.state, dhcp_repr.message_type) {
             (ClientState::Discovering(_state), DhcpMessageType::Offer) => {
                 if !dhcp_repr.your_ip.is_unicast() {
@@ -275,10 +336,9 @@ impl Socket {
             }
             (ClientState::Requesting(state), DhcpMessageType::Ack) => {
                 if let Some((config, renew_at, expires_at)) =
-                    Self::parse_ack(cx.now(), &dhcp_repr, self.max_lease_duration)
+                    Self::parse_ack(cx.now(), &dhcp_repr, self.max_lease_duration, state.server)
                 {
                     self.state = ClientState::Renewing(RenewState {
-                        server: state.server,
                         config,
                         renew_at,
                         expires_at,
@@ -293,7 +353,7 @@ impl Socket {
             }
             (ClientState::Renewing(state), DhcpMessageType::Ack) => {
                 if let Some((config, renew_at, expires_at)) =
-                    Self::parse_ack(cx.now(), &dhcp_repr, self.max_lease_duration)
+                    Self::parse_ack(cx.now(), &dhcp_repr, self.max_lease_duration, state.config.server)
                 {
                     state.renew_at = renew_at;
                     state.expires_at = expires_at;
@@ -321,7 +381,8 @@ impl Socket {
         now: Instant,
         dhcp_repr: &DhcpRepr,
         max_lease_duration: Option<Duration>,
-    ) -> Option<(Config, Instant, Instant)> {
+        server: ServerInfo,
+    ) -> Option<(Config<'static>, Instant, Instant)> {
         let subnet_mask = match dhcp_repr.subnet_mask {
             Some(subnet_mask) => subnet_mask,
             None => {
@@ -365,9 +426,11 @@ impl Socket {
             }
         }
         let config = Config {
+            server,
             address: Ipv4Cidr::new(dhcp_repr.your_ip, prefix_len),
             router: dhcp_repr.router,
-            dns_servers: dns_servers,
+            dns_servers,
+            packet: None,
         };
 
         // RFC 2131 indicates clients should renew a lease halfway through its expiration.
@@ -410,6 +473,7 @@ impl Socket {
         let mut dhcp_repr = DhcpRepr {
             message_type: DhcpMessageType::Discover,
             transaction_id: next_transaction_id,
+            secs: 0,
             client_hardware_address: ethernet_addr,
             client_ip: Ipv4Address::UNSPECIFIED,
             your_ip: Ipv4Address::UNSPECIFIED,
@@ -421,10 +485,14 @@ impl Socket {
             requested_ip: None,
             client_identifier: Some(ethernet_addr),
             server_identifier: None,
-            parameter_request_list: Some(PARAMETER_REQUEST_LIST),
+            parameter_request_list: Some(
+                self.parameter_request_list
+                    .unwrap_or(DEFAULT_PARAMETER_REQUEST_LIST),
+            ),
             max_size: Some((cx.ip_mtu() - MAX_IPV4_HEADER_LEN - UDP_HEADER_LEN) as u16),
             lease_duration: None,
             dns_servers: None,
+            additional_options: self.outgoing_options,
         };
 
         let udp_repr = UdpRepr {
@@ -456,7 +524,7 @@ impl Socket {
                 emit(cx, (ipv4_repr, udp_repr, dhcp_repr))?;
 
                 // Update state AFTER the packet has been successfully sent.
-                state.retry_at = cx.now() + DISCOVER_TIMEOUT;
+                state.retry_at = cx.now() + self.retry_config.discover_timeout;
                 self.transaction_id = next_transaction_id;
                 Ok(())
             }
@@ -465,7 +533,7 @@ impl Socket {
                     return Ok(());
                 }
 
-                if state.retry >= REQUEST_RETRIES {
+                if state.retry >= self.retry_config.request_retries {
                     net_debug!("DHCP request retries exceeded, restarting discovery");
                     self.reset();
                     return Ok(());
@@ -484,7 +552,8 @@ impl Socket {
                 emit(cx, (ipv4_repr, udp_repr, dhcp_repr))?;
 
                 // Exponential backoff: Double every 2 retries.
-                state.retry_at = cx.now() + (REQUEST_TIMEOUT << (state.retry as u32 / 2));
+                state.retry_at = cx.now()
+                    + (self.retry_config.initial_request_timeout << (state.retry as u32 / 2));
                 state.retry += 1;
 
                 self.transaction_id = next_transaction_id;
@@ -503,7 +572,7 @@ impl Socket {
                 }
 
                 ipv4_repr.src_addr = state.config.address.address();
-                ipv4_repr.dst_addr = state.server.address;
+                ipv4_repr.dst_addr = state.config.server.address;
                 dhcp_repr.message_type = DhcpMessageType::Request;
                 dhcp_repr.client_ip = state.config.address.address();
 
@@ -516,8 +585,11 @@ impl Socket {
                 // of the remaining time until T2 (in RENEWING state) and one-half of
                 // the remaining lease time (in REBINDING state), down to a minimum of
                 // 60 seconds, before retransmitting the DHCPREQUEST message.
-                state.renew_at =
-                    cx.now() + MIN_RENEW_TIMEOUT.max((state.expires_at - cx.now()) / 2);
+                state.renew_at = cx.now()
+                    + self
+                        .retry_config
+                        .min_renew_timeout
+                        .max((state.expires_at - cx.now()) / 2);
 
                 self.transaction_id = next_transaction_id;
                 Ok(())
@@ -548,7 +620,13 @@ impl Socket {
             None
         } else if let ClientState::Renewing(state) = &self.state {
             self.config_changed = false;
-            Some(Event::Configured(state.config))
+            Some(Event::Configured(Config {
+                server: state.config.server,
+                address: state.config.address,
+                router: state.config.router,
+                dns_servers: state.config.dns_servers,
+                packet: self.receive_packet_buffer.as_deref().map(DhcpPacket::new_unchecked),
+            }))
         } else {
             self.config_changed = false;
             Some(Event::Deconfigured)
@@ -594,12 +672,12 @@ mod test {
     // Helper functions
 
     struct TestSocket {
-        socket: Socket,
+        socket: Socket<'static>,
         cx: Context<'static>,
     }
 
     impl Deref for TestSocket {
-        type Target = Socket;
+        type Target = Socket<'static>;
         fn deref(&self) -> &Self::Target {
             &self.socket
         }
@@ -741,6 +819,7 @@ mod test {
     const DHCP_DEFAULT: DhcpRepr = DhcpRepr {
         message_type: DhcpMessageType::Unknown(99),
         transaction_id: TXID,
+        secs: 0,
         client_hardware_address: MY_MAC,
         client_ip: Ipv4Address::UNSPECIFIED,
         your_ip: Ipv4Address::UNSPECIFIED,
@@ -756,6 +835,7 @@ mod test {
         dns_servers: None,
         max_size: None,
         lease_duration: None,
+        additional_options: None,
     };
 
     const DHCP_DISCOVER: DhcpRepr = DhcpRepr {
@@ -840,13 +920,14 @@ mod test {
         let mut s = socket();
         s.state = ClientState::Renewing(RenewState {
             config: Config {
+                server: ServerInfo {
+                    address: SERVER_IP,
+                    identifier: SERVER_IP,
+                },
                 address: Ipv4Cidr::new(MY_IP, 24),
                 dns_servers: DNS_IPS,
                 router: Some(SERVER_IP),
-            },
-            server: ServerInfo {
-                address: SERVER_IP,
-                identifier: SERVER_IP,
+                packet: None,
             },
             renew_at: Instant::from_secs(500),
             expires_at: Instant::from_secs(1000),
@@ -870,9 +951,14 @@ mod test {
         assert_eq!(
             s.poll(),
             Some(Event::Configured(Config {
+                server: ServerInfo {
+                    address: SERVER_IP,
+                    identifier: SERVER_IP,
+                },
                 address: Ipv4Cidr::new(MY_IP, 24),
                 dns_servers: DNS_IPS,
                 router: Some(SERVER_IP),
+                packet: None,
             }))
         );
 

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -66,7 +66,7 @@ pub enum Socket<'a> {
     #[cfg(feature = "socket-tcp")]
     Tcp(tcp::Socket<'a>),
     #[cfg(feature = "socket-dhcpv4")]
-    Dhcpv4(dhcpv4::Socket),
+    Dhcpv4(dhcpv4::Socket<'a>),
     #[cfg(feature = "socket-dns")]
     Dns(dns::Socket<'a>),
 }
@@ -132,6 +132,6 @@ from_socket!(udp::Socket<'a>, Udp);
 #[cfg(feature = "socket-tcp")]
 from_socket!(tcp::Socket<'a>, Tcp);
 #[cfg(feature = "socket-dhcpv4")]
-from_socket!(dhcpv4::Socket, Dhcpv4);
+from_socket!(dhcpv4::Socket<'a>, Dhcpv4);
 #[cfg(feature = "socket-dns")]
 from_socket!(dns::Socket<'a>, Dns);

--- a/src/wire/dhcpv4.rs
+++ b/src/wire/dhcpv4.rs
@@ -1,5 +1,6 @@
 // See https://tools.ietf.org/html/rfc2131 for the DHCP specification.
 
+use core::iter;
 use bitflags::bitflags;
 use byteorder::{ByteOrder, NetworkEndian};
 
@@ -52,6 +53,84 @@ impl MessageType {
             MessageType::Offer | MessageType::Ack | MessageType::Nak => OpCode::Reply,
             MessageType::Unknown(_) => OpCode::Unknown(0),
         }
+    }
+}
+
+/// A buffer for DHCP options.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct DhcpOptionsBuffer<T> {
+    /// The underlying buffer, directly from the DHCP packet representation.
+    buffer: T,
+    len: usize,
+}
+
+impl<T: AsRef<[u8]>> DhcpOptionsBuffer<T> {
+    pub fn new(buffer: T) -> Self {
+        Self { buffer, len: 0 }
+    }
+
+    pub fn buffer_len(&self) -> usize {
+        self.len
+    }
+
+    pub fn map<F, U>(self, f: F) -> DhcpOptionsBuffer<U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        DhcpOptionsBuffer {
+            buffer: f(self.buffer),
+            len: self.len,
+        }
+    }
+
+    pub fn map_ref<'a, F, U>(&'a self, f: F) -> DhcpOptionsBuffer<U>
+    where
+        F: FnOnce(&'a T) -> U,
+    {
+        DhcpOptionsBuffer {
+            buffer: f(&self.buffer),
+            len: self.len,
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> DhcpOptionsBuffer<&'a T> {
+    /// Parse a [`DhcpOptionsBuffer`] into an iterator of [`DhcpOption`].
+    /// 
+    /// This will stop when it reaches [`DhcpOption::EndOfList`].
+    pub fn parse(&self) -> impl Iterator<Item = DhcpOption<'a>> {
+        let mut buf = &self.buffer.as_ref()[..self.len];
+        iter::from_fn(move || match DhcpOption::parse(buf) {
+            Ok((_, DhcpOption::EndOfList)) | Err(_) => None,
+            Ok((new_buf, option)) => {
+                buf = new_buf;
+                Some(option)
+            }
+        })
+    }
+}
+
+impl<T: AsMut<[u8]> + AsRef<[u8]>> DhcpOptionsBuffer<T> {
+    /// Emit an iterator of [`DhcpOption`] into a [`DhcpOptionsBuffer`].
+    pub fn emit<'a, I>(&mut self, options: I) -> Result<()>
+    where
+        I: IntoIterator<Item = DhcpOption<'a>>,
+    {
+        let mut buf = self.buffer.as_mut().get_mut(self.len..).unwrap_or(&mut []);
+        for option in options.into_iter() {
+            let option_size = option.buffer_len();
+            let buf_len = buf.len();
+            if option_size > buf_len {
+                return Err(Error);
+            }
+            buf = option.emit(buf);
+            if buf.len() != buf_len {
+                self.len += option_size;
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -217,7 +296,7 @@ impl<'a> DhcpOption<'a> {
 }
 
 /// A read/write wrapper around a Dynamic Host Configuration Protocol packet buffer.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Packet<T: AsRef<[u8]>> {
     buffer: T,
@@ -468,9 +547,37 @@ impl<T: AsRef<[u8]>> Packet<T> {
 impl<'a, T: AsRef<[u8]> + ?Sized> Packet<&'a T> {
     /// Return a pointer to the options.
     #[inline]
-    pub fn options(&self) -> Result<&'a [u8]> {
+    pub fn options(&self) -> Result<DhcpOptionsBuffer<&'a [u8]>> {
         let data = self.buffer.as_ref();
-        data.get(field::OPTIONS).ok_or(Error)
+        data.get(field::OPTIONS)
+            .ok_or(Error)
+            .map(|buffer| DhcpOptionsBuffer {
+                buffer,
+                len: buffer.len(),
+            })
+    }
+
+    pub fn get_sname(&self) -> Result<&'a str> {
+        let data = self.buffer.as_ref();
+        let data = data.get(field::SNAME).ok_or(Error)?;
+        let len = data.iter().position(|&x| x == 0).ok_or(Error)?;
+        if len == 0 {
+            return Err(Error);
+        }
+
+        let data = core::str::from_utf8(&data[..len]).map_err(|_| Error)?;
+        Ok(data)
+    }
+
+    pub fn get_boot_file(&self) -> Result<&'a str> {
+        let data = self.buffer.as_ref();
+        let data = data.get(field::FILE).ok_or(Error)?;
+        let len = data.iter().position(|&x| x == 0).ok_or(Error)?;
+        if len == 0 {
+            return Err(Error);
+        }
+        let data = core::str::from_utf8(&data[..len]).map_err(|_| Error)?;
+        Ok(data)
     }
 }
 
@@ -591,9 +698,11 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Packet<T> {
 impl<'a, T: AsRef<[u8]> + AsMut<[u8]> + ?Sized> Packet<&'a mut T> {
     /// Return a pointer to the options.
     #[inline]
-    pub fn options_mut(&mut self) -> Result<&mut [u8]> {
+    pub fn options_mut(&mut self) -> Result<DhcpOptionsBuffer<&mut [u8]>> {
         let data = self.buffer.as_mut();
-        data.get_mut(field::OPTIONS).ok_or(Error)
+        data.get_mut(field::OPTIONS)
+            .ok_or(Error)
+            .map(DhcpOptionsBuffer::new)
     }
 }
 
@@ -651,6 +760,11 @@ pub struct Repr<'a> {
     /// used by the client and server to associate messages and responses between a client and a
     /// server.
     pub transaction_id: u32,
+    /// seconds elapsed since client began address acquisition or renewal
+    /// process the DHCPREQUEST message MUST use the same value in the DHCP
+    /// message header's 'secs' field and be sent to the same IP broadcast
+    /// address as the original DHCPDISCOVER message.
+    pub secs: u16,
     /// This field is also known as `chaddr` in the RFC and for networks where the access layer is
     /// ethernet, it is the client MAC address.
     pub client_hardware_address: EthernetAddress,
@@ -704,6 +818,10 @@ pub struct Repr<'a> {
     pub max_size: Option<u16>,
     /// The DHCP IP lease duration, specified in seconds.
     pub lease_duration: Option<u32>,
+    /// When returned from [`Repr::parse`], this field will be `None`.
+    /// However, when calling [`Repr::emit`], this field should contain only
+    /// additional DHCP options not known to smoltcp.
+    pub additional_options: Option<DhcpOptionsBuffer<&'a [u8]>>,
 }
 
 impl<'a> Repr<'a> {
@@ -740,6 +858,9 @@ impl<'a> Repr<'a> {
         if let Some(list) = self.parameter_request_list {
             len += list.len() + 2;
         }
+        if let Some(additional_options) = self.additional_options {
+            len += additional_options.buffer_len();
+        }
 
         len
     }
@@ -755,6 +876,7 @@ impl<'a> Repr<'a> {
         let your_ip = packet.your_ip();
         let server_ip = packet.server_ip();
         let relay_agent_ip = packet.relay_agent_ip();
+        let secs = packet.secs();
 
         // only ethernet is supported right now
         match packet.hardware_type() {
@@ -781,9 +903,7 @@ impl<'a> Repr<'a> {
         let mut max_size = None;
         let mut lease_duration = None;
 
-        let mut options = packet.options()?;
-        while !options.is_empty() {
-            let (next_options, option) = DhcpOption::parse(options)?;
+        for option in packet.options()?.parse() {
             match option {
                 DhcpOption::EndOfList => break,
                 DhcpOption::Pad => {}
@@ -835,12 +955,12 @@ impl<'a> Repr<'a> {
                 }
                 DhcpOption::Other { .. } => {}
             }
-            options = next_options;
         }
 
         let broadcast = packet.flags().contains(Flags::BROADCAST);
 
         Ok(Repr {
+            secs,
             transaction_id,
             client_hardware_address,
             client_ip,
@@ -858,6 +978,7 @@ impl<'a> Repr<'a> {
             max_size,
             lease_duration,
             message_type: message_type?,
+            additional_options: None,
         })
     }
 
@@ -874,7 +995,7 @@ impl<'a> Repr<'a> {
         packet.set_transaction_id(self.transaction_id);
         packet.set_client_hardware_address(self.client_hardware_address);
         packet.set_hops(0);
-        packet.set_secs(0); // TODO
+        packet.set_secs(self.secs);
         packet.set_magic_number(0x63825363);
         packet.set_client_ip(self.client_ip);
         packet.set_your_ip(self.your_ip);
@@ -889,28 +1010,26 @@ impl<'a> Repr<'a> {
 
         {
             let mut options = packet.options_mut()?;
-            options = DhcpOption::MessageType(self.message_type).emit(options);
-            if let Some(eth_addr) = self.client_identifier {
-                options = DhcpOption::ClientIdentifier(eth_addr).emit(options);
-            }
-            if let Some(ip) = self.server_identifier {
-                options = DhcpOption::ServerIdentifier(ip).emit(options);
-            }
-            if let Some(ip) = self.router {
-                options = DhcpOption::Router(ip).emit(options);
-            }
-            if let Some(ip) = self.subnet_mask {
-                options = DhcpOption::SubnetMask(ip).emit(options);
-            }
-            if let Some(ip) = self.requested_ip {
-                options = DhcpOption::RequestedIp(ip).emit(options);
-            }
-            if let Some(size) = self.max_size {
-                options = DhcpOption::MaximumDhcpMessageSize(size).emit(options);
-            }
-            if let Some(duration) = self.lease_duration {
-                options = DhcpOption::IpLeaseTime(duration).emit(options);
-            }
+            options.emit(
+                iter::IntoIterator::into_iter([
+                    Some(DhcpOption::MessageType(self.message_type)),
+                    self.client_identifier.map(DhcpOption::ClientIdentifier),
+                    self.server_identifier.map(DhcpOption::ServerIdentifier),
+                    self.router.map(DhcpOption::Router),
+                    self.subnet_mask.map(DhcpOption::SubnetMask),
+                    self.requested_ip.map(DhcpOption::RequestedIp),
+                    self.max_size.map(DhcpOption::MaximumDhcpMessageSize),
+                    self.lease_duration.map(DhcpOption::IpLeaseTime),
+                    self.parameter_request_list.map(|list| {
+                        DhcpOption::Other {
+                            kind: field::OPT_PARAMETER_REQUEST_LIST,
+                            data: list,
+                        }
+                    }),
+                ])
+                .flatten()
+            )?;
+
             if let Some(dns_servers) = self.dns_servers {
                 const IP_SIZE: usize = core::mem::size_of::<u32>();
                 let mut servers = [0; MAX_DNS_SERVER_COUNT * IP_SIZE];
@@ -924,20 +1043,19 @@ impl<'a> Repr<'a> {
                     })
                     .count()
                     * IP_SIZE;
-                let option = DhcpOption::Other {
-                    kind: field::OPT_DOMAIN_NAME_SERVER,
-                    data: &servers[..data_len],
-                };
-                options = option.emit(options);
+                options.emit([
+                    DhcpOption::Other {
+                        kind: field::OPT_DOMAIN_NAME_SERVER,
+                        data: &servers[..data_len],
+                    },
+                ])?;
             }
-            if let Some(list) = self.parameter_request_list {
-                options = DhcpOption::Other {
-                    kind: field::OPT_PARAMETER_REQUEST_LIST,
-                    data: list,
-                }
-                .emit(options);
+
+            if let Some(additional_options) = self.additional_options {
+                options.emit(additional_options.parse())?;
             }
-            DhcpOption::EndOfList.emit(options);
+
+            options.emit([DhcpOption::EndOfList])?;
         }
 
         Ok(())
@@ -1042,37 +1160,19 @@ mod test {
         assert_eq!(packet.relay_agent_ip(), IP_NULL);
         assert_eq!(packet.client_hardware_address(), CLIENT_MAC);
         let options = packet.options().unwrap();
-        assert_eq!(options.len(), 3 + 9 + 6 + 4 + 6 + 1 + 7);
+        assert_eq!(options.buffer_len(), 3 + 9 + 6 + 4 + 6 + 1 + 7);
+        
+        let mut options = options.parse();
 
-        let (options, message_type) = DhcpOption::parse(options).unwrap();
-        assert_eq!(message_type, DhcpOption::MessageType(MessageType::Discover));
-        assert_eq!(options.len(), 9 + 6 + 4 + 6 + 1 + 7);
-
-        let (options, client_id) = DhcpOption::parse(options).unwrap();
-        assert_eq!(client_id, DhcpOption::ClientIdentifier(CLIENT_MAC));
-        assert_eq!(options.len(), 6 + 4 + 6 + 1 + 7);
-
-        let (options, client_id) = DhcpOption::parse(options).unwrap();
-        assert_eq!(client_id, DhcpOption::RequestedIp(IP_NULL));
-        assert_eq!(options.len(), 4 + 6 + 1 + 7);
-
-        let (options, msg_size) = DhcpOption::parse(options).unwrap();
-        assert_eq!(msg_size, DhcpOption::MaximumDhcpMessageSize(DHCP_SIZE));
-        assert_eq!(options.len(), 6 + 1 + 7);
-
-        let (options, client_id) = DhcpOption::parse(options).unwrap();
+        assert_eq!(options.next(), Some(DhcpOption::MessageType(MessageType::Discover)));
+        assert_eq!(options.next(), Some(DhcpOption::ClientIdentifier(CLIENT_MAC)));
+        assert_eq!(options.next(), Some(DhcpOption::RequestedIp(IP_NULL)));
+        assert_eq!(options.next(), Some(DhcpOption::MaximumDhcpMessageSize(DHCP_SIZE)));
         assert_eq!(
-            client_id,
-            DhcpOption::Other {
-                kind: field::OPT_PARAMETER_REQUEST_LIST,
-                data: &[1, 3, 6, 42]
-            }
+            options.next(),
+            Some(DhcpOption::Other{kind:field::OPT_PARAMETER_REQUEST_LIST,data: &[1,3,6,42]})
         );
-        assert_eq!(options.len(), 1 + 7);
-
-        let (options, client_id) = DhcpOption::parse(options).unwrap();
-        assert_eq!(client_id, DhcpOption::EndOfList);
-        assert_eq!(options.len(), 7); // padding
+        assert_eq!(options.next(), None);
     }
 
     #[test]
@@ -1096,16 +1196,15 @@ mod test {
 
         {
             let mut options = packet.options_mut().unwrap();
-            options = DhcpOption::MessageType(MessageType::Discover).emit(options);
-            options = DhcpOption::ClientIdentifier(CLIENT_MAC).emit(options);
-            options = DhcpOption::RequestedIp(IP_NULL).emit(options);
-            options = DhcpOption::MaximumDhcpMessageSize(DHCP_SIZE).emit(options);
-            let option = DhcpOption::Other {
+            options.emit([DhcpOption::MessageType(MessageType::Discover)]).unwrap();
+            options.emit([DhcpOption::ClientIdentifier(CLIENT_MAC)]).unwrap();
+            options.emit([DhcpOption::RequestedIp(IP_NULL)]).unwrap();
+            options.emit([DhcpOption::MaximumDhcpMessageSize(DHCP_SIZE)]).unwrap();
+            options.emit([DhcpOption::Other {
                 kind: field::OPT_PARAMETER_REQUEST_LIST,
                 data: &[1, 3, 6, 42],
-            };
-            options = option.emit(options);
-            DhcpOption::EndOfList.emit(options);
+            }]).unwrap();
+            options.emit([DhcpOption::EndOfList]).unwrap();
         }
 
         let packet = &mut packet.into_inner()[..];
@@ -1127,6 +1226,7 @@ mod test {
             router: Some(IP_NULL),
             subnet_mask: Some(IP_NULL),
             relay_agent_ip: IP_NULL,
+            secs: 0,
             broadcast: false,
             requested_ip: None,
             client_identifier: Some(CLIENT_MAC),
@@ -1135,6 +1235,7 @@ mod test {
             dns_servers: None,
             max_size: None,
             lease_duration: Some(0xffff_ffff), // Infinite lease
+            additional_options: None,
         }
     }
 
@@ -1150,6 +1251,7 @@ mod test {
             subnet_mask: None,
             relay_agent_ip: IP_NULL,
             broadcast: false,
+            secs: 0,
             max_size: Some(DHCP_SIZE),
             lease_duration: None,
             requested_ip: Some(IP_NULL),
@@ -1157,6 +1259,7 @@ mod test {
             server_identifier: None,
             parameter_request_list: Some(&[1, 3, 6, 42]),
             dns_servers: None,
+            additional_options: None,
         }
     }
 

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -243,9 +243,9 @@ pub use self::tcp::{
 
 #[cfg(feature = "proto-dhcpv4")]
 pub use self::dhcpv4::{
-    MessageType as DhcpMessageType, Packet as DhcpPacket, Repr as DhcpRepr,
-    CLIENT_PORT as DHCP_CLIENT_PORT, MAX_DNS_SERVER_COUNT as DHCP_MAX_DNS_SERVER_COUNT,
-    SERVER_PORT as DHCP_SERVER_PORT, DhcpOption, DhcpOptionsBuffer,
+    DhcpOption, DhcpOptionsBuffer, MessageType as DhcpMessageType, Packet as DhcpPacket,
+    Repr as DhcpRepr, CLIENT_PORT as DHCP_CLIENT_PORT,
+    MAX_DNS_SERVER_COUNT as DHCP_MAX_DNS_SERVER_COUNT, SERVER_PORT as DHCP_SERVER_PORT,
 };
 
 /// Parsing a packet failed.

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -245,7 +245,7 @@ pub use self::tcp::{
 pub use self::dhcpv4::{
     MessageType as DhcpMessageType, Packet as DhcpPacket, Repr as DhcpRepr,
     CLIENT_PORT as DHCP_CLIENT_PORT, MAX_DNS_SERVER_COUNT as DHCP_MAX_DNS_SERVER_COUNT,
-    SERVER_PORT as DHCP_SERVER_PORT,
+    SERVER_PORT as DHCP_SERVER_PORT, DhcpOption, DhcpOptionsBuffer,
 };
 
 /// Parsing a packet failed.


### PR DESCRIPTION
(I closed #635 since I'm transitioning this PR to a coworker and a different source repo.)

This PR is based on @Luis-Hebendanz's fork of smoltcp that adds some initial support for PXE to DHCP sockets.

From there, I've generalized it, removing most PXE specific code, but allowing users to send and receive custom DHCP options.