### PR TITLE
Use renewal time from DHCP server ACK, if given

### DIFF
--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -860,6 +860,8 @@ mod test {
         parameter_request_list: None,
         dns_servers: None,
         max_size: None,
+        renew_duration: None,
+        rebind_duration: None,
         lease_duration: None,
         additional_options: &[],
     };

--- a/src/wire/dhcpv4.rs
+++ b/src/wire/dhcpv4.rs
@@ -651,6 +651,10 @@ pub struct Repr<'a> {
     pub max_size: Option<u16>,
     /// The DHCP IP lease duration, specified in seconds.
     pub lease_duration: Option<u32>,
+    /// The DHCP IP renew duration (T1 interval), in seconds, if specified in the packet.
+    pub renew_duration: Option<u32>,
+    /// The DHCP IP rebind duration (T2 interval), in seconds, if specified in the packet.
+    pub rebind_duration: Option<u32>,
     /// When returned from [`Repr::parse`], this field will be `None`.
     /// However, when calling [`Repr::emit`], this field should contain only
     /// additional DHCP options not known to smoltcp.
@@ -735,6 +739,8 @@ impl<'a> Repr<'a> {
         let mut dns_servers = None;
         let mut max_size = None;
         let mut lease_duration = None;
+        let mut renew_duration = None;
+        let mut rebind_duration = None;
 
         for option in packet.options() {
             let data = option.data;
@@ -766,6 +772,12 @@ impl<'a> Repr<'a> {
                 }
                 (field::OPT_MAX_DHCP_MESSAGE_SIZE, 2) => {
                     max_size = Some(u16::from_be_bytes([data[0], data[1]]));
+                }
+                (field::OPT_RENEWAL_TIME_VALUE, 4) => {
+                    renew_duration = Some(u32::from_be_bytes([data[0], data[1], data[2], data[3]]))
+                }
+                (field::OPT_REBINDING_TIME_VALUE, 4) => {
+                    rebind_duration = Some(u32::from_be_bytes([data[0], data[1], data[2], data[3]]))
                 }
                 (field::OPT_IP_LEASE_TIME, 4) => {
                     lease_duration = Some(u32::from_be_bytes([data[0], data[1], data[2], data[3]]))
@@ -808,6 +820,8 @@ impl<'a> Repr<'a> {
             dns_servers,
             max_size,
             lease_duration,
+            renew_duration,
+            rebind_duration,
             message_type: message_type?,
             additional_options: &[],
         })

--- a/src/wire/dhcpv4.rs
+++ b/src/wire/dhcpv4.rs
@@ -1162,6 +1162,8 @@ mod test {
             parameter_request_list: None,
             dns_servers: None,
             max_size: None,
+            renew_duration: None,
+            rebind_duration: None,
             lease_duration: Some(0xffff_ffff), // Infinite lease
             additional_options: &[],
         }
@@ -1181,6 +1183,8 @@ mod test {
             broadcast: false,
             secs: 0,
             max_size: Some(DHCP_SIZE),
+            renew_duration: None,
+            rebind_duration: None,
             lease_duration: None,
             requested_ip: Some(IP_NULL),
             client_identifier: Some(CLIENT_MAC),


### PR DESCRIPTION
# Description

Per RFC 2132 section 9.11 the server can manually specify a renewal (T1) time different from the default value (half the lease time) through option code 58. This PR updates the behavior of the dhcp client to use that value, if provided, and only if not provided does it default to half of the lease duration.

Since smoltcp seems to ignore the REBINDING state, I also made it look for a provided rebinding (T2) time provided by the server (dhcp option 59) and made it use that value as the renewal time if no renewal time was provided and the rebinding time is less than the default. This behavior seems sensible to me, given that we're not following the REBINDING part of the spec, but I can change it to ignore option code 59, or any other handling, if that is preferred.

# Verification

I realized that this functionality was missing when I changed my configuration to set a 10 second renew time on a lease which lasts for a very long time, and observed that my devices (which use this library) weren't attempting to renew. To verify that this PR works, I ran it in my existing setup and confirmed that my devices now renew their leases at approximately 10 second intervals. I think this, alongside the tests in CI, should be good enough.