### PR TITLE
Enforce minimum supported Rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "smoltcp"
 version = "0.8.0"
 edition = "2018"
+rust-version = "1.60"
 authors = ["whitequark <whitequark@whitequark.org>"]
 description = "A TCP/IP stack designed for bare-metal, real-time systems without a heap."
 documentation = "https://docs.rs/smoltcp/"


### PR DESCRIPTION
This instructs Cargo to immediately fail compilation if the version of Rust is too old (https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field). Hopefully, this will save someone some headache.