### PR TITLE
Remove feature rust-1_28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,9 +74,6 @@ default = [
   "async"
 ]
 
-# experimental; do not use; no guarantees provided that this feature will be kept
-"rust-1_28" = []
-
 [[example]]
 name = "packet2pcap"
 path = "utils/packet2pcap.rs"

--- a/src/phy/loopback.rs
+++ b/src/phy/loopback.rs
@@ -1,8 +1,5 @@
-#[cfg(not(feature = "rust-1_28"))]
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;
-#[cfg(feature = "rust-1_28")]
-use alloc::VecDeque;
 
 use crate::phy::{self, Device, DeviceCapabilities, Medium};
 use crate::time::Instant;


### PR DESCRIPTION
Rust 1.28 is wayyyyyy below our MSRV so this feature is effectively useless.