### PR TITLE
DHCP indicate new config if there's a packet buffer provided

### DIFF
--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -361,8 +361,17 @@ impl<'a> Socket<'a> {
                 ) {
                     state.renew_at = renew_at;
                     state.expires_at = expires_at;
+                    // The `receive_packet_buffer` field isn't populated until
+                    // the client asks for the state, but receiving any packet
+                    // will change it, so we indicate that the config has
+                    // changed every time if the receive packet buffer is set,
+                    // but we only write changes to the rest of the config now.
+                    let config_changed =
+                        state.config != config || self.receive_packet_buffer.is_some();
                     if state.config != config {
                         state.config = config;
+                    }
+                    if config_changed {
                         self.config_changed();
                     }
                 }


### PR DESCRIPTION
# Description

If the user provides a buffer in which to store the packets, then the contents of the received packet will be buffered and included in the returned Config when the DHCP connection is made. However, it isn't included in the Config struct until the value is returned to the user, so the equality check for whether to call `config_changed` disregards any additional information in the buffer beyond what this library parses.

For my purposes, I need access to the contents of the buffer when they change as a result of a new packet, even if everything else is the same. Since two packets will almost certainly not be the same thanks to the magic cookie (unless the packet gets duplicated on the network, which is an acceptably low risk for my use of smoltcp), an acceptable option for my uses is to just always return the new configuration when a packet is received (gated on whether a buffer is provided to return the packet into).

# Alternatives

While this approach is the easiest and best for my uses, I can think of the following alternatives which would also work and might be preferred for other use-cases:
 * Allow the user to specify whether they wish to receive all packets instead of opting all users who provide a buffer into this behavior
 * Allow the user to provide a closure which compares the old and new packets and returns true if this represents a new config which should be returned.
 * Compare the old packet to the new packet (either byte-by-byte or looking at the provided options) and only return a new config if differences are found.

# Verification

In my setup, I was seeing bugs that were caused by smoltcp not exposing the config when the only changes were in the additional options that I want to use but which smoltcp doesn't use directly. Using this branch instead of the main release fixed those bugs and I was able to verify that it behaves the way I expected. I think this verification, along with CI tests passing, should be sufficient for verifying this PR.