### PR TITLE
fix socket feature check

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ compile_error!("You must enable at least one of the following features: proto-ip
         feature = "socket-udp",
         feature = "socket-tcp",
         feature = "socket-icmp",
-        feature = "socket-dhcp",
+        feature = "socket-dhcpv4",
         feature = "socket-dns",
     ))
 ))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ compile_error!("You must enable at least one of the following features: proto-ip
         feature = "socket-dns",
     ))
 ))]
-compile_error!("If you enable the socket feature, you must enable at least one of the following features: socket-raw, socket-udp, socket-tcp, socket-icmp, socket-dhcp, socket-dns");
+compile_error!("If you enable the socket feature, you must enable at least one of the following features: socket-raw, socket-udp, socket-tcp, socket-icmp, socket-dhcpv4, socket-dns");
 
 #[cfg(all(
     feature = "socket",


### PR DESCRIPTION
it requires you to have at least one socket type enabled but the feature
`socket-dhcp` does not exist because it's name is `socket-dhcpv4`. So if
that's only socket type you want enabled you weren't able to do that due
to this broken check.