### PR TITLE
medium-ip does not compile complaining of needing EthernetAddress

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -16,7 +16,9 @@ jobs:
           ref: refs/pull/${{ github.event.number }}/head
       - uses: actions/checkout@v2
         if: github.event_name != 'pull_request_target'
-      - run: sed -n 's,^rust-version = "\(.*\)"$,RUSTUP_TOOLCHAIN=\1,p' Cargo.toml >> $GITHUB_ENV
+      # TODO update when stable Rust 1.65 is out.
+      #- run: sed -n 's,^rust-version = "\(.*\)"$,RUSTUP_TOOLCHAIN=\1,p' Cargo.toml >> $GITHUB_ENV
+      - run: echo RUSTUP_TOOLCHAIN=beta >> $GITHUB_ENV
       - run: rustup toolchain install $RUSTUP_TOOLCHAIN
       - run: rustup component add clippy
       - uses: actions-rs/clippy-check@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,9 @@ jobs:
         # Test on stable, MSRV, and nightly.
         # Failure is permitted on nightly.
         rust:
-          - stable
-          - 1.61.0
+          # TODO update when stable Rust 1.65 is out.
+          #- stable
+          - beta
           - nightly
 
         features:
@@ -64,8 +65,9 @@ jobs:
         # Test on stable, MSRV, and nightly.
         # Failure is permitted on nightly.
         rust:
-          - stable
-          - 1.61.0
+          # TODO update when stable Rust 1.65 is out.
+          #- stable
+          - beta
           - nightly
 
         features:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
           - std medium-ethernet proto-ipv6 socket-tcp
           - std medium-ethernet medium-ip proto-ipv4 socket-icmp socket-tcp
           - std medium-ip proto-ipv6 socket-icmp socket-tcp
+          - std medium-ip proto-ipv4 proto-ipv6 socket-tcp socket-udp
 
           # Test features chosen to be as aggressive as possible.
           - std medium-ethernet medium-ip medium-ieee802154 proto-ipv4 proto-ipv6 socket-raw socket-udp socket-tcp socket-icmp socket-dns async

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove IpAddress::Unspecified
 - When sending packets with a raw socket, the source IP address is sent unmodified (it was previously replaced with the interface's address if it was unspecified).
 - Fix enable `defmt/alloc` if `alloc` or `std` is enabled.
-- Minimum Supported Rust Version (MSRV) **bumped** from 1.56 to 1.60
+- Minimum Supported Rust Version (MSRV) **bumped** from 1.56 to 1.65
 
 ## [0.8.1] - 2022-05-12
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "smoltcp"
 version = "0.8.1"
 edition = "2018"
-rust-version = "1.61"
+rust-version = "1.65"
 authors = ["whitequark <whitequark@whitequark.org>"]
 description = "A TCP/IP stack designed for bare-metal, real-time systems without a heap."
 documentation = "https://docs.rs/smoltcp/"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ include complicated compile-time computations, such as macro or type tricks, eve
 at cost of performance degradation.
 
 _smoltcp_ does not need heap allocation *at all*, is [extensively documented][docs],
-and compiles on stable Rust 1.61 and later.
+and compiles on stable Rust 1.65 and later.
 
 _smoltcp_ achieves [~Gbps of throughput](#examplesbenchmarkrs) when tested against
 the Linux TCP stack in loopback mode.

--- a/examples/utils.rs
+++ b/examples/utils.rs
@@ -159,7 +159,7 @@ pub fn parse_middleware_options<D>(
     loopback: bool,
 ) -> FaultInjector<Tracer<PcapWriter<D, Box<dyn io::Write>>>>
 where
-    D: for<'a> Device<'a>,
+    D: Device,
 {
     let drop_chance = matches
         .opt_str("drop-chance")

--- a/fuzz/utils.rs
+++ b/fuzz/utils.rs
@@ -93,7 +93,7 @@ pub fn parse_middleware_options<D>(
     loopback: bool,
 ) -> FaultInjector<Tracer<PcapWriter<D, Box<dyn Write>>>>
 where
-    D: for<'a> Device<'a>,
+    D: Device,
 {
     let drop_chance = matches
         .opt_str("drop-chance")

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -563,7 +563,7 @@ let iface = builder.finalize(&mut device);
     /// [neighbor_cache]: #method.neighbor_cache
     pub fn finalize<D>(self, device: &mut D) -> Interface<'a>
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         let caps = device.capabilities();
 
@@ -905,7 +905,7 @@ impl<'a> Interface<'a> {
         timestamp: Instant,
     ) -> Result<bool>
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         self.inner.now = timestamp;
 
@@ -947,7 +947,7 @@ impl<'a> Interface<'a> {
         timestamp: Instant,
     ) -> Result<bool>
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         self.inner.now = timestamp;
 
@@ -1047,7 +1047,7 @@ impl<'a> Interface<'a> {
         sockets: &mut SocketSet<'_>,
     ) -> Result<bool>
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         self.inner.now = timestamp;
 
@@ -1152,7 +1152,7 @@ impl<'a> Interface<'a> {
 
     fn socket_ingress<D>(&mut self, device: &mut D, sockets: &mut SocketSet<'_>) -> bool
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         let mut processed_any = false;
         let Self {
@@ -1208,7 +1208,7 @@ impl<'a> Interface<'a> {
 
     fn socket_egress<D>(&mut self, device: &mut D, sockets: &mut SocketSet<'_>) -> bool
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         let Self {
             inner,
@@ -1318,7 +1318,7 @@ impl<'a> Interface<'a> {
     #[cfg(feature = "proto-igmp")]
     fn igmp_egress<D>(&mut self, device: &mut D) -> Result<bool>
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         match self.inner.igmp_report_state {
             IgmpReportState::ToSpecificQuery {
@@ -1384,7 +1384,7 @@ impl<'a> Interface<'a> {
     #[cfg(feature = "proto-ipv4-fragmentation")]
     fn ipv4_egress<D>(&mut self, device: &mut D) -> Result<bool>
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         // Reset the buffer when we transmitted everything.
         if self.out_packets.ipv4_out_packet.finished() {
@@ -1422,7 +1422,7 @@ impl<'a> Interface<'a> {
     #[cfg(feature = "proto-sixlowpan-fragmentation")]
     fn sixlowpan_egress<D>(&mut self, device: &mut D) -> Result<bool>
     where
-        D: for<'d> Device<'d> + ?Sized,
+        D: Device + ?Sized,
     {
         // Reset the buffer when we transmitted everything.
         if self.out_packets.sixlowpan_out_packet.finished() {

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -79,7 +79,7 @@ impl<'a> OutPackets<'a> {
 }
 
 #[allow(unused)]
-#[cfg(feature = "proto-ipv4")]
+#[cfg(feature = "proto-ipv4-fragmentation")]
 pub(crate) struct Ipv4OutPacket<'a> {
     /// The buffer that holds the unfragmented 6LoWPAN packet.
     buffer: ManagedSlice<'a, u8>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 //!
 //! # Minimum Supported Rust Version (MSRV)
 //!
-//! This crate is guaranteed to compile on stable Rust 1.61 and up with any valid set of features.
+//! This crate is guaranteed to compile on stable Rust 1.65 and up with any valid set of features.
 //! It *might* compile on older versions but that may change in any new patch release.
 //!
 //! The exception is when using the `defmt` feature, in which case `defmt`'s MSRV applies, which

--- a/src/phy/loopback.rs
+++ b/src/phy/loopback.rs
@@ -29,9 +29,9 @@ impl Loopback {
     }
 }
 
-impl<'a> Device<'a> for Loopback {
-    type RxToken = RxToken;
-    type TxToken = TxToken<'a>;
+impl Device for Loopback {
+    type RxToken<'a> = RxToken;
+    type TxToken<'a> = TxToken<'a>;
 
     fn capabilities(&self) -> DeviceCapabilities {
         DeviceCapabilities {
@@ -41,7 +41,7 @@ impl<'a> Device<'a> for Loopback {
         }
     }
 
-    fn receive(&'a mut self) -> Option<(Self::RxToken, Self::TxToken)> {
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         self.queue.pop_front().map(move |buffer| {
             let rx = RxToken { buffer };
             let tx = TxToken {
@@ -51,7 +51,7 @@ impl<'a> Device<'a> for Loopback {
         })
     }
 
-    fn transmit(&'a mut self) -> Option<Self::TxToken> {
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>> {
         Some(TxToken {
             queue: &mut self.queue,
         })

--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -38,16 +38,16 @@ impl<'a> StmPhy {
     }
 }
 
-impl<'a> phy::Device<'a> for StmPhy {
-    type RxToken = StmPhyRxToken<'a>;
-    type TxToken = StmPhyTxToken<'a>;
+impl phy::Device for StmPhy {
+    type RxToken<'a> = StmPhyRxToken<'a> where Self: 'a;
+    type TxToken<'a> = StmPhyTxToken<'a> where Self: 'a;
 
-    fn receive(&'a mut self) -> Option<(Self::RxToken, Self::TxToken)> {
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         Some((StmPhyRxToken(&mut self.rx_buffer[..]),
               StmPhyTxToken(&mut self.tx_buffer[..])))
     }
 
-    fn transmit(&'a mut self) -> Option<Self::TxToken> {
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>> {
         Some(StmPhyTxToken(&mut self.tx_buffer[..]))
     }
 
@@ -308,9 +308,13 @@ impl Default for Medium {
 /// The interface is based on _tokens_, which are types that allow to receive/transmit a
 /// single packet. The `receive` and `transmit` functions only construct such tokens, the
 /// real sending/receiving operation are performed when the tokens are consumed.
-pub trait Device<'a> {
-    type RxToken: RxToken + 'a;
-    type TxToken: TxToken + 'a;
+pub trait Device {
+    type RxToken<'a>: RxToken
+    where
+        Self: 'a;
+    type TxToken<'a>: TxToken
+    where
+        Self: 'a;
 
     /// Construct a token pair consisting of one receive token and one transmit token.
     ///
@@ -318,10 +322,10 @@ pub trait Device<'a> {
     /// on the contents of the received packet. For example, this makes it possible to
     /// handle arbitrarily large ICMP echo ("ping") requests, where the all received bytes
     /// need to be sent back, without heap allocation.
-    fn receive(&'a mut self) -> Option<(Self::RxToken, Self::TxToken)>;
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)>;
 
     /// Construct a transmit token.
-    fn transmit(&'a mut self) -> Option<Self::TxToken>;
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>>;
 
     /// Get a description of device capabilities.
     fn capabilities(&self) -> DeviceCapabilities;

--- a/src/phy/raw_socket.rs
+++ b/src/phy/raw_socket.rs
@@ -54,9 +54,13 @@ impl RawSocket {
     }
 }
 
-impl<'a> Device<'a> for RawSocket {
-    type RxToken = RxToken;
-    type TxToken = TxToken;
+impl Device for RawSocket {
+    type RxToken<'a> = RxToken
+    where
+        Self: 'a;
+    type TxToken<'a> = TxToken
+    where
+        Self: 'a;
 
     fn capabilities(&self) -> DeviceCapabilities {
         DeviceCapabilities {
@@ -66,7 +70,7 @@ impl<'a> Device<'a> for RawSocket {
         }
     }
 
-    fn receive(&'a mut self) -> Option<(Self::RxToken, Self::TxToken)> {
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         let mut lower = self.lower.borrow_mut();
         let mut buffer = vec![0; self.mtu];
         match lower.recv(&mut buffer[..]) {
@@ -83,7 +87,7 @@ impl<'a> Device<'a> for RawSocket {
         }
     }
 
-    fn transmit(&'a mut self) -> Option<Self::TxToken> {
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>> {
         Some(TxToken {
             lower: self.lower.clone(),
         })

--- a/src/phy/tracer.rs
+++ b/src/phy/tracer.rs
@@ -12,12 +12,12 @@ use crate::{
 /// A tracer is a device that pretty prints all packets traversing it
 /// using the provided writer function, and then passes them to another
 /// device.
-pub struct Tracer<D: for<'a> Device<'a>> {
+pub struct Tracer<D: Device> {
     inner: D,
     writer: fn(Instant, Packet),
 }
 
-impl<D: for<'a> Device<'a>> Tracer<D> {
+impl<D: Device> Tracer<D> {
     /// Create a tracer device.
     pub fn new(inner: D, writer: fn(timestamp: Instant, packet: Packet)) -> Tracer<D> {
         Tracer { inner, writer }
@@ -44,18 +44,19 @@ impl<D: for<'a> Device<'a>> Tracer<D> {
     }
 }
 
-impl<'a, D> Device<'a> for Tracer<D>
-where
-    D: for<'b> Device<'b>,
-{
-    type RxToken = RxToken<<D as Device<'a>>::RxToken>;
-    type TxToken = TxToken<<D as Device<'a>>::TxToken>;
+impl<D: Device> Device for Tracer<D> {
+    type RxToken<'a> = RxToken<D::RxToken<'a>>
+    where
+        Self: 'a;
+    type TxToken<'a> = TxToken<D::TxToken<'a>>
+    where
+        Self: 'a;
 
     fn capabilities(&self) -> DeviceCapabilities {
         self.inner.capabilities()
     }
 
-    fn receive(&'a mut self) -> Option<(Self::RxToken, Self::TxToken)> {
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         let &mut Self {
             ref mut inner,
             writer,
@@ -77,7 +78,7 @@ where
         })
     }
 
-    fn transmit(&'a mut self) -> Option<Self::TxToken> {
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>> {
         let &mut Self {
             ref mut inner,
             writer,

--- a/src/phy/tuntap_interface.rs
+++ b/src/phy/tuntap_interface.rs
@@ -40,9 +40,9 @@ impl TunTapInterface {
     }
 }
 
-impl<'a> Device<'a> for TunTapInterface {
-    type RxToken = RxToken;
-    type TxToken = TxToken;
+impl Device for TunTapInterface {
+    type RxToken<'a> = RxToken;
+    type TxToken<'a> = TxToken;
 
     fn capabilities(&self) -> DeviceCapabilities {
         DeviceCapabilities {
@@ -52,7 +52,7 @@ impl<'a> Device<'a> for TunTapInterface {
         }
     }
 
-    fn receive(&'a mut self) -> Option<(Self::RxToken, Self::TxToken)> {
+    fn receive(&mut self) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         let mut lower = self.lower.borrow_mut();
         let mut buffer = vec![0; self.mtu];
         match lower.recv(&mut buffer[..]) {
@@ -69,7 +69,7 @@ impl<'a> Device<'a> for TunTapInterface {
         }
     }
 
-    fn transmit(&'a mut self) -> Option<Self::TxToken> {
+    fn transmit(&mut self) -> Option<Self::TxToken<'_>> {
         Some(TxToken {
             lower: self.lower.clone(),
         })


### PR DESCRIPTION
The structure in question seems to be used only for ipv4 fragmentation, hence marking it the same