### PR TITLE
Add address context information for resolving 6LoWPAN addresses

### DIFF
--- a/fuzz/fuzz_targets/sixlowpan_packet.rs
+++ b/fuzz/fuzz_targets/sixlowpan_packet.rs
@@ -43,6 +43,7 @@ fuzz_target!(|fuzz: SixlowpanPacketFuzzer| {
                     &frame,
                     fuzz.ll_src_addr.map(Into::into),
                     fuzz.ll_dst_addr.map(Into::into),
+                    &[],
                 ) {
                     let mut buffer = vec![0; iphc_repr.buffer_len()];
                     let mut iphc_frame = SixlowpanIphcPacket::new_unchecked(&mut buffer[..]);

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -151,7 +151,7 @@ pub use self::sixlowpan::{
         NhcPacket as SixlowpanNhcPacket, UdpNhcPacket as SixlowpanUdpNhcPacket,
         UdpNhcRepr as SixlowpanUdpNhcRepr,
     },
-    NextHeader as SixlowpanNextHeader, SixlowpanPacket,
+    AddressContext as SixlowpanAddressContext, NextHeader as SixlowpanNextHeader, SixlowpanPacket,
 };
 
 #[cfg(feature = "medium-ieee802154")]


### PR DESCRIPTION
Implements [3.1.2. Context Identifier Extension](https://www.rfc-editor.org/rfc/rfc6282#section-3.1.2)