### PR TITLE
use same version number as released

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoltcp"
-version = "0.9.0"
+version = "0.8.1"
 edition = "2018"
 rust-version = "1.60"
 authors = ["whitequark <whitequark@whitequark.org>"]


### PR DESCRIPTION
This reverts the bump to `0.9.0` and just makes the version the same as the released one.