### PR TITLE
Cleanup CI.

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -7,6 +7,8 @@ name: Clippy check
 jobs:
   clippy:
     runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: stable
     steps:
       - uses: actions/checkout@v2
         if: github.event_name == 'pull_request_target'
@@ -14,12 +16,6 @@ jobs:
           ref: refs/pull/${{ github.event.number }}/head
       - uses: actions/checkout@v2
         if: github.event_name != 'pull_request_target'
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.60.0
-          override: true
-          components: clippy
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -7,18 +7,12 @@ name: Fuzz
 
 jobs:
   fuzz:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    env:
+      RUSTUP_TOOLCHAIN: nightly
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
       - name: Install cargo-fuzz
-        # Fix for cargo-fuzz on latest nightly: https://github.com/rust-fuzz/cargo-fuzz/issues/276
-        # Switch back to installing from crates.io when it's released.
-        #run: cargo install cargo-fuzz
-        run: cargo install --git https://github.com/rust-fuzz/cargo-fuzz --rev b4df3e58f767b5cad8d1aa6753961003f56f3609
+        run: cargo install cargo-fuzz
       - name: Fuzz
         run: cargo fuzz run packet_parser -- -max_len=1536 -max_total_time=30

--- a/.github/workflows/rustfmt.yaml
+++ b/.github/workflows/rustfmt.yaml
@@ -9,10 +9,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          components: rustfmt
       - name: Check fmt
         run: cargo fmt -- --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,13 +7,13 @@ name: Test
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [test, check]
     steps:
       - name: Done
         run: exit 0
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     continue-on-error: ${{ matrix.rust == 'nightly' }}
     strategy:
       matrix:
@@ -49,23 +49,16 @@ jobs:
           # Test alloc feature which requires nightly.
           - rust: nightly
             features: alloc medium-ethernet proto-ipv4 proto-ipv6 socket-raw socket-udp socket-tcp socket-icmp
+    env:
+      RUSTUP_TOOLCHAIN: "${{ matrix.rust }}"
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
       - name: Run Tests
         run: cargo test --no-default-features --features "${{ matrix.features }}"
 
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     continue-on-error: ${{ matrix.rust == 'nightly' }}
-    env:
-      # Set DEFMT_LOG to trace so that all net_{error, .., trace} messages
-      # are actually compiled and verified
-      DEFMT_LOG: "trace"
     strategy:
       matrix:
         # Test on stable, MSRV, and nightly.
@@ -81,12 +74,12 @@ jobs:
           - defmt medium-ip medium-ethernet proto-ipv6 proto-ipv6 proto-igmp proto-dhcpv4 socket-raw socket-udp socket-tcp socket-icmp socket-dns async
           - defmt alloc medium-ip medium-ethernet proto-ipv6 proto-ipv6 proto-igmp proto-dhcpv4 socket-raw socket-udp socket-tcp socket-icmp socket-dns async
 
+    env:
+      # Set DEFMT_LOG to trace so that all net_{error, .., trace} messages
+      # are actually compiled and verified
+      DEFMT_LOG: "trace"
+      RUSTUP_TOOLCHAIN: "${{ matrix.rust }}"
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
       - name: Check
         run: cargo check --no-default-features --features "${{ matrix.features }}"


### PR DESCRIPTION
The GHA ubuntu images already have rustup, so actions-rs/toolchain is not required anymore.