### PR TITLE
[DO NOT MERGE] Allow a type implementing `phy::Device` to contain borrowed data

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
         if: github.event_name != 'pull_request_target'
       - run: sed -n 's,^rust-version = "\(.*\)"$,RUSTUP_TOOLCHAIN=\1,p' Cargo.toml >> $GITHUB_ENV
-      - run: rustup toolchain install $RUSTUP_TOOLCHAIN
+      - run: rustup toolchain install beta
       - run: rustup component add clippy
       - uses: actions-rs/clippy-check@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,7 @@ jobs:
         # Test on stable, MSRV, and nightly.
         # Failure is permitted on nightly.
         rust:
-          - stable
-          - 1.60.0
+          - beta
           - nightly
 
         features:
@@ -64,8 +63,7 @@ jobs:
         # Test on stable, MSRV, and nightly.
         # Failure is permitted on nightly.
         rust:
-          - stable
-          - 1.60.0
+          - beta
           - nightly
 
         features:

--- a/examples/utils.rs
+++ b/examples/utils.rs
@@ -159,7 +159,7 @@ pub fn parse_middleware_options<D>(
     loopback: bool,
 ) -> FaultInjector<Tracer<PcapWriter<D, Box<dyn io::Write>>>>
 where
-    D: for<'a> Device<'a>,
+    D: Device,
 {
     let drop_chance = matches
         .opt_str("drop-chance")

--- a/fuzz/utils.rs
+++ b/fuzz/utils.rs
@@ -87,13 +87,13 @@ pub fn add_middleware_options(opts: &mut Options, _free: &mut Vec<&str>) {
     );
 }
 
-pub fn parse_middleware_options<D>(
+pub fn parse_middleware_options<'a, D>(
     matches: &mut Matches,
     device: D,
     loopback: bool,
 ) -> FaultInjector<Tracer<PcapWriter<D, Box<dyn Write>>>>
 where
-    D: for<'a> Device<'a>,
+    D: Device<'a>,
 {
     let drop_chance = matches
         .opt_str("drop-chance")

--- a/src/iface/interface.rs
+++ b/src/iface/interface.rs
@@ -551,7 +551,7 @@ let iface = builder.finalize(&mut device);
     /// [neighbor_cache]: #method.neighbor_cache
     pub fn finalize<D>(self, device: &mut D) -> Interface<'a>
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         let caps = device.capabilities();
 
@@ -893,7 +893,7 @@ impl<'a> Interface<'a> {
         timestamp: Instant,
     ) -> Result<bool>
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         self.inner.now = timestamp;
 
@@ -935,7 +935,7 @@ impl<'a> Interface<'a> {
         timestamp: Instant,
     ) -> Result<bool>
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         self.inner.now = timestamp;
 
@@ -1035,7 +1035,7 @@ impl<'a> Interface<'a> {
         sockets: &mut SocketSet<'_>,
     ) -> Result<bool>
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         self.inner.now = timestamp;
 
@@ -1140,7 +1140,7 @@ impl<'a> Interface<'a> {
 
     fn socket_ingress<D>(&mut self, device: &mut D, sockets: &mut SocketSet<'_>) -> bool
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         let mut processed_any = false;
         let Self {
@@ -1196,7 +1196,7 @@ impl<'a> Interface<'a> {
 
     fn socket_egress<D>(&mut self, device: &mut D, sockets: &mut SocketSet<'_>) -> bool
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         let Self {
             inner,
@@ -1306,7 +1306,7 @@ impl<'a> Interface<'a> {
     #[cfg(feature = "proto-igmp")]
     fn igmp_egress<D>(&mut self, device: &mut D) -> Result<bool>
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         match self.inner.igmp_report_state {
             IgmpReportState::ToSpecificQuery {
@@ -1372,7 +1372,7 @@ impl<'a> Interface<'a> {
     #[cfg(feature = "proto-ipv4-fragmentation")]
     fn ipv4_egress<D>(&mut self, device: &mut D) -> Result<bool>
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         // Reset the buffer when we transmitted everything.
         if self.out_packets.ipv4_out_packet.finished() {
@@ -1410,7 +1410,7 @@ impl<'a> Interface<'a> {
     #[cfg(feature = "proto-sixlowpan-fragmentation")]
     fn sixlowpan_egress<D>(&mut self, device: &mut D) -> Result<bool>
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         // Reset the buffer when we transmitted everything.
         if self.out_packets.sixlowpan_out_packet.finished() {

--- a/src/phy/fuzz_injector.rs
+++ b/src/phy/fuzz_injector.rs
@@ -19,14 +19,14 @@ pub trait Fuzzer {
 #[allow(unused)]
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct FuzzInjector<D: for<'a> Device<'a>, FTx: Fuzzer, FRx: Fuzzer> {
+pub struct FuzzInjector<D: Device, FTx: Fuzzer, FRx: Fuzzer> {
     inner: D,
     fuzz_tx: FTx,
     fuzz_rx: FRx,
 }
 
 #[allow(unused)]
-impl<D: for<'a> Device<'a>, FTx: Fuzzer, FRx: Fuzzer> FuzzInjector<D, FTx, FRx> {
+impl<D: Device, FTx: Fuzzer, FRx: Fuzzer> FuzzInjector<D, FTx, FRx> {
     /// Create a fuzz injector device.
     pub fn new(inner: D, fuzz_tx: FTx, fuzz_rx: FRx) -> FuzzInjector<D, FTx, FRx> {
         FuzzInjector {
@@ -42,14 +42,19 @@ impl<D: for<'a> Device<'a>, FTx: Fuzzer, FRx: Fuzzer> FuzzInjector<D, FTx, FRx> 
     }
 }
 
-impl<'a, D, FTx, FRx> Device<'a> for FuzzInjector<D, FTx, FRx>
+impl<D, FTx, FRx> Device for FuzzInjector<D, FTx, FRx>
 where
-    D: for<'b> Device<'b>,
-    FTx: Fuzzer + 'a,
-    FRx: Fuzzer + 'a,
+    D: Device,
+    FTx: Fuzzer,
+    FRx: Fuzzer,
 {
-    type RxToken = RxToken<'a, <D as Device<'a>>::RxToken, FRx>;
-    type TxToken = TxToken<'a, <D as Device<'a>>::TxToken, FTx>;
+    type RxToken<'a> = RxToken<'a, <D as Device>::RxToken<'a>, FRx>
+    where
+        Self: 'a;
+
+    type TxToken<'a> = TxToken<'a, <D as Device>::TxToken<'a>, FTx>
+    where
+        Self: 'a;
 
     fn capabilities(&self) -> DeviceCapabilities {
         let mut caps = self.inner.capabilities();
@@ -59,7 +64,7 @@ where
         caps
     }
 
-    fn receive(&'a mut self) -> Option<(Self::RxToken, Self::TxToken)> {
+    fn receive<'a>(&'a mut self) -> Option<(Self::RxToken<'a>, Self::TxToken<'a>)> {
         let &mut Self {
             ref mut inner,
             ref fuzz_rx,
@@ -78,7 +83,7 @@ where
         })
     }
 
-    fn transmit(&'a mut self) -> Option<Self::TxToken> {
+    fn transmit<'a>(&'a mut self) -> Option<Self::TxToken<'a>> {
         let &mut Self {
             ref mut inner,
             fuzz_rx: _,

--- a/src/phy/loopback.rs
+++ b/src/phy/loopback.rs
@@ -29,9 +29,9 @@ impl Loopback {
     }
 }
 
-impl<'a> Device<'a> for Loopback {
-    type RxToken = RxToken;
-    type TxToken = TxToken<'a>;
+impl Device for Loopback {
+    type RxToken<'a> = RxToken;
+    type TxToken<'a> = TxToken<'a>;
 
     fn capabilities(&self) -> DeviceCapabilities {
         DeviceCapabilities {
@@ -41,7 +41,7 @@ impl<'a> Device<'a> for Loopback {
         }
     }
 
-    fn receive(&'a mut self) -> Option<(Self::RxToken, Self::TxToken)> {
+    fn receive<'a>(&'a mut self) -> Option<(Self::RxToken<'a>, Self::TxToken<'a>)> {
         self.queue.pop_front().map(move |buffer| {
             let rx = RxToken { buffer };
             let tx = TxToken {
@@ -51,7 +51,7 @@ impl<'a> Device<'a> for Loopback {
         })
     }
 
-    fn transmit(&'a mut self) -> Option<Self::TxToken> {
+    fn transmit<'a>(&'a mut self) -> Option<Self::TxToken<'a>> {
         Some(TxToken {
             queue: &mut self.queue,
         })

--- a/src/phy/pcap_writer.rs
+++ b/src/phy/pcap_writer.rs
@@ -118,7 +118,7 @@ impl<T: Write> PcapSink for T {
 #[derive(Debug)]
 pub struct PcapWriter<D, S>
 where
-    D: for<'a> Device<'a>,
+    D: Device,
     S: PcapSink,
 {
     lower: D,
@@ -126,7 +126,7 @@ where
     mode: PcapMode,
 }
 
-impl<D: for<'a> Device<'a>, S: PcapSink> PcapWriter<D, S> {
+impl<D: Device, S: PcapSink> PcapWriter<D, S> {
     /// Creates a packet capture writer.
     pub fn new(lower: D, mut sink: S, mode: PcapMode) -> PcapWriter<D, S> {
         let medium = lower.capabilities().medium;
@@ -162,19 +162,24 @@ impl<D: for<'a> Device<'a>, S: PcapSink> PcapWriter<D, S> {
     }
 }
 
-impl<'a, D, S> Device<'a> for PcapWriter<D, S>
+impl<D, S> Device for PcapWriter<D, S>
 where
-    D: for<'b> Device<'b>,
-    S: PcapSink + 'a,
+    D: Device,
+    S: PcapSink,
 {
-    type RxToken = RxToken<'a, <D as Device<'a>>::RxToken, S>;
-    type TxToken = TxToken<'a, <D as Device<'a>>::TxToken, S>;
+    type RxToken<'a> = RxToken<'a, <D as Device>::RxToken<'a>, S>
+    where
+        Self: 'a;
+
+    type TxToken<'a> = TxToken<'a, <D as Device>::TxToken<'a>, S>
+    where
+        Self: 'a;
 
     fn capabilities(&self) -> DeviceCapabilities {
         self.lower.capabilities()
     }
 
-    fn receive(&'a mut self) -> Option<(Self::RxToken, Self::TxToken)> {
+    fn receive<'a>(&'a mut self) -> Option<(Self::RxToken<'a>, Self::TxToken<'a>)> {
         let sink = &self.sink;
         let mode = self.mode;
         self.lower.receive().map(move |(rx_token, tx_token)| {
@@ -192,7 +197,7 @@ where
         })
     }
 
-    fn transmit(&'a mut self) -> Option<Self::TxToken> {
+    fn transmit<'a>(&'a mut self) -> Option<Self::TxToken<'a>> {
         let sink = &self.sink;
         let mode = self.mode;
         self.lower

--- a/src/phy/raw_socket.rs
+++ b/src/phy/raw_socket.rs
@@ -54,9 +54,9 @@ impl RawSocket {
     }
 }
 
-impl<'a> Device<'a> for RawSocket {
-    type RxToken = RxToken;
-    type TxToken = TxToken;
+impl Device for RawSocket {
+    type RxToken<'a> = RxToken;
+    type TxToken<'a> = TxToken;
 
     fn capabilities(&self) -> DeviceCapabilities {
         DeviceCapabilities {
@@ -66,7 +66,7 @@ impl<'a> Device<'a> for RawSocket {
         }
     }
 
-    fn receive(&'a mut self) -> Option<(Self::RxToken, Self::TxToken)> {
+    fn receive<'a>(&'a mut self) -> Option<(Self::RxToken<'a>, Self::TxToken<'a>)> {
         let mut lower = self.lower.borrow_mut();
         let mut buffer = vec![0; self.mtu];
         match lower.recv(&mut buffer[..]) {
@@ -83,7 +83,7 @@ impl<'a> Device<'a> for RawSocket {
         }
     }
 
-    fn transmit(&'a mut self) -> Option<Self::TxToken> {
+    fn transmit<'a>(&'a mut self) -> Option<Self::TxToken<'a>> {
         Some(TxToken {
             lower: self.lower.clone(),
         })

--- a/src/phy/tuntap_interface.rs
+++ b/src/phy/tuntap_interface.rs
@@ -40,9 +40,9 @@ impl TunTapInterface {
     }
 }
 
-impl<'a> Device<'a> for TunTapInterface {
-    type RxToken = RxToken;
-    type TxToken = TxToken;
+impl Device for TunTapInterface {
+    type RxToken<'a> = RxToken;
+    type TxToken<'a> = TxToken;
 
     fn capabilities(&self) -> DeviceCapabilities {
         DeviceCapabilities {
@@ -52,7 +52,7 @@ impl<'a> Device<'a> for TunTapInterface {
         }
     }
 
-    fn receive(&'a mut self) -> Option<(Self::RxToken, Self::TxToken)> {
+    fn receive<'a>(&'a mut self) -> Option<(Self::RxToken<'a>, Self::TxToken<'a>)> {
         let mut lower = self.lower.borrow_mut();
         let mut buffer = vec![0; self.mtu];
         match lower.recv(&mut buffer[..]) {
@@ -69,7 +69,7 @@ impl<'a> Device<'a> for TunTapInterface {
         }
     }
 
-    fn transmit(&'a mut self) -> Option<Self::TxToken> {
+    fn transmit<'a>(&'a mut self) -> Option<Self::TxToken<'a>> {
         Some(TxToken {
             lower: self.lower.clone(),
         })


### PR DESCRIPTION
Previously, a limitation of Rust's type system required a device to
implement `phy::Device<'a>` for all lifetimes, including `'static`, to
be able to call methods on `iface::Interface`. This prevented types
implementing `phy::Device<'a>` from containing any borrowed data.

Now that Rust supports GATs (generic associated types), it is possible
to lift this restriction and allow implementations of `phy::Device<'a>`
which contain borrowed data.