### PR TITLE
More heapless

### DIFF
--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -4,7 +4,6 @@ mod utils;
 
 use log::debug;
 use std::cmp;
-use std::collections::BTreeMap;
 use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::os::unix::io::AsRawFd;
@@ -82,7 +81,7 @@ fn main() {
         _ => panic!("invalid mode"),
     };
 
-    let neighbor_cache = NeighborCache::new(BTreeMap::new());
+    let neighbor_cache = NeighborCache::new();
 
     let tcp1_rx_buffer = tcp::SocketBuffer::new(vec![0; 65535]);
     let tcp1_tx_buffer = tcp::SocketBuffer::new(vec![0; 65535]);

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -47,8 +47,7 @@ fn main() {
         .push(IpCidr::new(IpAddress::v4(192, 168, 69, 2), 24))
         .unwrap();
     let default_v4_gw = Ipv4Address::new(192, 168, 69, 100);
-    let mut routes_storage = [None; 1];
-    let mut routes = Routes::new(&mut routes_storage[..]);
+    let mut routes = Routes::new();
     routes.add_default_ipv4_route(default_v4_gw).unwrap();
 
     let medium = device.capabilities().medium;

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -35,7 +35,7 @@ fn main() {
     let address = IpAddress::from_str(&matches.free[0]).expect("invalid address format");
     let port = u16::from_str(&matches.free[1]).expect("invalid port format");
 
-    let neighbor_cache = NeighborCache::new(BTreeMap::new());
+    let neighbor_cache = NeighborCache::new();
 
     let tcp_rx_buffer = tcp::SocketBuffer::new(vec![0; 1500]);
     let tcp_tx_buffer = tcp::SocketBuffer::new(vec![0; 1500]);

--- a/examples/dhcp_client.rs
+++ b/examples/dhcp_client.rs
@@ -34,11 +34,9 @@ fn main() {
     ip_addrs
         .push(IpCidr::new(Ipv4Address::UNSPECIFIED.into(), 0))
         .unwrap();
-    let mut routes_storage = [None; 1];
-    let routes = Routes::new(&mut routes_storage[..]);
 
     let medium = device.capabilities().medium;
-    let mut builder = InterfaceBuilder::new().ip_addrs(ip_addrs).routes(routes);
+    let mut builder = InterfaceBuilder::new().ip_addrs(ip_addrs);
     if medium == Medium::Ethernet {
         builder = builder
             .hardware_addr(ethernet_addr.into())

--- a/examples/dhcp_client.rs
+++ b/examples/dhcp_client.rs
@@ -2,10 +2,9 @@
 mod utils;
 
 use log::*;
-use std::collections::BTreeMap;
 use std::os::unix::io::AsRawFd;
 
-use smoltcp::iface::{Interface, InterfaceBuilder, NeighborCache, Routes, SocketSet};
+use smoltcp::iface::{Interface, InterfaceBuilder, NeighborCache, SocketSet};
 use smoltcp::socket::dhcpv4;
 use smoltcp::time::Instant;
 use smoltcp::wire::{EthernetAddress, IpCidr, Ipv4Address, Ipv4Cidr};
@@ -28,7 +27,7 @@ fn main() {
     let mut device =
         utils::parse_middleware_options(&mut matches, device, /*loopback=*/ false);
 
-    let neighbor_cache = NeighborCache::new(BTreeMap::new());
+    let neighbor_cache = NeighborCache::new();
     let ethernet_addr = EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]);
     let mut ip_addrs = heapless::Vec::<IpCidr, 5>::new();
     ip_addrs

--- a/examples/dns.rs
+++ b/examples/dns.rs
@@ -53,8 +53,7 @@ fn main() {
         .unwrap();
     let default_v4_gw = Ipv4Address::new(192, 168, 69, 100);
     let default_v6_gw = Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 0x100);
-    let mut routes_storage = [None; 2];
-    let mut routes = Routes::new(&mut routes_storage[..]);
+    let mut routes = Routes::new();
     routes.add_default_ipv4_route(default_v4_gw).unwrap();
     routes.add_default_ipv6_route(default_v6_gw).unwrap();
 

--- a/examples/dns.rs
+++ b/examples/dns.rs
@@ -15,7 +15,6 @@ use smoltcp::time::Instant;
 use smoltcp::wire::{
     DnsQueryType, EthernetAddress, HardwareAddress, IpAddress, IpCidr, Ipv4Address, Ipv6Address,
 };
-use std::collections::BTreeMap;
 use std::os::unix::io::AsRawFd;
 
 fn main() {
@@ -33,7 +32,7 @@ fn main() {
         utils::parse_middleware_options(&mut matches, device, /*loopback=*/ false);
     let name = &matches.free[0];
 
-    let neighbor_cache = NeighborCache::new(BTreeMap::new());
+    let neighbor_cache = NeighborCache::new();
 
     let servers = &[
         Ipv4Address::new(8, 8, 4, 4).into(),

--- a/examples/httpclient.rs
+++ b/examples/httpclient.rs
@@ -1,7 +1,6 @@
 mod utils;
 
 use log::debug;
-use std::collections::BTreeMap;
 use std::os::unix::io::AsRawFd;
 use std::str::{self, FromStr};
 use url::Url;
@@ -29,7 +28,7 @@ fn main() {
     let address = IpAddress::from_str(&matches.free[0]).expect("invalid address format");
     let url = Url::parse(&matches.free[1]).expect("invalid url format");
 
-    let neighbor_cache = NeighborCache::new(BTreeMap::new());
+    let neighbor_cache = NeighborCache::new();
 
     let tcp_rx_buffer = tcp::SocketBuffer::new(vec![0; 1024]);
     let tcp_tx_buffer = tcp::SocketBuffer::new(vec![0; 1024]);

--- a/examples/httpclient.rs
+++ b/examples/httpclient.rs
@@ -48,8 +48,7 @@ fn main() {
         .unwrap();
     let default_v4_gw = Ipv4Address::new(192, 168, 69, 100);
     let default_v6_gw = Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 0x100);
-    let mut routes_storage = [None; 2];
-    let mut routes = Routes::new(&mut routes_storage[..]);
+    let mut routes = Routes::new();
     routes.add_default_ipv4_route(default_v4_gw).unwrap();
     routes.add_default_ipv6_route(default_v6_gw).unwrap();
 

--- a/examples/loopback.rs
+++ b/examples/loopback.rs
@@ -82,16 +82,13 @@ fn main() {
         utils::parse_middleware_options(&mut matches, device, /*loopback=*/ true)
     };
 
-    let mut neighbor_cache_entries = [None; 8];
-    let mut neighbor_cache = NeighborCache::new(&mut neighbor_cache_entries[..]);
-
     let mut ip_addrs = heapless::Vec::<IpCidr, 5>::new();
     ip_addrs
         .push(IpCidr::new(IpAddress::v4(127, 0, 0, 1), 8))
         .unwrap();
     let mut iface = InterfaceBuilder::new()
         .hardware_addr(EthernetAddress::default().into())
-        .neighbor_cache(neighbor_cache)
+        .neighbor_cache(NeighborCache::new())
         .ip_addrs(ip_addrs)
         .finalize(&mut device);
 

--- a/examples/multicast.rs
+++ b/examples/multicast.rs
@@ -35,12 +35,10 @@ fn main() {
     let ip_addr = IpCidr::new(IpAddress::from(local_addr), 24);
     let mut ip_addrs = heapless::Vec::<IpCidr, 5>::new();
     ip_addrs.push(ip_addr).unwrap();
-    let mut ipv4_multicast_storage = [None; 1];
     let mut iface = InterfaceBuilder::new()
         .hardware_addr(ethernet_addr.into())
         .neighbor_cache(neighbor_cache)
         .ip_addrs(ip_addrs)
-        .ipv4_multicast_groups(&mut ipv4_multicast_storage[..])
         .finalize(&mut device);
 
     let now = Instant::now();

--- a/examples/multicast.rs
+++ b/examples/multicast.rs
@@ -1,7 +1,6 @@
 mod utils;
 
 use log::debug;
-use std::collections::BTreeMap;
 use std::os::unix::io::AsRawFd;
 
 use smoltcp::iface::{InterfaceBuilder, NeighborCache, SocketSet};
@@ -28,7 +27,7 @@ fn main() {
     let fd = device.as_raw_fd();
     let mut device =
         utils::parse_middleware_options(&mut matches, device, /*loopback=*/ false);
-    let neighbor_cache = NeighborCache::new(BTreeMap::new());
+    let neighbor_cache = NeighborCache::new();
 
     let local_addr = Ipv4Address::new(192, 168, 69, 2);
 

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -126,8 +126,7 @@ fn main() {
         .unwrap();
     let default_v4_gw = Ipv4Address::new(192, 168, 69, 100);
     let default_v6_gw = Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 0x100);
-    let mut routes_storage = [None; 2];
-    let mut routes = Routes::new(&mut routes_storage[..]);
+    let mut routes = Routes::new();
     routes.add_default_ipv4_route(default_v4_gw).unwrap();
     routes.add_default_ipv6_route(default_v6_gw).unwrap();
 

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -4,7 +4,6 @@ use byteorder::{ByteOrder, NetworkEndian};
 use log::debug;
 use smoltcp::iface::SocketSet;
 use std::cmp;
-use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::os::unix::io::AsRawFd;
 use std::str::FromStr;
@@ -106,7 +105,7 @@ fn main() {
             .unwrap_or(5),
     );
 
-    let neighbor_cache = NeighborCache::new(BTreeMap::new());
+    let neighbor_cache = NeighborCache::new();
 
     let remote_addr = address;
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -29,7 +29,7 @@ fn main() {
     let mut device =
         utils::parse_middleware_options(&mut matches, device, /*loopback=*/ false);
 
-    let neighbor_cache = NeighborCache::new(BTreeMap::new());
+    let neighbor_cache = NeighborCache::new();
 
     let udp_rx_buffer = udp::PacketBuffer::new(
         vec![udp::PacketMetadata::EMPTY, udp::PacketMetadata::EMPTY],

--- a/examples/sixlowpan.rs
+++ b/examples/sixlowpan.rs
@@ -68,7 +68,7 @@ fn main() {
     let mut device =
         utils::parse_middleware_options(&mut matches, device, /*loopback=*/ false);
 
-    let neighbor_cache = NeighborCache::new(BTreeMap::new());
+    let neighbor_cache = NeighborCache::new();
 
     let udp_rx_buffer = udp::PacketBuffer::new(vec![udp::PacketMetadata::EMPTY], vec![0; 1280]);
     let udp_tx_buffer = udp::PacketBuffer::new(vec![udp::PacketMetadata::EMPTY], vec![0; 1280]);

--- a/examples/sixlowpan_benchmark.rs
+++ b/examples/sixlowpan_benchmark.rs
@@ -148,7 +148,7 @@ fn main() {
         _ => panic!("invalid mode"),
     };
 
-    let neighbor_cache = NeighborCache::new(BTreeMap::new());
+    let neighbor_cache = NeighborCache::new();
 
     let tcp1_rx_buffer = tcp::SocketBuffer::new(vec![0; 4096]);
     let tcp1_tx_buffer = tcp::SocketBuffer::new(vec![0; 4096]);

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -16,6 +16,7 @@ mod ipv4;
 mod ipv6;
 
 use core::cmp;
+use core::marker::PhantomData;
 use heapless::Vec;
 use managed::{ManagedMap, ManagedSlice};
 
@@ -258,6 +259,8 @@ pub struct InterfaceInner<'a> {
     now: Instant,
     rand: Rand,
 
+    phantom: PhantomData<&'a mut ()>,
+
     #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
     neighbor_cache: Option<NeighborCache>,
     #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
@@ -285,6 +288,8 @@ pub struct InterfaceInner<'a> {
 
 /// A builder structure used for creating a network interface.
 pub struct InterfaceBuilder<'a> {
+    phantom: PhantomData<&'a mut ()>,
+
     #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
     hardware_addr: Option<HardwareAddress>,
     #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
@@ -360,6 +365,8 @@ let iface = builder.finalize(&mut device);
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         InterfaceBuilder {
+            phantom: PhantomData,
+
             #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
             hardware_addr: None,
             #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
@@ -672,6 +679,7 @@ let iface = builder.finalize(&mut device);
                 _lifetime: core::marker::PhantomData,
             },
             inner: InterfaceInner {
+                phantom: PhantomData,
                 now: Instant::from_secs(0),
                 caps,
                 #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
@@ -1534,6 +1542,7 @@ impl<'a> InterfaceInner<'a> {
     #[cfg(test)]
     pub(crate) fn mock() -> Self {
         Self {
+            phantom: PhantomData,
             caps: DeviceCapabilities {
                 #[cfg(feature = "medium-ethernet")]
                 medium: crate::phy::Medium::Ethernet,

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -259,7 +259,7 @@ pub struct InterfaceInner<'a> {
     rand: Rand,
 
     #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
-    neighbor_cache: Option<NeighborCache<'a>>,
+    neighbor_cache: Option<NeighborCache>,
     #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
     hardware_addr: Option<HardwareAddress>,
     #[cfg(feature = "medium-ieee802154")]
@@ -288,7 +288,7 @@ pub struct InterfaceBuilder<'a> {
     #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
     hardware_addr: Option<HardwareAddress>,
     #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
-    neighbor_cache: Option<NeighborCache<'a>>,
+    neighbor_cache: Option<NeighborCache>,
     #[cfg(feature = "medium-ieee802154")]
     pan_id: Option<Ieee802154Pan>,
     ip_addrs: Vec<IpCidr, MAX_IP_ADDRS_NUM>,
@@ -337,7 +337,7 @@ let mut device = // ...
 let hw_addr = // ...
 # EthernetAddress::default();
 let neighbor_cache = // ...
-# NeighborCache::new(BTreeMap::new());
+# NeighborCache::new();
 # #[cfg(feature = "proto-ipv4-fragmentation")]
 # let ipv4_frag_cache = // ...
 # ReassemblyBuffer::new(vec![], BTreeMap::new());
@@ -496,7 +496,7 @@ let iface = builder.finalize(&mut device);
 
     /// Set the Neighbor Cache the interface will use.
     #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
-    pub fn neighbor_cache(mut self, neighbor_cache: NeighborCache<'a>) -> Self {
+    pub fn neighbor_cache(mut self, neighbor_cache: NeighborCache) -> Self {
         self.neighbor_cache = Some(neighbor_cache);
         self
     }

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -275,7 +275,7 @@ pub struct InterfaceInner<'a> {
     ip_addrs: Vec<IpCidr, MAX_IP_ADDRS_NUM>,
     #[cfg(feature = "proto-ipv4")]
     any_ip: bool,
-    routes: Routes<'a>,
+    routes: Routes,
     #[cfg(feature = "proto-igmp")]
     ipv4_multicast_groups: ManagedMap<'a, Ipv4Address, ()>,
     /// When to report for (all or) the next multicast group membership via IGMP
@@ -294,7 +294,7 @@ pub struct InterfaceBuilder<'a> {
     ip_addrs: Vec<IpCidr, MAX_IP_ADDRS_NUM>,
     #[cfg(feature = "proto-ipv4")]
     any_ip: bool,
-    routes: Routes<'a>,
+    routes: Routes,
     /// Does not share storage with `ipv6_multicast_groups` to avoid IPv6 size overhead.
     #[cfg(feature = "proto-igmp")]
     ipv4_multicast_groups: ManagedMap<'a, Ipv4Address, ()>,
@@ -371,7 +371,7 @@ let iface = builder.finalize(&mut device);
             ip_addrs: Vec::new(),
             #[cfg(feature = "proto-ipv4")]
             any_ip: false,
-            routes: Routes::new(ManagedMap::Borrowed(&mut [])),
+            routes: Routes::new(),
             #[cfg(feature = "proto-igmp")]
             ipv4_multicast_groups: ManagedMap::Borrowed(&mut []),
             random_seed: 0,
@@ -469,7 +469,7 @@ let iface = builder.finalize(&mut device);
     /// [routes]: struct.Interface.html#method.routes
     pub fn routes<T>(mut self, routes: T) -> InterfaceBuilder<'a>
     where
-        T: Into<Routes<'a>>,
+        T: Into<Routes>,
     {
         self.routes = routes.into();
         self
@@ -1023,11 +1023,11 @@ impl<'a> Interface<'a> {
         self.inner.ipv4_address()
     }
 
-    pub fn routes(&self) -> &Routes<'a> {
+    pub fn routes(&self) -> &Routes {
         &self.inner.routes
     }
 
-    pub fn routes_mut(&mut self) -> &mut Routes<'a> {
+    pub fn routes_mut(&mut self) -> &mut Routes {
         &mut self.inner.routes
     }
 
@@ -1570,7 +1570,7 @@ impl<'a> InterfaceInner<'a> {
             ])
             .unwrap(),
             rand: Rand::new(1234),
-            routes: Routes::new(&mut [][..]),
+            routes: Routes::new(),
 
             #[cfg(feature = "proto-ipv4")]
             any_ip: false,

--- a/src/iface/interface/tests.rs
+++ b/src/iface/interface/tests.rs
@@ -90,7 +90,7 @@ fn create_ethernet<'a>() -> (Interface<'a>, SocketSet<'a>, Loopback) {
 
     let iface_builder = InterfaceBuilder::new()
         .hardware_addr(EthernetAddress::default().into())
-        .neighbor_cache(NeighborCache::new(BTreeMap::new()))
+        .neighbor_cache(NeighborCache::new())
         .ip_addrs(ip_addrs);
 
     #[cfg(feature = "proto-sixlowpan-fragmentation")]
@@ -126,7 +126,7 @@ fn create_ieee802154<'a>() -> (Interface<'a>, SocketSet<'a>, Loopback) {
 
     let iface_builder = InterfaceBuilder::new()
         .hardware_addr(Ieee802154Address::default().into())
-        .neighbor_cache(NeighborCache::new(BTreeMap::new()))
+        .neighbor_cache(NeighborCache::new())
         .ip_addrs(ip_addrs);
 
     #[cfg(feature = "proto-sixlowpan-fragmentation")]

--- a/src/iface/interface/tests.rs
+++ b/src/iface/interface/tests.rs
@@ -42,7 +42,7 @@ fn create<'a>(medium: Medium) -> (Interface<'a>, SocketSet<'a>, Loopback) {
 fn create_ip<'a>() -> (Interface<'a>, SocketSet<'a>, Loopback) {
     // Create a basic device
     let mut device = Loopback::new(Medium::Ip);
-    let mut ip_addrs = heapless::Vec::<IpCidr, MAX_IP_ADDRS_NUM>::new();
+    let mut ip_addrs = heapless::Vec::<IpCidr, MAX_IP_ADDR_COUNT>::new();
     #[cfg(feature = "proto-ipv4")]
     ip_addrs
         .push(IpCidr::new(IpAddress::v4(127, 0, 0, 1), 8))
@@ -63,8 +63,6 @@ fn create_ip<'a>() -> (Interface<'a>, SocketSet<'a>, Loopback) {
         .ipv4_reassembly_buffer(PacketAssemblerSet::new(vec![], BTreeMap::new()))
         .ipv4_fragmentation_buffer(vec![]);
 
-    #[cfg(feature = "proto-igmp")]
-    let iface_builder = iface_builder.ipv4_multicast_groups(BTreeMap::new());
     let iface = iface_builder.finalize(&mut device);
 
     (iface, SocketSet::new(vec![]), device)
@@ -74,7 +72,7 @@ fn create_ip<'a>() -> (Interface<'a>, SocketSet<'a>, Loopback) {
 fn create_ethernet<'a>() -> (Interface<'a>, SocketSet<'a>, Loopback) {
     // Create a basic device
     let mut device = Loopback::new(Medium::Ethernet);
-    let mut ip_addrs = heapless::Vec::<IpCidr, MAX_IP_ADDRS_NUM>::new();
+    let mut ip_addrs = heapless::Vec::<IpCidr, MAX_IP_ADDR_COUNT>::new();
     #[cfg(feature = "proto-ipv4")]
     ip_addrs
         .push(IpCidr::new(IpAddress::v4(127, 0, 0, 1), 8))
@@ -103,8 +101,6 @@ fn create_ethernet<'a>() -> (Interface<'a>, SocketSet<'a>, Loopback) {
         .ipv4_reassembly_buffer(PacketAssemblerSet::new(vec![], BTreeMap::new()))
         .ipv4_fragmentation_buffer(vec![]);
 
-    #[cfg(feature = "proto-igmp")]
-    let iface_builder = iface_builder.ipv4_multicast_groups(BTreeMap::new());
     let iface = iface_builder.finalize(&mut device);
 
     (iface, SocketSet::new(vec![]), device)
@@ -114,7 +110,7 @@ fn create_ethernet<'a>() -> (Interface<'a>, SocketSet<'a>, Loopback) {
 fn create_ieee802154<'a>() -> (Interface<'a>, SocketSet<'a>, Loopback) {
     // Create a basic device
     let mut device = Loopback::new(Medium::Ieee802154);
-    let mut ip_addrs = heapless::Vec::<IpCidr, MAX_IP_ADDRS_NUM>::new();
+    let mut ip_addrs = heapless::Vec::<IpCidr, MAX_IP_ADDR_COUNT>::new();
     #[cfg(feature = "proto-ipv6")]
     ip_addrs
         .push(IpCidr::new(IpAddress::v6(0, 0, 0, 0, 0, 0, 0, 1), 128))
@@ -1063,7 +1059,7 @@ fn test_icmpv4_socket() {
 #[cfg(feature = "proto-ipv6")]
 fn test_solicited_node_addrs() {
     let (mut iface, _, _device) = create(MEDIUM);
-    let mut new_addrs = heapless::Vec::<IpCidr, MAX_IP_ADDRS_NUM>::new();
+    let mut new_addrs = heapless::Vec::<IpCidr, MAX_IP_ADDR_COUNT>::new();
     new_addrs
         .push(IpCidr::new(IpAddress::v6(0xfe80, 0, 0, 0, 1, 2, 0, 2), 64))
         .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ compile_error!("at least one socket needs to be enabled"); */
 #![allow(clippy::identity_op)]
 #![allow(clippy::option_map_unit_fn)]
 #![allow(clippy::unit_arg)]
+#![allow(clippy::new_without_default)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/src/wire/ipv6.rs
+++ b/src/wire/ipv6.rs
@@ -68,17 +68,34 @@ impl Address {
 
     /// Construct an IPv6 address from parts.
     #[allow(clippy::too_many_arguments)]
-    pub fn new(a0: u16, a1: u16, a2: u16, a3: u16, a4: u16, a5: u16, a6: u16, a7: u16) -> Address {
-        let mut addr = [0u8; ADDR_SIZE];
-        NetworkEndian::write_u16(&mut addr[..2], a0);
-        NetworkEndian::write_u16(&mut addr[2..4], a1);
-        NetworkEndian::write_u16(&mut addr[4..6], a2);
-        NetworkEndian::write_u16(&mut addr[6..8], a3);
-        NetworkEndian::write_u16(&mut addr[8..10], a4);
-        NetworkEndian::write_u16(&mut addr[10..12], a5);
-        NetworkEndian::write_u16(&mut addr[12..14], a6);
-        NetworkEndian::write_u16(&mut addr[14..], a7);
-        Address(addr)
+    pub const fn new(
+        a0: u16,
+        a1: u16,
+        a2: u16,
+        a3: u16,
+        a4: u16,
+        a5: u16,
+        a6: u16,
+        a7: u16,
+    ) -> Address {
+        Address([
+            (a0 >> 8) as u8,
+            a0 as u8,
+            (a1 >> 8) as u8,
+            a1 as u8,
+            (a2 >> 8) as u8,
+            a2 as u8,
+            (a3 >> 8) as u8,
+            a3 as u8,
+            (a4 >> 8) as u8,
+            a4 as u8,
+            (a5 >> 8) as u8,
+            a5 as u8,
+            (a6 >> 8) as u8,
+            a6 as u8,
+            (a7 >> 8) as u8,
+            a7 as u8,
+        ])
     }
 
     /// Construct an IPv6 address from a sequence of octets, in big-endian.
@@ -324,7 +341,7 @@ impl Cidr {
     ///
     /// # Panics
     /// This function panics if the prefix length is larger than 128.
-    pub fn new(address: Address, prefix_len: u8) -> Cidr {
+    pub const fn new(address: Address, prefix_len: u8) -> Cidr {
         assert!(prefix_len <= 128);
         Cidr {
             address,


### PR DESCRIPTION
More heapless use, continues work started in #719 

Use heapless for Routes and NeighborCache.

Routes reduces code size by 1.7kb. Makes sense since the new code is much simpler (no maps).
NeighborCache increases code size by 152 bytes. Not sure why, it should also be simpler....