### PR TITLE
assembler: do not return whether there was an overlap.

### DIFF
--- a/src/iface/fragmentation.rs
+++ b/src/iface/fragmentation.rs
@@ -182,12 +182,8 @@ impl<'a> PacketAssembler<'a> {
                 );
 
                 match assembler.add(offset, data.len()) {
-                    Ok(overlap) => {
+                    Ok(()) => {
                         net_debug!("assembler: {}", self.assembler);
-
-                        if overlap {
-                            net_debug!("packet was added, but there was an overlap.");
-                        }
                         self.is_complete()
                     }
                     // NOTE(thvdveld): hopefully we wont get too many holes errors I guess?

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1764,7 +1764,7 @@ impl<'a> Socket<'a> {
 
         // Try adding payload octets to the assembler.
         match self.assembler.add(payload_offset, payload_len) {
-            Ok(_) => {
+            Ok(()) => {
                 debug_assert!(self.assembler.total_size() == self.rx_buffer.capacity());
                 // Place payload octets into the buffer.
                 tcp_trace!(


### PR DESCRIPTION
This functionality is completely unused, and was panicky with overflow checking (see #694).

Fixes #694

bors r+