### PR TITLE
Constification of the wire module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         # Failure is permitted on nightly.
         rust:
           - stable
-          - 1.60.0
+          - 1.61.0
           - nightly
 
         features:
@@ -65,7 +65,7 @@ jobs:
         # Failure is permitted on nightly.
         rust:
           - stable
-          - 1.60.0
+          - 1.61.0
           - nightly
 
         features:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "smoltcp"
 version = "0.8.1"
 edition = "2018"
-rust-version = "1.60"
+rust-version = "1.61"
 authors = ["whitequark <whitequark@whitequark.org>"]
 description = "A TCP/IP stack designed for bare-metal, real-time systems without a heap."
 documentation = "https://docs.rs/smoltcp/"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ include complicated compile-time computations, such as macro or type tricks, eve
 at cost of performance degradation.
 
 _smoltcp_ does not need heap allocation *at all*, is [extensively documented][docs],
-and compiles on stable Rust 1.60 and later.
+and compiles on stable Rust 1.61 and later.
 
 _smoltcp_ achieves [~Gbps of throughput](#examplesbenchmarkrs) when tested against
 the Linux TCP stack in loopback mode.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 //!
 //! # Minimum Supported Rust Version (MSRV)
 //!
-//! This crate is guaranteed to compile on stable Rust 1.60 and up with any valid set of features.
+//! This crate is guaranteed to compile on stable Rust 1.61 and up with any valid set of features.
 //! It *might* compile on older versions but that may change in any new patch release.
 //!
 //! The exception is when using the `defmt` feature, in which case `defmt`'s MSRV applies, which

--- a/src/wire/arp.rs
+++ b/src/wire/arp.rs
@@ -39,25 +39,25 @@ mod field {
     pub const OPER: Field = 6..8;
 
     #[inline]
-    pub fn SHA(hardware_len: u8, _protocol_len: u8) -> Field {
+    pub const fn SHA(hardware_len: u8, _protocol_len: u8) -> Field {
         let start = OPER.end;
         start..(start + hardware_len as usize)
     }
 
     #[inline]
-    pub fn SPA(hardware_len: u8, protocol_len: u8) -> Field {
+    pub const fn SPA(hardware_len: u8, protocol_len: u8) -> Field {
         let start = SHA(hardware_len, protocol_len).end;
         start..(start + protocol_len as usize)
     }
 
     #[inline]
-    pub fn THA(hardware_len: u8, protocol_len: u8) -> Field {
+    pub const fn THA(hardware_len: u8, protocol_len: u8) -> Field {
         let start = SPA(hardware_len, protocol_len).end;
         start..(start + hardware_len as usize)
     }
 
     #[inline]
-    pub fn TPA(hardware_len: u8, protocol_len: u8) -> Field {
+    pub const fn TPA(hardware_len: u8, protocol_len: u8) -> Field {
         let start = THA(hardware_len, protocol_len).end;
         start..(start + protocol_len as usize)
     }
@@ -65,7 +65,7 @@ mod field {
 
 impl<T: AsRef<[u8]>> Packet<T> {
     /// Imbue a raw octet buffer with ARP packet structure.
-    pub fn new_unchecked(buffer: T) -> Packet<T> {
+    pub const fn new_unchecked(buffer: T) -> Packet<T> {
         Packet { buffer }
     }
 
@@ -289,7 +289,7 @@ impl Repr {
     }
 
     /// Return the length of a packet that will be emitted from this high-level representation.
-    pub fn buffer_len(&self) -> usize {
+    pub const fn buffer_len(&self) -> usize {
         match *self {
             Repr::EthernetIpv4 { .. } => field::TPA(6, 4).end,
         }

--- a/src/wire/dhcpv4.rs
+++ b/src/wire/dhcpv4.rs
@@ -44,7 +44,7 @@ bitflags! {
 }
 
 impl MessageType {
-    fn opcode(&self) -> OpCode {
+    const fn opcode(&self) -> OpCode {
         match *self {
             MessageType::Discover
             | MessageType::Inform
@@ -233,7 +233,7 @@ pub(crate) mod field {
 
 impl<T: AsRef<[u8]>> Packet<T> {
     /// Imbue a raw octet buffer with DHCP packet structure.
-    pub fn new_unchecked(buffer: T) -> Packet<T> {
+    pub const fn new_unchecked(buffer: T) -> Packet<T> {
         Packet { buffer }
     }
 
@@ -1143,7 +1143,7 @@ mod test {
         assert_eq!(packet, DISCOVER_BYTES);
     }
 
-    fn offer_repr() -> Repr<'static> {
+    const fn offer_repr() -> Repr<'static> {
         Repr {
             message_type: MessageType::Offer,
             transaction_id: 0x3d1d,
@@ -1169,7 +1169,7 @@ mod test {
         }
     }
 
-    fn discover_repr() -> Repr<'static> {
+    const fn discover_repr() -> Repr<'static> {
         Repr {
             message_type: MessageType::Discover,
             transaction_id: 0x3d1d,

--- a/src/wire/dns.rs
+++ b/src/wire/dns.rs
@@ -83,7 +83,7 @@ pub struct Packet<T: AsRef<[u8]>> {
 
 impl<T: AsRef<[u8]>> Packet<T> {
     /// Imbue a raw octet buffer with DNS packet structure.
-    pub fn new_unchecked(buffer: T) -> Packet<T> {
+    pub const fn new_unchecked(buffer: T) -> Packet<T> {
         Packet { buffer }
     }
 
@@ -311,7 +311,7 @@ impl<'a> Question<'a> {
     }
 
     /// Return the length of a packet that will be emitted from this high-level representation.
-    pub fn buffer_len(&self) -> usize {
+    pub const fn buffer_len(&self) -> usize {
         self.name.len() + 4
     }
 
@@ -412,7 +412,7 @@ pub struct Repr<'a> {
 
 impl<'a> Repr<'a> {
     /// Return the length of a packet that will be emitted from this high-level representation.
-    pub fn buffer_len(&self) -> usize {
+    pub const fn buffer_len(&self) -> usize {
         field::HEADER_END + self.question.buffer_len()
     }
 

--- a/src/wire/ethernet.rs
+++ b/src/wire/ethernet.rs
@@ -43,7 +43,7 @@ impl Address {
     }
 
     /// Return an Ethernet address as a sequence of octets, in big-endian.
-    pub fn as_bytes(&self) -> &[u8] {
+    pub const fn as_bytes(&self) -> &[u8] {
         &self.0
     }
 
@@ -58,12 +58,12 @@ impl Address {
     }
 
     /// Query whether the "multicast" bit in the OUI is set.
-    pub fn is_multicast(&self) -> bool {
+    pub const fn is_multicast(&self) -> bool {
         self.0[0] & 0x01 != 0
     }
 
     /// Query whether the "locally administered" bit in the OUI is set.
-    pub fn is_local(&self) -> bool {
+    pub const fn is_local(&self) -> bool {
         self.0[0] & 0x02 != 0
     }
 }
@@ -100,7 +100,7 @@ pub const HEADER_LEN: usize = field::PAYLOAD.start;
 
 impl<T: AsRef<[u8]>> Frame<T> {
     /// Imbue a raw octet buffer with Ethernet frame structure.
-    pub fn new_unchecked(buffer: T) -> Frame<T> {
+    pub const fn new_unchecked(buffer: T) -> Frame<T> {
         Frame { buffer }
     }
 
@@ -131,13 +131,13 @@ impl<T: AsRef<[u8]>> Frame<T> {
     }
 
     /// Return the length of a frame header.
-    pub fn header_len() -> usize {
+    pub const fn header_len() -> usize {
         HEADER_LEN
     }
 
     /// Return the length of a buffer required to hold a packet with the payload
     /// of a given length.
-    pub fn buffer_len(payload_len: usize) -> usize {
+    pub const fn buffer_len(payload_len: usize) -> usize {
         HEADER_LEN + payload_len
     }
 
@@ -277,7 +277,7 @@ impl Repr {
     }
 
     /// Return the length of a header that will be emitted from this high-level representation.
-    pub fn buffer_len(&self) -> usize {
+    pub const fn buffer_len(&self) -> usize {
         HEADER_LEN
     }
 

--- a/src/wire/icmpv4.rs
+++ b/src/wire/icmpv4.rs
@@ -184,7 +184,7 @@ mod field {
 
 impl<T: AsRef<[u8]>> Packet<T> {
     /// Imbue a raw octet buffer with ICMPv4 packet structure.
-    pub fn new_unchecked(buffer: T) -> Packet<T> {
+    pub const fn new_unchecked(buffer: T) -> Packet<T> {
         Packet { buffer }
     }
 
@@ -468,7 +468,7 @@ impl<'a> Repr<'a> {
     }
 
     /// Return the length of a packet that will be emitted from this high-level representation.
-    pub fn buffer_len(&self) -> usize {
+    pub const fn buffer_len(&self) -> usize {
         match self {
             &Repr::EchoRequest { data, .. } | &Repr::EchoReply { data, .. } => {
                 field::ECHO_SEQNO.end + data.len()

--- a/src/wire/icmpv6.rs
+++ b/src/wire/icmpv6.rs
@@ -55,7 +55,7 @@ impl Message {
     /// is an [NDISC] message type.
     ///
     /// [NDISC]: https://tools.ietf.org/html/rfc4861
-    pub fn is_ndisc(&self) -> bool {
+    pub const fn is_ndisc(&self) -> bool {
         match *self {
             Message::RouterSolicit
             | Message::RouterAdvert
@@ -70,7 +70,7 @@ impl Message {
     /// is an [MLD] message type.
     ///
     /// [MLD]: https://tools.ietf.org/html/rfc3810
-    pub fn is_mld(&self) -> bool {
+    pub const fn is_mld(&self) -> bool {
         match *self {
             Message::MldQuery | Message::MldReport => true,
             _ => false,
@@ -247,7 +247,7 @@ pub(super) mod field {
 
 impl<T: AsRef<[u8]>> Packet<T> {
     /// Imbue a raw octet buffer with ICMPv6 packet structure.
-    pub fn new_unchecked(buffer: T) -> Packet<T> {
+    pub const fn new_unchecked(buffer: T) -> Packet<T> {
         Packet { buffer }
     }
 
@@ -625,7 +625,7 @@ impl<'a> Repr<'a> {
     }
 
     /// Return the length of a packet that will be emitted from this high-level representation.
-    pub fn buffer_len(&self) -> usize {
+    pub const fn buffer_len(&self) -> usize {
         match self {
             &Repr::DstUnreachable { header, data, .. }
             | &Repr::PktTooBig { header, data, .. }

--- a/src/wire/ieee802154.rs
+++ b/src/wire/ieee802154.rs
@@ -43,7 +43,7 @@ enum_with_unknown! {
 
 impl AddressingMode {
     /// Return the size in octets of the address.
-    fn size(&self) -> usize {
+    const fn size(&self) -> usize {
         match self {
             AddressingMode::Absent => 0,
             AddressingMode::Short => 2,
@@ -103,11 +103,11 @@ impl Address {
         *self == Self::BROADCAST
     }
 
-    fn short_from_bytes(a: [u8; 2]) -> Self {
+    const fn short_from_bytes(a: [u8; 2]) -> Self {
         Self::Short(a)
     }
 
-    fn extended_from_bytes(a: [u8; 8]) -> Self {
+    const fn extended_from_bytes(a: [u8; 8]) -> Self {
         Self::Extended(a)
     }
 
@@ -125,7 +125,7 @@ impl Address {
         }
     }
 
-    pub fn as_bytes(&self) -> &[u8] {
+    pub const fn as_bytes(&self) -> &[u8] {
         match self {
             Address::Absent => &[],
             Address::Short(value) => value,
@@ -224,7 +224,7 @@ macro_rules! set_fc_bit_field {
 
 impl<T: AsRef<[u8]>> Frame<T> {
     /// Input a raw octet buffer with Ethernet frame structure.
-    pub fn new_unchecked(buffer: T) -> Frame<T> {
+    pub const fn new_unchecked(buffer: T) -> Frame<T> {
         Frame { buffer }
     }
 
@@ -784,7 +784,7 @@ impl Repr {
 
     /// Return the length of a buffer required to hold a packet with the payload of a given length.
     #[inline]
-    pub fn buffer_len(&self) -> usize {
+    pub const fn buffer_len(&self) -> usize {
         3 + 2
             + match self.dst_addr {
                 Some(Address::Absent) | None => 0,

--- a/src/wire/igmp.rs
+++ b/src/wire/igmp.rs
@@ -54,7 +54,7 @@ impl fmt::Display for Message {
 /// [RFC 2236]: https://tools.ietf.org/html/rfc2236
 impl<T: AsRef<[u8]>> Packet<T> {
     /// Imbue a raw octet buffer with IGMPv2 packet structure.
-    pub fn new_unchecked(buffer: T) -> Packet<T> {
+    pub const fn new_unchecked(buffer: T) -> Packet<T> {
         Packet { buffer }
     }
 
@@ -246,7 +246,7 @@ impl Repr {
     }
 
     /// Return the length of a packet that will be emitted from this high-level representation.
-    pub fn buffer_len(&self) -> usize {
+    pub const fn buffer_len(&self) -> usize {
         // always 8 bytes
         field::GROUP_ADDRESS.end
     }
@@ -304,7 +304,7 @@ fn max_resp_code_to_duration(value: u8) -> Duration {
     Duration::from_millis(decisecs * 100)
 }
 
-fn duration_to_max_resp_code(duration: Duration) -> u8 {
+const fn duration_to_max_resp_code(duration: Duration) -> u8 {
     let decisecs = duration.total_millis() / 100;
     if decisecs < 128 {
         decisecs as u8

--- a/src/wire/ip.rs
+++ b/src/wire/ip.rs
@@ -23,7 +23,7 @@ impl Version {
     ///
     /// This function never returns `Ok(IpVersion::Unspecified)`; instead,
     /// unknown versions result in `Err(Error)`.
-    pub fn of_packet(data: &[u8]) -> Result<Version> {
+    pub const fn of_packet(data: &[u8]) -> Result<Version> {
         match data[0] >> 4 {
             #[cfg(feature = "proto-ipv4")]
             4 => Ok(Version::Ipv4),
@@ -93,7 +93,7 @@ pub enum Address {
 impl Address {
     /// Create an address wrapping an IPv4 address with the given octets.
     #[cfg(feature = "proto-ipv4")]
-    pub fn v4(a0: u8, a1: u8, a2: u8, a3: u8) -> Address {
+    pub const fn v4(a0: u8, a1: u8, a2: u8, a3: u8) -> Address {
         Address::Ipv4(Ipv4Address::new(a0, a1, a2, a3))
     }
 
@@ -105,7 +105,7 @@ impl Address {
     }
 
     /// Return the protocol version.
-    pub fn version(&self) -> Version {
+    pub const fn version(&self) -> Version {
         match self {
             #[cfg(feature = "proto-ipv4")]
             Address::Ipv4(_) => Version::Ipv4,
@@ -115,7 +115,7 @@ impl Address {
     }
 
     /// Return an address as a sequence of octets, in big-endian.
-    pub fn as_bytes(&self) -> &[u8] {
+    pub const fn as_bytes(&self) -> &[u8] {
         match *self {
             #[cfg(feature = "proto-ipv4")]
             Address::Ipv4(ref addr) => addr.as_bytes(),
@@ -135,7 +135,7 @@ impl Address {
     }
 
     /// Query whether the address is a valid multicast address.
-    pub fn is_multicast(&self) -> bool {
+    pub const fn is_multicast(&self) -> bool {
         match *self {
             #[cfg(feature = "proto-ipv4")]
             Address::Ipv4(addr) => addr.is_multicast(),
@@ -289,7 +289,7 @@ impl Cidr {
     }
 
     /// Return the IP address of this CIDR block.
-    pub fn address(&self) -> Address {
+    pub const fn address(&self) -> Address {
         match *self {
             #[cfg(feature = "proto-ipv4")]
             Cidr::Ipv4(cidr) => Address::Ipv4(cidr.address()),
@@ -299,7 +299,7 @@ impl Cidr {
     }
 
     /// Return the prefix length of this CIDR block.
-    pub fn prefix_len(&self) -> u8 {
+    pub const fn prefix_len(&self) -> u8 {
         match *self {
             #[cfg(feature = "proto-ipv4")]
             Cidr::Ipv4(cidr) => cidr.prefix_len(),
@@ -386,7 +386,7 @@ pub struct Endpoint {
 
 impl Endpoint {
     /// Create an endpoint address from given address and port.
-    pub fn new(addr: Address, port: u16) -> Endpoint {
+    pub const fn new(addr: Address, port: u16) -> Endpoint {
         Endpoint { addr: addr, port }
     }
 }
@@ -457,7 +457,7 @@ pub struct ListenEndpoint {
 
 impl ListenEndpoint {
     /// Query whether the endpoint has a specified address and port.
-    pub fn is_specified(&self) -> bool {
+    pub const fn is_specified(&self) -> bool {
         self.addr.is_some() && self.port != 0
     }
 }
@@ -596,7 +596,7 @@ impl Repr {
     }
 
     /// Return the protocol version.
-    pub fn version(&self) -> Version {
+    pub const fn version(&self) -> Version {
         match *self {
             #[cfg(feature = "proto-ipv4")]
             Repr::Ipv4(_) => Version::Ipv4,
@@ -606,7 +606,7 @@ impl Repr {
     }
 
     /// Return the source address.
-    pub fn src_addr(&self) -> Address {
+    pub const fn src_addr(&self) -> Address {
         match *self {
             #[cfg(feature = "proto-ipv4")]
             Repr::Ipv4(repr) => Address::Ipv4(repr.src_addr),
@@ -616,7 +616,7 @@ impl Repr {
     }
 
     /// Return the destination address.
-    pub fn dst_addr(&self) -> Address {
+    pub const fn dst_addr(&self) -> Address {
         match *self {
             #[cfg(feature = "proto-ipv4")]
             Repr::Ipv4(repr) => Address::Ipv4(repr.dst_addr),
@@ -626,7 +626,7 @@ impl Repr {
     }
 
     /// Return the next header (protocol).
-    pub fn next_header(&self) -> Protocol {
+    pub const fn next_header(&self) -> Protocol {
         match *self {
             #[cfg(feature = "proto-ipv4")]
             Repr::Ipv4(repr) => repr.next_header,
@@ -636,7 +636,7 @@ impl Repr {
     }
 
     /// Return the payload length.
-    pub fn payload_len(&self) -> usize {
+    pub const fn payload_len(&self) -> usize {
         match *self {
             #[cfg(feature = "proto-ipv4")]
             Repr::Ipv4(repr) => repr.payload_len,
@@ -656,7 +656,7 @@ impl Repr {
     }
 
     /// Return the TTL value.
-    pub fn hop_limit(&self) -> u8 {
+    pub const fn hop_limit(&self) -> u8 {
         match *self {
             #[cfg(feature = "proto-ipv4")]
             Repr::Ipv4(Ipv4Repr { hop_limit, .. }) => hop_limit,
@@ -666,7 +666,7 @@ impl Repr {
     }
 
     /// Return the length of a header that will be emitted from this high-level representation.
-    pub fn header_len(&self) -> usize {
+    pub const fn header_len(&self) -> usize {
         match *self {
             #[cfg(feature = "proto-ipv4")]
             Repr::Ipv4(repr) => repr.buffer_len(),
@@ -693,7 +693,7 @@ impl Repr {
     /// high-level representation.
     ///
     /// This is the same as `repr.buffer_len() + repr.payload_len()`.
-    pub fn buffer_len(&self) -> usize {
+    pub const fn buffer_len(&self) -> usize {
         self.header_len() + self.payload_len()
     }
 }
@@ -703,7 +703,7 @@ pub mod checksum {
 
     use super::*;
 
-    fn propagate_carries(word: u32) -> u16 {
+    const fn propagate_carries(word: u32) -> u16 {
         let sum = (word >> 16) + (word & 0xffff);
         ((sum >> 16) as u16) + (sum as u16)
     }

--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -67,7 +67,7 @@ impl Address {
     }
 
     /// Return an IPv4 address as a sequence of octets, in big-endian.
-    pub fn as_bytes(&self) -> &[u8] {
+    pub const fn as_bytes(&self) -> &[u8] {
         &self.0
     }
 
@@ -192,7 +192,7 @@ impl Cidr {
     }
 
     /// Return the network mask of this IPv4 CIDR.
-    pub fn netmask(&self) -> Address {
+    pub const fn netmask(&self) -> Address {
         if self.prefix_len == 0 {
             return Address([0, 0, 0, 0]);
         }
@@ -229,7 +229,7 @@ impl Cidr {
     }
 
     /// Return the network block of this IPv4 CIDR.
-    pub fn network(&self) -> Cidr {
+    pub const fn network(&self) -> Cidr {
         let mask = self.netmask().0;
         let network = [
             self.address.0[0] & mask[0],
@@ -303,7 +303,7 @@ pub const HEADER_LEN: usize = field::DST_ADDR.end;
 
 impl<T: AsRef<[u8]>> Packet<T> {
     /// Imbue a raw octet buffer with IPv4 packet structure.
-    pub fn new_unchecked(buffer: T) -> Packet<T> {
+    pub const fn new_unchecked(buffer: T) -> Packet<T> {
         Packet { buffer }
     }
 
@@ -662,7 +662,7 @@ impl Repr {
     }
 
     /// Return the length of a header that will be emitted from this high-level representation.
-    pub fn buffer_len(&self) -> usize {
+    pub const fn buffer_len(&self) -> usize {
         // We never emit any options.
         field::DST_ADDR.end
     }
@@ -880,7 +880,7 @@ mod test {
 
     static REPR_PAYLOAD_BYTES: [u8; ADDR_SIZE] = [0xaa, 0x00, 0x00, 0xff];
 
-    fn packet_repr() -> Repr {
+    const fn packet_repr() -> Repr {
         Repr {
             src_addr: Address([0x11, 0x12, 0x13, 0x14]),
             dst_addr: Address([0x21, 0x22, 0x23, 0x24]),

--- a/src/wire/ipv6.rs
+++ b/src/wire/ipv6.rs
@@ -116,7 +116,7 @@ impl Address {
     }
 
     /// Return an IPv6 address as a sequence of octets, in big-endian.
-    pub fn as_bytes(&self) -> &[u8] {
+    pub const fn as_bytes(&self) -> &[u8] {
         &self.0
     }
 
@@ -130,7 +130,7 @@ impl Address {
     /// Query whether the IPv6 address is a [multicast address].
     ///
     /// [multicast address]: https://tools.ietf.org/html/rfc4291#section-2.7
-    pub fn is_multicast(&self) -> bool {
+    pub const fn is_multicast(&self) -> bool {
         self.0[0] == 0xff
     }
 
@@ -333,12 +333,12 @@ impl Cidr {
     }
 
     /// Return the address of this IPv6 CIDR block.
-    pub fn address(&self) -> Address {
+    pub const fn address(&self) -> Address {
         self.address
     }
 
     /// Return the prefix length of this IPv6 CIDR block.
-    pub fn prefix_len(&self) -> u8 {
+    pub const fn prefix_len(&self) -> u8 {
         self.prefix_len
     }
 
@@ -425,7 +425,7 @@ pub const HEADER_LEN: usize = field::DST_ADDR.end;
 impl<T: AsRef<[u8]>> Packet<T> {
     /// Create a raw octet buffer with an IPv6 packet structure.
     #[inline]
-    pub fn new_unchecked(buffer: T) -> Packet<T> {
+    pub const fn new_unchecked(buffer: T) -> Packet<T> {
         Packet { buffer }
     }
 
@@ -464,7 +464,7 @@ impl<T: AsRef<[u8]>> Packet<T> {
 
     /// Return the header length.
     #[inline]
-    pub fn header_len(&self) -> usize {
+    pub const fn header_len(&self) -> usize {
         // This is not a strictly necessary function, but it makes
         // code more readable.
         field::DST_ADDR.end
@@ -670,7 +670,7 @@ impl Repr {
     }
 
     /// Return the length of a header that will be emitted from this high-level representation.
-    pub fn buffer_len(&self) -> usize {
+    pub const fn buffer_len(&self) -> usize {
         // This function is not strictly necessary, but it can make client code more readable.
         field::DST_ADDR.end
     }
@@ -1055,7 +1055,7 @@ mod test {
         0x00, 0x01, 0x00, 0x02, 0x00, 0x0c, 0x02, 0x4e, 0xff, 0xff, 0xff, 0xff,
     ];
 
-    fn packet_repr() -> Repr {
+    const fn packet_repr() -> Repr {
         Repr {
             src_addr: Address([
                 0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/src/wire/ipv6fragment.rs
+++ b/src/wire/ipv6fragment.rs
@@ -36,7 +36,7 @@ mod field {
 
 impl<T: AsRef<[u8]>> Header<T> {
     /// Create a raw octet buffer with an IPv6 Fragment Header structure.
-    pub fn new_unchecked(buffer: T) -> Header<T> {
+    pub const fn new_unchecked(buffer: T) -> Header<T> {
         Header { buffer }
     }
 
@@ -188,7 +188,7 @@ impl Repr {
 
     /// Return the length, in bytes, of a header that will be emitted from this high-level
     /// representation.
-    pub fn buffer_len(&self) -> usize {
+    pub const fn buffer_len(&self) -> usize {
         field::IDENT.end
     }
 

--- a/src/wire/ipv6hopbyhop.rs
+++ b/src/wire/ipv6hopbyhop.rs
@@ -42,7 +42,7 @@ mod field {
     //
     // Length of the header is in 8-octet units, not including the first 8 octets. The first two
     // octets are the next header type and the header length.
-    pub fn OPTIONS(length_field: u8) -> Field {
+    pub const fn OPTIONS(length_field: u8) -> Field {
         let bytes = length_field as usize * 8 + 8;
         2..bytes
     }
@@ -50,7 +50,7 @@ mod field {
 
 impl<T: AsRef<[u8]>> Header<T> {
     /// Create a raw octet buffer with an IPv6 Hop-by-Hop Options Header structure.
-    pub fn new_unchecked(buffer: T) -> Header<T> {
+    pub const fn new_unchecked(buffer: T) -> Header<T> {
         Header { buffer }
     }
 
@@ -183,7 +183,7 @@ impl<'a> Repr<'a> {
 
     /// Return the length, in bytes, of a header that will be emitted from this high-level
     /// representation.
-    pub fn buffer_len(&self) -> usize {
+    pub const fn buffer_len(&self) -> usize {
         field::OPTIONS(self.length).end
     }
 

--- a/src/wire/ipv6option.rs
+++ b/src/wire/ipv6option.rs
@@ -81,14 +81,14 @@ mod field {
     // 8-bit unsigned integer. Length of the DATA field of this option, in octets.
     pub const LENGTH: usize = 1;
     // Variable-length field. Option-Type-specific data.
-    pub fn DATA(length: u8) -> Field {
+    pub const fn DATA(length: u8) -> Field {
         2..length as usize + 2
     }
 }
 
 impl<T: AsRef<[u8]>> Ipv6Option<T> {
     /// Create a raw octet buffer with an IPv6 Extension Header Option structure.
-    pub fn new_unchecked(buffer: T) -> Ipv6Option<T> {
+    pub const fn new_unchecked(buffer: T) -> Ipv6Option<T> {
         Ipv6Option { buffer }
     }
 
@@ -245,7 +245,7 @@ impl<'a> Repr<'a> {
     }
 
     /// Return the length of a header that will be emitted from this high-level representation.
-    pub fn buffer_len(&self) -> usize {
+    pub const fn buffer_len(&self) -> usize {
         match *self {
             Repr::Pad1 => 1,
             Repr::PadN(length) => field::DATA(length).end,

--- a/src/wire/ipv6routing.rs
+++ b/src/wire/ipv6routing.rs
@@ -91,7 +91,7 @@ mod field {
     //
     // Length of the header is in 8-octet units, not including the first 8 octets. The first four
     // octets are the next header type, the header length, routing type and segments left.
-    pub fn DATA(length_field: u8) -> Field {
+    pub const fn DATA(length_field: u8) -> Field {
         let bytes = length_field as usize * 8 + 8;
         4..bytes
     }
@@ -134,7 +134,7 @@ mod field {
     // 8-bit field containing the Pad value.
     pub const PAD: usize = 5;
     // Variable length field containing addresses
-    pub fn ADDRESSES(length_field: u8) -> Field {
+    pub const fn ADDRESSES(length_field: u8) -> Field {
         let data = DATA(length_field);
         8..data.end
     }
@@ -143,7 +143,7 @@ mod field {
 /// Core getter methods relevant to any routing type.
 impl<T: AsRef<[u8]>> Header<T> {
     /// Create a raw octet buffer with an IPv6 Routing Header structure.
-    pub fn new(buffer: T) -> Header<T> {
+    pub const fn new(buffer: T) -> Header<T> {
         Header { buffer }
     }
 
@@ -457,7 +457,7 @@ impl<'a> Repr<'a> {
 
     /// Return the length, in bytes, of a header that will be emitted from this high-level
     /// representation.
-    pub fn buffer_len(&self) -> usize {
+    pub const fn buffer_len(&self) -> usize {
         match self {
             &Repr::Rpl { length, .. } | &Repr::Type2 { length, .. } => field::DATA(length).end,
         }

--- a/src/wire/mld.rs
+++ b/src/wire/mld.rs
@@ -173,7 +173,7 @@ pub struct AddressRecord<T: AsRef<[u8]>> {
 
 impl<T: AsRef<[u8]>> AddressRecord<T> {
     /// Imbue a raw octet buffer with a Address Record structure.
-    pub fn new_unchecked(buffer: T) -> Self {
+    pub const fn new_unchecked(buffer: T) -> Self {
         Self { buffer }
     }
 
@@ -338,7 +338,7 @@ impl<'a> Repr<'a> {
     }
 
     /// Return the length of a packet that will be emitted from this high-level representation.
-    pub fn buffer_len(&self) -> usize {
+    pub const fn buffer_len(&self) -> usize {
         match self {
             Repr::Query { data, .. } => field::QUERY_NUM_SRCS.end + data.len(),
             Repr::Report { data, .. } => field::NR_MCAST_RCRDS.end + data.len(),

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -284,7 +284,7 @@ pub enum HardwareAddress {
 
 #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
 impl HardwareAddress {
-    pub fn as_bytes(&self) -> &[u8] {
+    pub const fn as_bytes(&self) -> &[u8] {
         match self {
             #[cfg(feature = "medium-ethernet")]
             HardwareAddress::Ethernet(addr) => addr.as_bytes(),
@@ -372,11 +372,11 @@ impl RawHardwareAddress {
         &self.data[..self.len as usize]
     }
 
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.len as usize
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len == 0
     }
 

--- a/src/wire/ndisc.rs
+++ b/src/wire/ndisc.rs
@@ -351,7 +351,7 @@ impl<'a> Repr<'a> {
         }
     }
 
-    pub fn buffer_len(&self) -> usize {
+    pub const fn buffer_len(&self) -> usize {
         match self {
             &Repr::RouterSolicit { lladdr } => match lladdr {
                 Some(addr) => {

--- a/src/wire/ndiscoption.rs
+++ b/src/wire/ndiscoption.rs
@@ -75,7 +75,7 @@ mod field {
     // Minimum length of an option.
     pub const MIN_OPT_LEN: usize = 8;
     // Variable-length field. Option-Type-specific data.
-    pub fn DATA(length: u8) -> Field {
+    pub const fn DATA(length: u8) -> Field {
         2..length as usize * 8
     }
 
@@ -145,7 +145,7 @@ mod field {
 /// Core getter methods relevant to any type of NDISC option.
 impl<T: AsRef<[u8]>> NdiscOption<T> {
     /// Create a raw octet buffer with an NDISC Option structure.
-    pub fn new_unchecked(buffer: T) -> NdiscOption<T> {
+    pub const fn new_unchecked(buffer: T) -> NdiscOption<T> {
         NdiscOption { buffer }
     }
 
@@ -499,7 +499,7 @@ impl<'a> Repr<'a> {
     }
 
     /// Return the length of a header that will be emitted from this high-level representation.
-    pub fn buffer_len(&self) -> usize {
+    pub const fn buffer_len(&self) -> usize {
         match self {
             &Repr::SourceLinkLayerAddr(addr) | &Repr::TargetLinkLayerAddr(addr) => {
                 let len = 2 + addr.len();

--- a/src/wire/sixlowpan.rs
+++ b/src/wire/sixlowpan.rs
@@ -282,7 +282,7 @@ pub mod frag {
 
     impl<T: AsRef<[u8]>> Packet<T> {
         /// Input a raw octet buffer with a 6LoWPAN Fragment header structure.
-        pub fn new_unchecked(buffer: T) -> Self {
+        pub const fn new_unchecked(buffer: T) -> Self {
             Self { buffer }
         }
 
@@ -445,7 +445,7 @@ pub mod frag {
         }
 
         /// Returns the length of the Fragment header.
-        pub fn buffer_len(&self) -> usize {
+        pub const fn buffer_len(&self) -> usize {
             match self {
                 Self::FirstFragment { .. } => field::FIRST_FRAGMENT_REST.start,
                 Self::Fragment { .. } => field::NEXT_FRAGMENT_REST.start,
@@ -558,7 +558,7 @@ pub mod iphc {
 
     impl<T: AsRef<[u8]>> Packet<T> {
         /// Input a raw octet buffer with a 6LoWPAN IPHC header structure.
-        pub fn new_unchecked(buffer: T) -> Self {
+        pub const fn new_unchecked(buffer: T) -> Self {
             Packet { buffer }
         }
 
@@ -1526,7 +1526,7 @@ pub mod nhc {
 
     impl<T: AsRef<[u8]>> ExtHeaderPacket<T> {
         /// Input a raw octet buffer with a 6LoWPAN NHC Extension Header structure.
-        pub fn new_unchecked(buffer: T) -> Self {
+        pub const fn new_unchecked(buffer: T) -> Self {
             ExtHeaderPacket { buffer }
         }
 
@@ -1745,7 +1745,7 @@ pub mod nhc {
 
     impl<T: AsRef<[u8]>> UdpNhcPacket<T> {
         /// Input a raw octet buffer with a LOWPAN_NHC frame structure for UDP.
-        pub fn new_unchecked(buffer: T) -> Self {
+        pub const fn new_unchecked(buffer: T) -> Self {
             Self { buffer }
         }
 
@@ -1786,7 +1786,7 @@ pub mod nhc {
         get_field!(ports_field, 0b11, 0);
 
         /// Returns the index of the start of the next header compressed fields.
-        fn nhc_fields_start(&self) -> usize {
+        const fn nhc_fields_start(&self) -> usize {
             1
         }
 

--- a/src/wire/tcp.rs
+++ b/src/wire/tcp.rs
@@ -87,7 +87,7 @@ mod field {
     pub const CHECKSUM: Field = 16..18;
     pub const URGENT: Field = 18..20;
 
-    pub fn OPTIONS(length: u8) -> Field {
+    pub const fn OPTIONS(length: u8) -> Field {
         URGENT.end..(length as usize)
     }
 
@@ -113,7 +113,7 @@ pub const HEADER_LEN: usize = field::URGENT.end;
 
 impl<T: AsRef<[u8]>> Packet<T> {
     /// Imbue a raw octet buffer with TCP packet structure.
-    pub fn new_unchecked(buffer: T) -> Packet<T> {
+    pub const fn new_unchecked(buffer: T) -> Packet<T> {
         Packet { buffer }
     }
 
@@ -753,7 +753,7 @@ pub enum Control {
 #[allow(clippy::len_without_is_empty)]
 impl Control {
     /// Return the length of a control flag, in terms of sequence space.
-    pub fn len(self) -> usize {
+    pub const fn len(self) -> usize {
         match self {
             Control::Syn | Control::Fin => 1,
             _ => 0,
@@ -761,7 +761,7 @@ impl Control {
     }
 
     /// Turn the PSH flag into no flag, and keep the rest as-is.
-    pub fn quash_psh(self) -> Control {
+    pub const fn quash_psh(self) -> Control {
         match self {
             Control::Psh => Control::None,
             _ => self,
@@ -971,12 +971,12 @@ impl<'a> Repr<'a> {
     }
 
     /// Return the length of the segment, in terms of sequence space.
-    pub fn segment_len(&self) -> usize {
+    pub const fn segment_len(&self) -> usize {
         self.payload.len() + self.control.len()
     }
 
     /// Return whether the segment has no flags set (except PSH) and no data.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         match self.control {
             _ if !self.payload.is_empty() => false,
             Control::Syn | Control::Fin | Control::Rst => false,

--- a/src/wire/udp.rs
+++ b/src/wire/udp.rs
@@ -23,7 +23,7 @@ mod field {
     pub const LENGTH: Field = 4..6;
     pub const CHECKSUM: Field = 6..8;
 
-    pub fn PAYLOAD(length: u16) -> Field {
+    pub const fn PAYLOAD(length: u16) -> Field {
         CHECKSUM.end..(length as usize)
     }
 }
@@ -33,7 +33,7 @@ pub const HEADER_LEN: usize = field::CHECKSUM.end;
 #[allow(clippy::len_without_is_empty)]
 impl<T: AsRef<[u8]>> Packet<T> {
     /// Imbue a raw octet buffer with UDP packet structure.
-    pub fn new_unchecked(buffer: T) -> Packet<T> {
+    pub const fn new_unchecked(buffer: T) -> Packet<T> {
         Packet { buffer }
     }
 
@@ -246,7 +246,7 @@ impl Repr {
     }
 
     /// Return the length of the packet header that will be emitted from this high-level representation.
-    pub fn header_len(&self) -> usize {
+    pub const fn header_len(&self) -> usize {
         HEADER_LEN
     }
 


### PR DESCRIPTION
A huge portion of the `wire` module is constifyable, as shown in this commit. Making these `const fn`s, especially the functions set aside in the `field` modules of wire, would be greatly beneficial to me as a consumer of this crate, and I imagine many others. Many of the structs in my own crate's "wire" module for a custom protocol are more constrained versions of the packets and reprs provided by smoltcp. Due to being more constrained, many fields which are variable in the generic reprs are now constant in mine, which then lend themselves to being constants in my crate, however these functions and methods not being marked `const` prevents me from using smoltcp's tools to calculate these values. **Most** of the functions which I marked `const` in this commit are by their very nature/semantics guaranteed to be constifiable anyway, however a handful aren't necessarily, therefore:

**Important note:** While the majority of the functions are marked `const` are very safe to do so, not all of them are guaranteed to be so, and the reviewer of this PR should take caution and feel free to unmark something as const if they're not comfortable making that guarantee in the public API.

Another note: There are various other functions which can't be made `const fn` as written, but could be with minor tweaks. I did not include these tweaks but I think it should be considered as further work for this PR or a potential follow-up PR. Furthermore, plenty outside of `wire` is constifyable as well but I did not include those in the scope of this PR.