### PR TITLE
Fix panic when using IPv4 fragmentation with Layer 3 networks.

### DIFF
--- a/src/iface/interface/ipv4.rs
+++ b/src/iface/interface/ipv4.rs
@@ -466,6 +466,7 @@ impl<'a> InterfaceInner<'a> {
         }
 
         // Emit function for the Ethernet header.
+        #[cfg(feature = "medium-ethernet")]
         let emit_ethernet = |repr: &IpRepr, tx_buffer: &mut [u8]| {
             let mut frame = EthernetFrame::new_unchecked(tx_buffer);
 


### PR DESCRIPTION
```console
7:     0x7fe44617f300 - smoltcp::iface::interface::InterfaceInner::lookup_hardware_addr::h640efcd865d49106
						at ~/sio-smoltcp/smoltcp/src/iface/interface/mod.rs:2007:15
18:     0x7fe44618039a - smoltcp::iface::interface::InterfaceInner::dispatch_ip::h477a4410ea082342
						at ~/sio-smoltcp/smoltcp/src/iface/interface/mod.rs:2133:19
19:     0x7fe44617cd0f - smoltcp::iface::interface::Interface::socket_egress::{{closure}}::h0b25e0ce461b54e7
						at ~/sio-smoltcp/smoltcp/src/iface/interface/mod.rs:1241:17
20:     0x7fe44617d346 - smoltcp::iface::interface::Interface::socket_egress::{{closure}}::h3e55a2ce63c16877
						at ~/sio-smoltcp/smoltcp/src/iface/interface/mod.rs:1274:21
21:     0x7fe4461a24b4 - smoltcp::socket::udp::Socket::dispatch::{{closure}}::h52b2f159c6047eb1
						at ~/sio-smoltcp/smoltcp/src/socket/udp.rs:465:13
22:     0x7fe4461a4fa8 - smoltcp::storage::packet_buffer::PacketBuffer<H>::dequeue_with::{{closure}}::{{closure}}::ha53ebbf3d6d0e373
						at ~/sio-smoltcp/smoltcp/src/storage/packet_buffer.rs:200:27
23:     0x7fe446185b41 - smoltcp::storage::ring_buffer::RingBuffer<T>::dequeue_many_with::h4769dc1f2ccd50aa
						at ~/sio-smoltcp/smoltcp/src/storage/ring_buffer.rs:245:30
24:     0x7fe4461a4b16 - smoltcp::storage::packet_buffer::PacketBuffer<H>::dequeue_with::{{closure}}::h9789743e8966cfbe
						at ~/sio-smoltcp/smoltcp/src/storage/packet_buffer.rs:196:13
25:     0x7fe4461851cd - smoltcp::storage::ring_buffer::RingBuffer<T>::dequeue_one_with::h1201370f614614d2
						at ~/sio-smoltcp/smoltcp/src/storage/ring_buffer.rs:154:19
26:     0x7fe4461a494c - smoltcp::storage::packet_buffer::PacketBuffer<H>::dequeue_with::h62d428db6c52466d
						at ~/sio-smoltcp/smoltcp/src/storage/packet_buffer.rs:190:9
27:     0x7fe4461a1ca6 - smoltcp::socket::udp::Socket::dispatch::h3345cb3f2e0a28c5
						at ~/sio-smoltcp/smoltcp/src/socket/udp.rs:431:19
28:     0x7fe44617c75e - smoltcp::iface::interface::Interface::socket_egress::h4832c80b5e44260b
						at ~/sio-smoltcp/smoltcp/src/iface/interface/mod.rs:1273:40
29:     0x7fe44617b8b4 - smoltcp::iface::interface::Interface::poll::h3576f55b9ff8b575
						at ~/sio-smoltcp/smoltcp/src/iface/interface/mod.rs:1088:31
```