### PR TITLE
Make `std` imply `alloc` feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ rand = "0.8"
 url = "2.0"
 
 [features]
-std = ["managed/std", "defmt?/alloc"]
+std = ["managed/std", "alloc"]
 alloc = ["managed/alloc", "defmt?/alloc"]
 verbose = []
 defmt = [ "dep:defmt", "heapless/defmt", "heapless/defmt-impl" ]

--- a/src/iface/fragmentation.rs
+++ b/src/iface/fragmentation.rs
@@ -84,7 +84,7 @@ impl<'a> PacketAssembler<'a> {
                     }
                 }
             }
-            #[cfg(any(feature = "std", feature = "alloc"))]
+            #[cfg(feature = "alloc")]
             ManagedSlice::Owned(b) => {
                 if let Some(total_size) = total_size {
                     b.resize(total_size, 0);
@@ -164,7 +164,7 @@ impl<'a> PacketAssembler<'a> {
                             return Err(Error::PacketAssemblerBufferTooSmall);
                         }
                     }
-                    #[cfg(any(feature = "std", feature = "alloc"))]
+                    #[cfg(feature = "alloc")]
                     ManagedSlice::Owned(b) => {
                         if offset + data.len() > b.len() {
                             b.resize(offset + data.len(), 0);
@@ -287,19 +287,19 @@ impl<'a, K: Eq + Ord + Clone + Copy> PacketAssemblerSet<'a, K> {
                     panic!("The amount of places in the index buffer must be the same as the amount of possible fragments assemblers.");
                 }
             }
-            #[cfg(any(feature = "std", feature = "alloc"))]
+            #[cfg(feature = "alloc")]
             (ManagedSlice::Borrowed(f), ManagedMap::Owned(_)) => {
                 if f.is_empty() {
                     panic!("The packet buffer cannot be empty.");
                 }
             }
-            #[cfg(any(feature = "std", feature = "alloc"))]
+            #[cfg(feature = "alloc")]
             (ManagedSlice::Owned(_), ManagedMap::Borrowed(i)) => {
                 if i.is_empty() {
                     panic!("The index buffer cannot be empty.");
                 }
             }
-            #[cfg(any(feature = "std", feature = "alloc"))]
+            #[cfg(feature = "alloc")]
             (ManagedSlice::Owned(_), ManagedMap::Owned(_)) => (),
         }
 
@@ -326,7 +326,7 @@ impl<'a, K: Eq + Ord + Clone + Copy> PacketAssemblerSet<'a, K> {
         if self.packet_buffer.len() == self.index_buffer.len() {
             match &mut self.packet_buffer {
                 ManagedSlice::Borrowed(_) => return Err(Error::PacketAssemblerSetFull),
-                #[cfg(any(feature = "std", feature = "alloc"))]
+                #[cfg(feature = "alloc")]
                 ManagedSlice::Owned(b) => (),
             }
         }
@@ -346,7 +346,7 @@ impl<'a, K: Eq + Ord + Clone + Copy> PacketAssemblerSet<'a, K> {
     fn get_free_packet_assembler(&mut self) -> Option<usize> {
         match &mut self.packet_buffer {
             ManagedSlice::Borrowed(_) => (),
-            #[cfg(any(feature = "std", feature = "alloc"))]
+            #[cfg(feature = "alloc")]
             ManagedSlice::Owned(b) => b.push(PacketAssembler::new(alloc::vec![])),
         }
 

--- a/src/iface/interface/sixlowpan.rs
+++ b/src/iface/interface/sixlowpan.rs
@@ -404,7 +404,7 @@ impl<'a> InterfaceInner<'a> {
                             return Err(Error::Exhausted);
                         }
                     }
-                    #[cfg(any(feature = "std", feature = "alloc"))]
+                    #[cfg(feature = "alloc")]
                     managed::ManagedSlice::Owned(buffer) => buffer.resize(total_size, 0),
                 }
 

--- a/src/iface/neighbor.rs
+++ b/src/iface/neighbor.rs
@@ -63,7 +63,7 @@ impl Answer {
 pub struct Cache<'a> {
     storage: ManagedMap<'a, IpAddress, Neighbor>,
     silent_until: Instant,
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     gc_threshold: usize,
 }
 
@@ -75,7 +75,7 @@ impl<'a> Cache<'a> {
     pub(crate) const ENTRY_LIFETIME: Duration = Duration::from_millis(60_000);
 
     /// Default number of entries in the cache before GC kicks in
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     pub(crate) const GC_THRESHOLD: usize = 1024;
 
     /// Create a cache. The backing storage is cleared upon creation.
@@ -91,13 +91,13 @@ impl<'a> Cache<'a> {
 
         Cache {
             storage,
-            #[cfg(any(feature = "std", feature = "alloc"))]
+            #[cfg(feature = "alloc")]
             gc_threshold: Self::GC_THRESHOLD,
             silent_until: Instant::from_millis(0),
         }
     }
 
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     pub fn new_with_limit<T>(storage: T, gc_threshold: usize) -> Cache<'a>
     where
         T: Into<ManagedMap<'a, IpAddress, Neighbor>>,
@@ -121,12 +121,12 @@ impl<'a> Cache<'a> {
         debug_assert!(protocol_addr.is_unicast());
         debug_assert!(hardware_addr.is_unicast());
 
-        #[cfg(any(feature = "std", feature = "alloc"))]
+        #[cfg(feature = "alloc")]
         let current_storage_size = self.storage.len();
 
         match self.storage {
             ManagedMap::Borrowed(_) => (),
-            #[cfg(any(feature = "std", feature = "alloc"))]
+            #[cfg(feature = "alloc")]
             ManagedMap::Owned(ref mut map) => {
                 if current_storage_size >= self.gc_threshold {
                     let new_btree_map = map
@@ -173,7 +173,7 @@ impl<'a> Cache<'a> {
                             .0
                     }
                     // Owned maps can extend themselves.
-                    #[cfg(any(feature = "std", feature = "alloc"))]
+                    #[cfg(feature = "alloc")]
                     ManagedMap::Owned(_) => unreachable!(),
                 };
 

--- a/src/iface/socket_set.rs
+++ b/src/iface/socket_set.rs
@@ -79,7 +79,7 @@ impl<'a> SocketSet<'a> {
 
         match self.sockets {
             ManagedSlice::Borrowed(_) => panic!("adding a socket to a full SocketSet"),
-            #[cfg(any(feature = "std", feature = "alloc"))]
+            #[cfg(feature = "alloc")]
             ManagedSlice::Owned(ref mut sockets) => {
                 sockets.push(SocketStorage { inner: None });
                 let index = sockets.len() - 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ compile_error!("at least one socket needs to be enabled"); */
 #![allow(clippy::option_map_unit_fn)]
 #![allow(clippy::unit_arg)]
 
-#[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 #[cfg(not(any(

--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -100,7 +100,7 @@ mod sys;
 
 mod fault_injector;
 mod fuzz_injector;
-#[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 mod loopback;
 mod pcap_writer;
 #[cfg(all(feature = "phy-raw_socket", unix))]
@@ -120,7 +120,7 @@ pub use self::sys::wait;
 
 pub use self::fault_injector::FaultInjector;
 pub use self::fuzz_injector::{FuzzInjector, Fuzzer};
-#[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 pub use self::loopback::Loopback;
 pub use self::pcap_writer::{PcapLinkType, PcapMode, PcapSink, PcapWriter};
 #[cfg(all(feature = "phy-raw_socket", unix))]

--- a/src/socket/dns.rs
+++ b/src/socket/dns.rs
@@ -184,7 +184,7 @@ impl<'a> Socket<'a> {
 
         match self.queries {
             ManagedSlice::Borrowed(_) => None,
-            #[cfg(any(feature = "std", feature = "alloc"))]
+            #[cfg(feature = "alloc")]
             ManagedSlice::Owned(ref mut queries) => {
                 queries.push(None);
                 let index = queries.len() - 1;

--- a/src/storage/assembler.rs
+++ b/src/storage/assembler.rs
@@ -81,14 +81,12 @@ impl Contig {
     }
 }
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
+#[cfg(feature = "alloc")]
 use alloc::boxed::Box;
-#[cfg(feature = "std")]
-use std::boxed::Box;
-#[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 const CONTIG_COUNT: usize = 32;
 
-#[cfg(not(any(feature = "std", feature = "alloc")))]
+#[cfg(not(feature = "alloc"))]
 const CONTIG_COUNT: usize = 4;
 
 /// A buffer (re)assembler.
@@ -97,9 +95,9 @@ const CONTIG_COUNT: usize = 4;
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Assembler {
-    #[cfg(not(any(feature = "std", feature = "alloc")))]
+    #[cfg(not(feature = "alloc"))]
     contigs: [Contig; CONTIG_COUNT],
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     contigs: Box<[Contig; CONTIG_COUNT]>,
 }
 
@@ -120,9 +118,9 @@ impl fmt::Display for Assembler {
 impl Assembler {
     /// Create a new buffer assembler for buffers of the given size.
     pub fn new(size: usize) -> Assembler {
-        #[cfg(not(any(feature = "std", feature = "alloc")))]
+        #[cfg(not(feature = "alloc"))]
         let mut contigs = [Contig::empty(); CONTIG_COUNT];
-        #[cfg(any(feature = "std", feature = "alloc"))]
+        #[cfg(feature = "alloc")]
         let mut contigs = Box::new([Contig::empty(); CONTIG_COUNT]);
         contigs[0] = Contig::hole(size);
         Assembler { contigs }
@@ -328,9 +326,9 @@ mod test {
 
     impl From<Vec<(usize, usize)>> for Assembler {
         fn from(vec: Vec<(usize, usize)>) -> Assembler {
-            #[cfg(not(any(feature = "std", feature = "alloc")))]
+            #[cfg(not(feature = "alloc"))]
             let mut contigs = [Contig::empty(); CONTIG_COUNT];
-            #[cfg(any(feature = "std", feature = "alloc"))]
+            #[cfg(feature = "alloc")]
             let mut contigs = Box::new([Contig::empty(); CONTIG_COUNT]);
             for (i, &(hole_size, data_size)) in vec.iter().enumerate() {
                 contigs[i] = Contig {


### PR DESCRIPTION
This allows simplifying all cfg's to just check alloc.

There should be no downside to using `extern crate alloc` in targets with `std`, since std support implies alloc support.

bors r+