### PR TITLE
Pin Clippy Check

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,3 +1,11 @@
+# When bumping the toolchain version, note that it must be done in two pull
+# requests - the first one being the version bump itself and the second one the
+# necessary code changes based on the updated clippy lints (if any). This is due
+# to the fact that actions-rs/clippy-check requires a GitHub API token with
+# write permission on the "check" scope. A token of this type is only available
+# when triggering on `pull_request_target`, but this runs the action using the
+# configuration from the base of the pull request rather than the merge commit.
+
 on:
   push:
     branches: [ staging, trying ]

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -7,8 +7,6 @@ name: Clippy check
 jobs:
   clippy:
     runs-on: ubuntu-latest
-    env:
-      RUSTUP_TOOLCHAIN: stable
     permissions:
       checks: write
     steps:
@@ -18,6 +16,12 @@ jobs:
           ref: refs/pull/${{ github.event.number }}/head
       - uses: actions/checkout@v2
         if: github.event_name != 'pull_request_target'
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.60.0
+          override: true
+          components: clippy
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is a follow-up to https://github.com/smoltcp-rs/smoltcp/pull/652. I'm concerned that without explicit control over the clippy version, whenever there is a new stable release, work on this repository may be blocked until the latest clippy lints can be addressed. I've also documented the process of bumping the version for future reference.

There's a tradeoff to make here - this pull request reintroduces a slightly cumbersome process, but it does prevent surprise CI failures (notably, it removes the surprise, but technically CI is still broken in between the two pull requests - it just allows the maintainers control over when). Which direction would folks prefer?