### PR TITLE
Remove implicit sized bound on device generics

### DIFF
--- a/src/iface/interface.rs
+++ b/src/iface/interface.rs
@@ -429,7 +429,7 @@ let iface = builder.finalize(&mut device);
     /// [neighbor_cache]: #method.neighbor_cache
     pub fn finalize<D>(self, device: &mut D) -> Interface<'a>
     where
-        D: for<'d> Device<'d>,
+        D: for<'d> Device<'d> + ?Sized,
     {
         let caps = device.capabilities();
 
@@ -764,7 +764,7 @@ impl<'a> Interface<'a> {
         timestamp: Instant,
     ) -> Result<bool>
     where
-        D: for<'d> Device<'d>,
+        D: for<'d> Device<'d> + ?Sized,
     {
         self.inner.now = timestamp;
 
@@ -806,7 +806,7 @@ impl<'a> Interface<'a> {
         timestamp: Instant,
     ) -> Result<bool>
     where
-        D: for<'d> Device<'d>,
+        D: for<'d> Device<'d> + ?Sized,
     {
         self.inner.now = timestamp;
 
@@ -906,7 +906,7 @@ impl<'a> Interface<'a> {
         sockets: &mut SocketSet<'_>,
     ) -> Result<bool>
     where
-        D: for<'d> Device<'d>,
+        D: for<'d> Device<'d> + ?Sized,
     {
         self.inner.now = timestamp;
 
@@ -1006,7 +1006,7 @@ impl<'a> Interface<'a> {
 
     fn socket_ingress<D>(&mut self, device: &mut D, sockets: &mut SocketSet<'_>) -> bool
     where
-        D: for<'d> Device<'d>,
+        D: for<'d> Device<'d> + ?Sized,
     {
         let mut processed_any = false;
         let Self {
@@ -1060,7 +1060,7 @@ impl<'a> Interface<'a> {
 
     fn socket_egress<D>(&mut self, device: &mut D, sockets: &mut SocketSet<'_>) -> bool
     where
-        D: for<'d> Device<'d>,
+        D: for<'d> Device<'d> + ?Sized,
     {
         let Self {
             inner,
@@ -1172,7 +1172,7 @@ impl<'a> Interface<'a> {
     #[cfg(feature = "proto-igmp")]
     fn igmp_egress<D>(&mut self, device: &mut D) -> Result<bool>
     where
-        D: for<'d> Device<'d>,
+        D: for<'d> Device<'d> + ?Sized,
     {
         match self.inner.igmp_report_state {
             IgmpReportState::ToSpecificQuery {
@@ -1233,7 +1233,7 @@ impl<'a> Interface<'a> {
     #[cfg(feature = "proto-sixlowpan-fragmentation")]
     fn sixlowpan_egress<D>(&mut self, device: &mut D) -> Result<bool>
     where
-        D: for<'d> Device<'d>,
+        D: for<'d> Device<'d> + ?Sized,
     {
         let SixlowpanOutPacket {
             packet_len,


### PR DESCRIPTION
The generic is only ever accessed through a reference and so it doesn't have to be sized.

Signed-off-by: Klim Tsoutsman <klim@tsoutsman.com>