### PR TITLE
Make `AnySocket` object safe

### DIFF
--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -92,15 +92,9 @@ impl<'a> Socket<'a> {
 
 /// A conversion trait for network sockets.
 pub trait AnySocket<'a> {
-    fn upcast(self) -> Socket<'a>
-    where
-        Self: Sized;
-    fn downcast<'c>(socket: &'c Socket<'a>) -> Option<&'c Self>
-    where
-        Self: Sized;
-    fn downcast_mut<'c>(socket: &'c mut Socket<'a>) -> Option<&'c mut Self>
-    where
-        Self: Sized;
+    fn upcast(self) -> Socket<'a>;
+    fn downcast<'c>(socket: &'c Socket<'a>) -> Option<&'c Self>;
+    fn downcast_mut<'c>(socket: &'c mut Socket<'a>) -> Option<&'c mut Self>;
 }
 
 macro_rules! from_socket {

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -91,10 +91,16 @@ impl<'a> Socket<'a> {
 }
 
 /// A conversion trait for network sockets.
-pub trait AnySocket<'a>: Sized {
-    fn upcast(self) -> Socket<'a>;
-    fn downcast<'c>(socket: &'c Socket<'a>) -> Option<&'c Self>;
-    fn downcast_mut<'c>(socket: &'c mut Socket<'a>) -> Option<&'c mut Self>;
+pub trait AnySocket<'a> {
+    fn upcast(self) -> Socket<'a>
+    where
+        Self: Sized;
+    fn downcast<'c>(socket: &'c Socket<'a>) -> Option<&'c Self>
+    where
+        Self: Sized;
+    fn downcast_mut<'c>(socket: &'c mut Socket<'a>) -> Option<&'c mut Self>
+    where
+        Self: Sized;
 }
 
 macro_rules! from_socket {


### PR DESCRIPTION
Hi, I'm using `smoltcp` in an operating system and need to keep a global list of sockets NICs can poll when they receive an interrupt. Each socket is stored in its own socket set as that needs ownership over the socket and is the only way it can be polled. When the socket is registered, we know the concrete type, and so my `Socket` struct looks like so:

```rust
#[repr(transparent)]
pub struct Socket<T>
where
    T: AnySocket<'static> + ?Sized,
{
    pub(crate) inner: SocketSet<'static>,
    phantom_data: PhantomData<T>,
}

impl<T> Socket<T>
where
    T: AnySocket<'static> + ?Sized,
{
    pub(crate) fn new(inner: SocketSet<'static>) -> Self {
        Self {
            inner,
            phantom_data: PhantomData,
        }
    }
}

impl<T> Deref for Socket<T>
where
    T: AnySocket<'static>,
{
    type Target = T;

    fn deref(&self) -> &Self::Target {
        AnySocket::downcast(self.inner.iter().next().expect("no socket in socket set").1)
            .expect("incorrect socket type")
    }
}

impl<T> DerefMut for Socket<T>
where
    T: AnySocket<'static>,
{
    fn deref_mut(&mut self) -> &mut Self::Target {
        AnySocket::downcast_mut(
            self.inner
                .iter_mut()
                .next()
                .expect("no socket in socket set")
                .1,
        )
        .expect("incorrect socket type")
    }
}
```

However, they must be type erased as they are stored in a vec:
```rust
static SOCKETS: Mutex<Vec<Arc<Mutex<Socket<dyn AnySocket<'static> + Send>>>>>;

pub fn add_socket<T>(&self, socket: T) -> Arc<Mutex<crate::Socket<T>>>
where
    T: AnySocket<'static> + Send,
{
    let mut socket_set = SocketSet::new([iface::SocketStorage::default(); 1]);
    socket_set.add(socket);
    let socket_arc = Arc::new(Mutex::new(crate::Socket::<T>::new(socket_set)));
    SOCKETS
        .lock()
        // SAFETY: Socket has a transparent representation and so the memory layout is the same
        // regardless of T. The Send bound on T ensures that transmuting to a type that
        // implemnts Send is sound.
        .push(unsafe { core::mem::transmute(socket_arc.clone()) });
    socket_arc
}

```

This is only possible if `AnySocket` is object safe.