### PR TITLE
DHCPv4: use a Vec to store DNS server addresses instead of an array o…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ url = "2.0"
 std = ["managed/std", "defmt?/alloc"]
 alloc = ["managed/alloc", "defmt?/alloc"]
 verbose = []
+defmt = [ "dep:defmt", "heapless/defmt", "heapless/defmt-impl" ]
 "medium-ethernet" = ["socket"]
 "medium-ip" = ["socket"]
 "medium-ieee802154" = ["socket", "proto-sixlowpan"]

--- a/examples/dhcp_client.rs
+++ b/examples/dhcp_client.rs
@@ -78,9 +78,7 @@ fn main() {
                 }
 
                 for (i, s) in config.dns_servers.iter().enumerate() {
-                    if let Some(s) = s {
-                        debug!("DNS server {}:    {}", i, s);
-                    }
+                    debug!("DNS server {}:    {}", i, s);
                 }
             }
             Some(dhcpv4::Event::Deconfigured) => {


### PR DESCRIPTION
…f options

This simplifies usage of this field, but does remove the `Copy` derive from that struct.

If the `Copy` derive on `Dhcpv4Repr` is not a requirement, I would like to replace it's internal `Option<[Option<Ipv4Address>; 3]>` with an `Option<Vec<Ipv4Address; 3>>` too.