### PR TITLE
Pin clippy to minimum supported Rust version 

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -7,8 +7,6 @@ name: Clippy check
 jobs:
   clippy:
     runs-on: ubuntu-latest
-    env:
-      RUSTUP_TOOLCHAIN: stable
     permissions:
       checks: write
     steps:
@@ -18,6 +16,9 @@ jobs:
           ref: refs/pull/${{ github.event.number }}/head
       - uses: actions/checkout@v2
         if: github.event_name != 'pull_request_target'
+      - run: sed -n 's,^rust-version = "\(.*\)"$,RUSTUP_TOOLCHAIN=\1,p' Cargo.toml >> $GITHUB_ENV
+      - run: rustup toolchain install $RUSTUP_TOOLCHAIN
+      - run: rustup component add clippy
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "smoltcp"
 version = "0.8.0"
 edition = "2018"
+rust-version = "1.60"
 authors = ["whitequark <whitequark@whitequark.org>"]
 description = "A TCP/IP stack designed for bare-metal, real-time systems without a heap."
 documentation = "https://docs.rs/smoltcp/"


### PR DESCRIPTION
Alternate to #657. Builds on #663.

The rationale is the same as discussed in 0b0f96e:

> It can be rather surprising when new lints pop up when a new stable
> toolchain is released. Let's pin this check to a specific version to
> avoid those surprises.

In deciding which version of clippy to use, I went with the MSRV since
that's what's been done historically. The other option was to read
from the repo a version number specifically for clippy, but I was
afraid that adding one more version number to juggle would increase
the odds that it would be forgotten and fall out of sync.

Note that this approach uses rustup to install the toolchain
dynamically rather than making use of an action. The advantage of this
method is that it allows a single pull request to contain the version
bump and suggested code changes (this is due to the fact that
actions-rs/clippy-check requires a GitHub API token with write
permission, but a token of this type is only available when triggering
on `pull_request_target` which runs the action using the configuration
from the base of the pull request rather than the merge commit). The
disadvantage of this approach is that the toolchain setup can no
longer be cached by the underlying layering mechanism used by GitHub
actions (unlikely to significantly affect this project).