### PR TITLE
Limit the permissions of the clippy action

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTUP_TOOLCHAIN: stable
+    permissions:
+      checks: write
     steps:
       - uses: actions/checkout@v2
         if: github.event_name == 'pull_request_target'


### PR DESCRIPTION
actions-rs/clippy-check only requires read/write access to the
"checks" scope. When the "permissions" object is present, all of the
scopes default to "none".