### PR TITLE
Make `AnySocket` object safe

### DIFF
--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -93,8 +93,12 @@ impl<'a> Socket<'a> {
 /// A conversion trait for network sockets.
 pub trait AnySocket<'a> {
     fn upcast(self) -> Socket<'a>;
-    fn downcast<'c>(socket: &'c Socket<'a>) -> Option<&'c Self>;
-    fn downcast_mut<'c>(socket: &'c mut Socket<'a>) -> Option<&'c mut Self>;
+    fn downcast<'c>(socket: &'c Socket<'a>) -> Option<&'c Self>
+    where
+        Self: Sized;
+    fn downcast_mut<'c>(socket: &'c mut Socket<'a>) -> Option<&'c mut Self>
+    where
+        Self: Sized;
 }
 
 macro_rules! from_socket {


### PR DESCRIPTION
Apologies, in #718, removing the sized bound in `downcast` and `downcast_mut` implicitly made `AnySocket` object unsafe as they don't have a `self` method. I had a bit of a brain fart.

Signed-off-by: Klim Tsoutsman <klim@tsoutsman.com>