### PR TITLE
Remove cfg-if dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ log = { version = "0.4.4", default-features = false, optional = true }
 libc = { version = "0.2.18", optional = true }
 bitflags = { version = "1.0", default-features = false }
 defmt = { version = "0.3", optional = true }
-cfg-if = "1.0.0"
 heapless = "0.7.8"
 
 [dev-dependencies]

--- a/src/iface/interface.rs
+++ b/src/iface/interface.rs
@@ -1512,12 +1512,12 @@ impl<'a> InterfaceInner<'a> {
             EthernetProtocol::Ipv4 => {
                 let ipv4_packet = check!(Ipv4Packet::new_checked(eth_frame.payload()));
 
-                cfg_if::cfg_if! {
-                if #[cfg(feature = "proto-ipv4-fragmentation")] {
+                if cfg!(feature = "proto-ipv4-fragmentation") {
                     self.process_ipv4(sockets, &ipv4_packet, Some(&mut _fragments.ipv4_fragments))
-                    .map(EthernetPacket::Ip) } else {
-                    self.process_ipv4(sockets, &ipv4_packet, None).map(EthernetPacket::Ip)
-                }
+                        .map(EthernetPacket::Ip)
+                } else {
+                    self.process_ipv4(sockets, &ipv4_packet, None)
+                        .map(EthernetPacket::Ip)
                 }
             }
             #[cfg(feature = "proto-ipv6")]
@@ -1542,13 +1542,10 @@ impl<'a> InterfaceInner<'a> {
             #[cfg(feature = "proto-ipv4")]
             Ok(IpVersion::Ipv4) => {
                 let ipv4_packet = check!(Ipv4Packet::new_checked(ip_payload));
-                cfg_if::cfg_if! {
-                    if #[cfg(feature = "proto-ipv4-fragmentation")] {
-                        self.process_ipv4(sockets, &ipv4_packet, Some(&mut _fragments.ipv4_fragments))
-                    } else {
-                        self.process_ipv4(sockets, &ipv4_packet, None)
-
-                    }
+                if cfg!(feature = "proto-ipv4-fragmentation") {
+                    self.process_ipv4(sockets, &ipv4_packet, Some(&mut _fragments.ipv4_fragments))
+                } else {
+                    self.process_ipv4(sockets, &ipv4_packet, None)
                 }
             }
             #[cfg(feature = "proto-ipv6")]
@@ -1591,12 +1588,18 @@ impl<'a> InterfaceInner<'a> {
 
         match ieee802154_frame.payload() {
             Some(payload) => {
-                cfg_if::cfg_if! {
-                    if #[cfg(feature = "proto-sixlowpan-fragmentation")] {
-                        self.process_sixlowpan(sockets, &ieee802154_repr, payload, Some((&mut _fragments.sixlowpan_fragments, _fragments.sixlowpan_fragments_cache_timeout)))
-                    } else {
-                        self.process_sixlowpan(sockets, &ieee802154_repr, payload, None)
-                    }
+                if cfg!(feature = "proto-sixlowpan-fragmentation") {
+                    self.process_sixlowpan(
+                        sockets,
+                        &ieee802154_repr,
+                        payload,
+                        Some((
+                            &mut _fragments.sixlowpan_fragments,
+                            _fragments.sixlowpan_fragments_cache_timeout,
+                        )),
+                    )
+                } else {
+                    self.process_sixlowpan(sockets, &ieee802154_repr, payload, None)
                 }
             }
             None => None,
@@ -3037,140 +3040,142 @@ impl<'a> InterfaceInner<'a> {
         let ieee_len = ieee_repr.buffer_len();
 
         if total_size + ieee_len > 125 {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "proto-sixlowpan-fragmentation")] {
-                    // The packet does not fit in one Ieee802154 frame, so we need fragmentation.
-                    // We do this by emitting everything in the `out_packet.buffer` from the interface.
-                    // After emitting everything into that buffer, we send the first fragment heere.
-                    // When `poll` is called again, we check if out_packet was fully sent, otherwise we
-                    // call `dispatch_ieee802154_out_packet`, which will transmit the other fragments.
+            if cfg!(feature = "proto-sixlowpan-fragmentation") {
+                // The packet does not fit in one Ieee802154 frame, so we need fragmentation.
+                // We do this by emitting everything in the `out_packet.buffer` from the interface.
+                // After emitting everything into that buffer, we send the first fragment heere.
+                // When `poll` is called again, we check if out_packet was fully sent, otherwise we
+                // call `dispatch_ieee802154_out_packet`, which will transmit the other fragments.
 
-                    // `dispatch_ieee802154_out_packet` requires some information about the total packet size,
-                    // the link local source and destination address...
-                    let SixlowpanOutPacket {
-                        buffer,
-                        packet_len,
-                        datagram_size,
-                        datagram_tag,
-                        sent_bytes,
-                        fragn_size,
-                        ll_dst_addr,
-                        ll_src_addr,
-                        datagram_offset,
-                        ..
-                    } = &mut _out_packet.unwrap().sixlowpan_out_packet;
+                // `dispatch_ieee802154_out_packet` requires some information about the total packet size,
+                // the link local source and destination address...
+                let SixlowpanOutPacket {
+                    buffer,
+                    packet_len,
+                    datagram_size,
+                    datagram_tag,
+                    sent_bytes,
+                    fragn_size,
+                    ll_dst_addr,
+                    ll_src_addr,
+                    datagram_offset,
+                    ..
+                } = &mut _out_packet.unwrap().sixlowpan_out_packet;
 
-                    *ll_dst_addr = ll_dst_a;
-                    *ll_src_addr = ll_src_a;
+                *ll_dst_addr = ll_dst_a;
+                *ll_src_addr = ll_src_a;
 
-                    let mut iphc_packet =
-                        SixlowpanIphcPacket::new_unchecked(&mut buffer[..iphc_repr.buffer_len()]);
-                    iphc_repr.emit(&mut iphc_packet);
+                let mut iphc_packet =
+                    SixlowpanIphcPacket::new_unchecked(&mut buffer[..iphc_repr.buffer_len()]);
+                iphc_repr.emit(&mut iphc_packet);
 
-                    let b = &mut buffer[iphc_repr.buffer_len()..];
+                let b = &mut buffer[iphc_repr.buffer_len()..];
 
-                    #[allow(unreachable_patterns)]
-                    match packet {
-                        #[cfg(feature = "socket-udp")]
-                        IpPacket::Udp((_, udpv6_repr, payload)) => {
-                            let udp_repr = SixlowpanUdpNhcRepr(udpv6_repr);
-                            let mut udp_packet = SixlowpanUdpNhcPacket::new_unchecked(
-                                &mut b[..udp_repr.header_len() + payload.len()],
-                            );
-                            udp_repr.emit(
-                                &mut udp_packet,
-                                &iphc_repr.src_addr,
-                                &iphc_repr.dst_addr,
-                                payload.len(),
-                                |buf| buf.copy_from_slice(payload),
-                            );
-                        }
-                        #[cfg(feature = "socket-tcp")]
-                        IpPacket::Tcp((_, tcp_repr)) => {
-                            let mut tcp_packet = TcpPacket::new_unchecked(&mut b[..tcp_repr.buffer_len()]);
-                            tcp_repr.emit(
-                                &mut tcp_packet,
-                                &iphc_repr.src_addr.into(),
-                                &iphc_repr.dst_addr.into(),
-                                &self.caps.checksum,
-                            );
-                        }
-                        #[cfg(feature = "proto-ipv6")]
-                        IpPacket::Icmpv6((_, icmp_repr)) => {
-                            let mut icmp_packet =
-                                Icmpv6Packet::new_unchecked(&mut b[..icmp_repr.buffer_len()]);
-                            icmp_repr.emit(
-                                &iphc_repr.src_addr.into(),
-                                &iphc_repr.dst_addr.into(),
-                                &mut icmp_packet,
-                                &self.caps.checksum,
-                            );
-                        }
-                        _ => return Err(Error::Unrecognized),
+                #[allow(unreachable_patterns)]
+                match packet {
+                    #[cfg(feature = "socket-udp")]
+                    IpPacket::Udp((_, udpv6_repr, payload)) => {
+                        let udp_repr = SixlowpanUdpNhcRepr(udpv6_repr);
+                        let mut udp_packet = SixlowpanUdpNhcPacket::new_unchecked(
+                            &mut b[..udp_repr.header_len() + payload.len()],
+                        );
+                        udp_repr.emit(
+                            &mut udp_packet,
+                            &iphc_repr.src_addr,
+                            &iphc_repr.dst_addr,
+                            payload.len(),
+                            |buf| buf.copy_from_slice(payload),
+                        );
                     }
-
-                    *packet_len = total_size;
-
-                    // The datagram size that we need to set in the first fragment header is equal to the
-                    // IPv6 payload length + 40.
-                    *datagram_size = (packet.ip_repr().payload_len() + 40) as u16;
-
-                    // We generate a random tag.
-                    let tag = self.get_sixlowpan_fragment_tag();
-                    // We save the tag for the other fragments that will be created when calling `poll`
-                    // multiple times.
-                    *datagram_tag = tag;
-
-                    let frag1 = SixlowpanFragRepr::FirstFragment {
-                        size: *datagram_size,
-                        tag,
-                    };
-                    let fragn = SixlowpanFragRepr::Fragment {
-                        size: *datagram_size,
-                        tag,
-                        offset: 0,
-                    };
-
-                    // We calculate how much data we can send in the first fragment and the other
-                    // fragments. The eventual IPv6 sizes of these fragments need to be a multiple of eight
-                    // (except for the last fragment) since the offset field in the fragment is an offset
-                    // in multiples of 8 octets. This is explained in [RFC 4944 § 5.3].
-                    //
-                    // [RFC 4944 § 5.3]: https://datatracker.ietf.org/doc/html/rfc4944#section-5.3
-
-                    let header_diff = _uncompressed_headers_len - _compressed_headers_len;
-                    let frag1_size =
-                        (125 - ieee_len - frag1.buffer_len() + header_diff) / 8 * 8 - (header_diff);
-
-                    *fragn_size = (125 - ieee_len - fragn.buffer_len()) / 8 * 8;
-
-                    *sent_bytes = frag1_size;
-                    *datagram_offset = frag1_size + header_diff;
-
-                    tx_token.consume(
-                        self.now,
-                        ieee_len + frag1.buffer_len() + frag1_size,
-                        |mut tx_buf| {
-                            // Add the IEEE header.
-                            let mut ieee_packet = Ieee802154Frame::new_unchecked(&mut tx_buf[..ieee_len]);
-                            ieee_repr.emit(&mut ieee_packet);
-                            tx_buf = &mut tx_buf[ieee_len..];
-
-                            // Add the first fragment header
-                            let mut frag1_packet = SixlowpanFragPacket::new_unchecked(&mut tx_buf);
-                            frag1.emit(&mut frag1_packet);
-                            tx_buf = &mut tx_buf[frag1.buffer_len()..];
-
-                            // Add the buffer part.
-                            tx_buf[..frag1_size].copy_from_slice(&buffer[..frag1_size]);
-
-                            Ok(())
-                        },
-                    )
-                } else {
-                    net_debug!("Enable the `proto-sixlowpan-fragmentation` feature for fragmentation support.");
-                    Ok(())
+                    #[cfg(feature = "socket-tcp")]
+                    IpPacket::Tcp((_, tcp_repr)) => {
+                        let mut tcp_packet =
+                            TcpPacket::new_unchecked(&mut b[..tcp_repr.buffer_len()]);
+                        tcp_repr.emit(
+                            &mut tcp_packet,
+                            &iphc_repr.src_addr.into(),
+                            &iphc_repr.dst_addr.into(),
+                            &self.caps.checksum,
+                        );
+                    }
+                    #[cfg(feature = "proto-ipv6")]
+                    IpPacket::Icmpv6((_, icmp_repr)) => {
+                        let mut icmp_packet =
+                            Icmpv6Packet::new_unchecked(&mut b[..icmp_repr.buffer_len()]);
+                        icmp_repr.emit(
+                            &iphc_repr.src_addr.into(),
+                            &iphc_repr.dst_addr.into(),
+                            &mut icmp_packet,
+                            &self.caps.checksum,
+                        );
+                    }
+                    _ => return Err(Error::Unrecognized),
                 }
+
+                *packet_len = total_size;
+
+                // The datagram size that we need to set in the first fragment header is equal to the
+                // IPv6 payload length + 40.
+                *datagram_size = (packet.ip_repr().payload_len() + 40) as u16;
+
+                // We generate a random tag.
+                let tag = self.get_sixlowpan_fragment_tag();
+                // We save the tag for the other fragments that will be created when calling `poll`
+                // multiple times.
+                *datagram_tag = tag;
+
+                let frag1 = SixlowpanFragRepr::FirstFragment {
+                    size: *datagram_size,
+                    tag,
+                };
+                let fragn = SixlowpanFragRepr::Fragment {
+                    size: *datagram_size,
+                    tag,
+                    offset: 0,
+                };
+
+                // We calculate how much data we can send in the first fragment and the other
+                // fragments. The eventual IPv6 sizes of these fragments need to be a multiple of eight
+                // (except for the last fragment) since the offset field in the fragment is an offset
+                // in multiples of 8 octets. This is explained in [RFC 4944 § 5.3].
+                //
+                // [RFC 4944 § 5.3]: https://datatracker.ietf.org/doc/html/rfc4944#section-5.3
+
+                let header_diff = _uncompressed_headers_len - _compressed_headers_len;
+                let frag1_size =
+                    (125 - ieee_len - frag1.buffer_len() + header_diff) / 8 * 8 - (header_diff);
+
+                *fragn_size = (125 - ieee_len - fragn.buffer_len()) / 8 * 8;
+
+                *sent_bytes = frag1_size;
+                *datagram_offset = frag1_size + header_diff;
+
+                tx_token.consume(
+                    self.now,
+                    ieee_len + frag1.buffer_len() + frag1_size,
+                    |mut tx_buf| {
+                        // Add the IEEE header.
+                        let mut ieee_packet =
+                            Ieee802154Frame::new_unchecked(&mut tx_buf[..ieee_len]);
+                        ieee_repr.emit(&mut ieee_packet);
+                        tx_buf = &mut tx_buf[ieee_len..];
+
+                        // Add the first fragment header
+                        let mut frag1_packet = SixlowpanFragPacket::new_unchecked(&mut tx_buf);
+                        frag1.emit(&mut frag1_packet);
+                        tx_buf = &mut tx_buf[frag1.buffer_len()..];
+
+                        // Add the buffer part.
+                        tx_buf[..frag1_size].copy_from_slice(&buffer[..frag1_size]);
+
+                        Ok(())
+                    },
+                )
+            } else {
+                net_debug!(
+                    "Enable the `proto-sixlowpan-fragmentation` feature for fragmentation support."
+                );
+                Ok(())
             }
         } else {
             // We don't need fragmentation, so we emit everything to the TX token.

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -2309,35 +2309,40 @@ mod test {
     const LOCAL_SEQ: TcpSeqNumber = TcpSeqNumber(10000);
     const REMOTE_SEQ: TcpSeqNumber = TcpSeqNumber(-10001);
 
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "proto-ipv4")] {
-            use crate::wire::Ipv4Address as IpvXAddress;
-            use crate::wire::Ipv4Repr as IpvXRepr;
-            use IpRepr::Ipv4 as IpReprIpvX;
+    #[cfg(feature = "proto-ipv4")]
+    mod proto_ipv4 {
+        pub use super::IpRepr::Ipv4 as IpReprIpvX;
+        pub use crate::wire::Ipv4Address as IpvXAddress;
+        pub use crate::wire::Ipv4Repr as IpvXRepr;
 
-            const LOCAL_ADDR: IpvXAddress = IpvXAddress([192, 168, 1, 1]);
-            const REMOTE_ADDR: IpvXAddress = IpvXAddress([192, 168, 1, 2]);
-            const OTHER_ADDR: IpvXAddress = IpvXAddress([192, 168, 1, 3]);
+        pub const LOCAL_ADDR: IpvXAddress = IpvXAddress([192, 168, 1, 1]);
+        pub const REMOTE_ADDR: IpvXAddress = IpvXAddress([192, 168, 1, 2]);
+        pub const OTHER_ADDR: IpvXAddress = IpvXAddress([192, 168, 1, 3]);
 
-            const BASE_MSS: u16 = 1460;
-        } else {
-            use crate::wire::Ipv6Address as IpvXAddress;
-            use crate::wire::Ipv6Repr as IpvXRepr;
-            use IpRepr::Ipv6 as IpReprIpvX;
-
-            const LOCAL_ADDR: IpvXAddress = IpvXAddress([
-                0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
-            ]);
-            const REMOTE_ADDR: IpvXAddress = IpvXAddress([
-                0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
-            ]);
-            const OTHER_ADDR: IpvXAddress = IpvXAddress([
-                0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3,
-            ]);
-
-            const BASE_MSS: u16 = 1440;
-        }
+        pub const BASE_MSS: u16 = 1460;
     }
+
+    #[cfg(not(feature = "proto-ipv4"))]
+    mod proto_ipv6 {
+        pub use super::IpRepr::Ipv6 as IpReprIpvX;
+        pub use crate::wire::Ipv6Address as IpvXAddress;
+        pub use crate::wire::Ipv6Repr as IpvXRepr;
+
+        pub const LOCAL_ADDR: IpvXAddress =
+            IpvXAddress([0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+        pub const REMOTE_ADDR: IpvXAddress =
+            IpvXAddress([0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2]);
+        pub const OTHER_ADDR: IpvXAddress =
+            IpvXAddress([0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3]);
+
+        pub const BASE_MSS: u16 = 1440;
+    }
+
+    #[cfg(feature = "proto-ipv4")]
+    use proto_ipv4::*;
+
+    #[cfg(not(feature = "proto-ipv4"))]
+    use proto_ipv6::*;
 
     const SEND_IP_TEMPL: IpRepr = IpReprIpvX(IpvXRepr {
         src_addr: LOCAL_ADDR,

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -504,31 +504,36 @@ mod test {
     const LOCAL_PORT: u16 = 53;
     const REMOTE_PORT: u16 = 49500;
 
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "proto-ipv4")] {
-            use crate::wire::Ipv4Address as IpvXAddress;
-            use crate::wire::Ipv4Repr as IpvXRepr;
-            use IpRepr::Ipv4 as IpReprIpvX;
+    #[cfg(feature = "proto-ipv4")]
+    mod proto_ipv4 {
+        pub use super::IpRepr::Ipv4 as IpReprIpvX;
+        pub use crate::wire::Ipv4Address as IpvXAddress;
+        pub use crate::wire::Ipv4Repr as IpvXRepr;
 
-            const LOCAL_ADDR: IpvXAddress = IpvXAddress([192, 168, 1, 1]);
-            const REMOTE_ADDR: IpvXAddress = IpvXAddress([192, 168, 1, 2]);
-            const OTHER_ADDR: IpvXAddress = IpvXAddress([192, 168, 1, 3]);
-        } else {
-            use crate::wire::Ipv6Address as IpvXAddress;
-            use crate::wire::Ipv6Repr as IpvXRepr;
-            use IpRepr::Ipv6 as IpReprIpvX;
-
-            const LOCAL_ADDR: IpvXAddress = IpvXAddress([
-                0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
-            ]);
-            const REMOTE_ADDR: IpvXAddress = IpvXAddress([
-                0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
-            ]);
-            const OTHER_ADDR: IpvXAddress = IpvXAddress([
-                0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3,
-            ]);
-        }
+        pub const LOCAL_ADDR: IpvXAddress = IpvXAddress([192, 168, 1, 1]);
+        pub const REMOTE_ADDR: IpvXAddress = IpvXAddress([192, 168, 1, 2]);
+        pub const OTHER_ADDR: IpvXAddress = IpvXAddress([192, 168, 1, 3]);
     }
+
+    #[cfg(not(feature = "proto-ipv4"))]
+    mod proto_ipv6 {
+        pub use super::IpRepr::Ipv6 as IpReprIpvX;
+        pub use crate::wire::Ipv6Address as IpvXAddress;
+        pub use crate::wire::Ipv6Repr as IpvXRepr;
+
+        pub const LOCAL_ADDR: IpvXAddress =
+            IpvXAddress([0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+        pub const REMOTE_ADDR: IpvXAddress =
+            IpvXAddress([0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2]);
+        pub const OTHER_ADDR: IpvXAddress =
+            IpvXAddress([0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3]);
+    }
+
+    #[cfg(feature = "proto-ipv4")]
+    use proto_ipv4::*;
+
+    #[cfg(not(feature = "proto-ipv4"))]
+    use proto_ipv6::*;
 
     pub const LOCAL_END: IpEndpoint = IpEndpoint {
         addr: LOCAL_ADDR.into_address(),


### PR DESCRIPTION
We don't actually need the `cfg-if` dependency. It's also annoying to format inside the `cfg_if!` macro. This PR removes it.