### PR TITLE
Assembler refactors

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,15 +1,9 @@
 mod utils;
 
 use log::debug;
-use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::os::unix::io::AsRawFd;
 
-#[cfg(any(
-    feature = "proto-sixlowpan-fragmentation",
-    feature = "proto-ipv4-fragmentation"
-))]
-use smoltcp::iface::ReassemblyBuffer;
 use smoltcp::iface::{InterfaceBuilder, NeighborCache, SocketSet};
 use smoltcp::phy::{wait as phy_wait, Device, Medium};
 use smoltcp::socket::{tcp, udp};
@@ -82,22 +76,12 @@ fn main() {
     #[cfg(feature = "proto-ipv4-fragmentation")]
     let mut ipv4_out_packet_cache = [0u8; 10_000];
     #[cfg(feature = "proto-ipv4-fragmentation")]
-    {
-        let ipv4_frag_cache = ReassemblyBuffer::new(vec![], BTreeMap::new());
-        builder = builder
-            .ipv4_reassembly_buffer(ipv4_frag_cache)
-            .ipv4_fragmentation_buffer(&mut ipv4_out_packet_cache[..]);
-    }
+    let builder = builder.ipv4_fragmentation_buffer(&mut ipv4_out_packet_cache[..]);
 
     #[cfg(feature = "proto-sixlowpan-fragmentation")]
     let mut sixlowpan_out_packet_cache = [0u8; 1280];
     #[cfg(feature = "proto-sixlowpan-fragmentation")]
-    {
-        let sixlowpan_frag_cache = ReassemblyBuffer::new(vec![], BTreeMap::new());
-        builder = builder
-            .sixlowpan_reassembly_buffer(sixlowpan_frag_cache)
-            .sixlowpan_fragmentation_buffer(&mut sixlowpan_out_packet_cache[..]);
-    }
+    let mut builder = builder.sixlowpan_fragmentation_buffer(&mut sixlowpan_out_packet_cache[..]);
 
     if medium == Medium::Ethernet {
         builder = builder

--- a/examples/sixlowpan.rs
+++ b/examples/sixlowpan.rs
@@ -43,11 +43,10 @@
 mod utils;
 
 use log::debug;
-use std::collections::BTreeMap;
 use std::os::unix::io::AsRawFd;
 use std::str;
 
-use smoltcp::iface::{InterfaceBuilder, NeighborCache, ReassemblyBuffer, SocketSet};
+use smoltcp::iface::{InterfaceBuilder, NeighborCache, SocketSet};
 use smoltcp::phy::{wait as phy_wait, Medium, RawSocket};
 use smoltcp::socket::tcp;
 use smoltcp::socket::udp;
@@ -96,20 +95,11 @@ fn main() {
         .hardware_addr(ieee802154_addr.into())
         .neighbor_cache(neighbor_cache);
 
-    #[cfg(feature = "proto-ipv4-fragmentation")]
-    {
-        let ipv4_frag_cache = ReassemblyBuffer::new(vec![], BTreeMap::new());
-        builder = builder.ipv4_reassembly_buffer(ipv4_frag_cache);
-    }
-
     #[cfg(feature = "proto-sixlowpan-fragmentation")]
     let mut out_packet_buffer = [0u8; 1280];
     #[cfg(feature = "proto-sixlowpan-fragmentation")]
     {
-        let sixlowpan_frag_cache = ReassemblyBuffer::new(vec![], BTreeMap::new());
-        builder = builder
-            .sixlowpan_reassembly_buffer(sixlowpan_frag_cache)
-            .sixlowpan_fragmentation_buffer(&mut out_packet_buffer[..]);
+        builder = builder.sixlowpan_fragmentation_buffer(&mut out_packet_buffer[..]);
     }
 
     let mut iface = builder.finalize(&mut device);

--- a/examples/sixlowpan_benchmark.rs
+++ b/examples/sixlowpan_benchmark.rs
@@ -44,11 +44,10 @@
 mod utils;
 
 use log::debug;
-use std::collections::BTreeMap;
 use std::os::unix::io::AsRawFd;
 use std::str;
 
-use smoltcp::iface::{InterfaceBuilder, NeighborCache, ReassemblyBuffer, SocketSet};
+use smoltcp::iface::{InterfaceBuilder, NeighborCache, SocketSet};
 use smoltcp::phy::{wait as phy_wait, Medium, RawSocket};
 use smoltcp::socket::tcp;
 use smoltcp::wire::{Ieee802154Pan, IpAddress, IpCidr};
@@ -169,15 +168,12 @@ fn main() {
         ))
         .unwrap();
 
-    let cache = ReassemblyBuffer::new(vec![], BTreeMap::new());
-
     let mut builder = InterfaceBuilder::new()
         .ip_addrs(ip_addrs)
         .pan_id(Ieee802154Pan(0xbeef));
     builder = builder
         .hardware_addr(ieee802154_addr.into())
         .neighbor_cache(neighbor_cache)
-        .sixlowpan_reassembly_buffer(cache)
         .sixlowpan_fragmentation_buffer(vec![]);
     let mut iface = builder.finalize(&mut device);
 

--- a/src/iface/fragmentation.rs
+++ b/src/iface/fragmentation.rs
@@ -103,7 +103,6 @@ impl<'a> PacketAssembler<'a> {
     ///
     /// - Returns [`Error::PacketAssemblerBufferTooSmall`] when trying to add data into the buffer at a non-existing
     /// place.
-    /// - Returns [`Error::PacketAssemblerOverlap`] when there was an overlap when adding data.
     pub(crate) fn add(&mut self, data: &[u8], offset: usize) -> Result<bool> {
         let offset = offset as isize + self.offset_correction;
         let offset = if offset <= 0 { 0 } else { offset as usize };

--- a/src/iface/fragmentation.rs
+++ b/src/iface/fragmentation.rs
@@ -233,7 +233,7 @@ impl<'a> PacketAssembler<'a> {
                 total_size,
                 ..
             } => match (total_size, assembler.peek_front()) {
-                (Some(total_size), Some(front)) => Ok(front == *total_size),
+                (Some(total_size), front) => Ok(front == *total_size),
                 _ => Ok(false),
             },
         }

--- a/src/iface/fragmentation.rs
+++ b/src/iface/fragmentation.rs
@@ -6,8 +6,24 @@ use managed::{ManagedMap, ManagedSlice};
 
 use crate::storage::Assembler;
 use crate::time::{Duration, Instant};
-use crate::Error;
-use crate::Result;
+
+// TODO: make configurable.
+const BUFFER_SIZE: usize = 1500;
+
+#[cfg(feature = "alloc")]
+type Buffer = alloc::vec::Vec<u8>;
+#[cfg(not(feature = "alloc"))]
+type Buffer = [u8; BUFFER_SIZE];
+
+const PACKET_ASSEMBLER_COUNT: usize = 4;
+
+/// Problem when assembling: something was out of bounds.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct AssemblerError;
+
+/// Packet assembler is full
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct AssemblerFullError;
 
 /// Holds different fragments of one packet, used for assembling fragmented packets.
 ///
@@ -15,8 +31,9 @@ use crate::Result;
 /// or should be statically allocated based upon the MTU of the type of packet being
 /// assembled (ex: 1280 for a IPv6 frame).
 #[derive(Debug)]
-pub struct PacketAssembler<'a> {
-    buffer: ManagedSlice<'a, u8>,
+pub struct PacketAssembler<K> {
+    key: Option<K>,
+    buffer: Buffer,
 
     assembler: Assembler,
     total_size: Option<usize>,
@@ -24,15 +41,16 @@ pub struct PacketAssembler<'a> {
     offset_correction: isize,
 }
 
-impl<'a> PacketAssembler<'a> {
+impl<K> PacketAssembler<K> {
     /// Create a new empty buffer for fragments.
-    pub fn new<S>(storage: S) -> Self
-    where
-        S: Into<ManagedSlice<'a, u8>>,
-    {
-        let s = storage.into();
-        PacketAssembler {
-            buffer: s,
+    pub fn new() -> Self {
+        Self {
+            key: None,
+
+            #[cfg(feature = "alloc")]
+            buffer: Buffer::new(),
+            #[cfg(not(feature = "alloc"))]
+            buffer: [0u8; BUFFER_SIZE],
 
             assembler: Assembler::new(),
             total_size: None,
@@ -42,50 +60,33 @@ impl<'a> PacketAssembler<'a> {
     }
 
     pub(crate) fn reset(&mut self) {
-        self.assembler = Assembler::new();
+        self.key = None;
+        self.assembler.clear();
         self.total_size = None;
         self.expires_at = Instant::ZERO;
         self.offset_correction = 0;
     }
 
-    /// Start with saving fragments.
-    /// We initialize the assembler with the total size of the final packet.
-    ///
-    /// # Errors
-    ///
-    /// - Returns [`Error::PacketAssemblerBufferTooSmall`] when the buffer is too small for holding all the
-    /// fragments of a packet.
-    pub(crate) fn start(
-        &mut self,
-        total_size: Option<usize>,
-        expires_at: Instant,
-        offset_correction: isize,
-    ) -> Result<()> {
-        self.reset();
-        if let Some(total_size) = total_size {
-            self.set_total_size(total_size)?;
-        }
-        self.expires_at = expires_at;
-        self.offset_correction = offset_correction;
-        Ok(())
+    pub(crate) fn set_offset_correction(&mut self, correction: isize) {
+        self.offset_correction = correction;
     }
 
     /// Set the total size of the packet assembler.
-    pub(crate) fn set_total_size(&mut self, size: usize) -> Result<()> {
+    pub(crate) fn set_total_size(&mut self, size: usize) -> Result<(), AssemblerError> {
         if let Some(old_size) = self.total_size {
             if old_size != size {
-                return Err(Error::Malformed);
+                return Err(AssemblerError);
             }
         }
 
-        match &mut self.buffer {
-            ManagedSlice::Borrowed(b) => {
-                if b.len() < size {
-                    return Err(Error::PacketAssemblerBufferTooSmall);
-                }
-            }
-            #[cfg(feature = "alloc")]
-            ManagedSlice::Owned(b) => b.resize(size, 0),
+        #[cfg(not(feature = "alloc"))]
+        if self.buffer.len() < size {
+            return Err(AssemblerError);
+        }
+
+        #[cfg(feature = "alloc")]
+        if self.buffer.len() < size {
+            self.buffer.resize(size, 0);
         }
 
         self.total_size = Some(size);
@@ -93,8 +94,8 @@ impl<'a> PacketAssembler<'a> {
     }
 
     /// Return the instant when the assembler expires.
-    pub(crate) fn expires_at(&self) -> Result<Instant> {
-        Ok(self.expires_at)
+    pub(crate) fn expires_at(&self) -> Instant {
+        self.expires_at
     }
 
     /// Add a fragment into the packet that is being reassembled.
@@ -103,29 +104,25 @@ impl<'a> PacketAssembler<'a> {
     ///
     /// - Returns [`Error::PacketAssemblerBufferTooSmall`] when trying to add data into the buffer at a non-existing
     /// place.
-    pub(crate) fn add(&mut self, data: &[u8], offset: usize) -> Result<bool> {
+    pub(crate) fn add(&mut self, data: &[u8], offset: usize) -> Result<(), AssemblerError> {
         let offset = offset as isize + self.offset_correction;
         let offset = if offset <= 0 { 0 } else { offset as usize };
 
-        match &mut self.buffer {
-            ManagedSlice::Borrowed(b) => {
-                if offset + data.len() > b.len() {
-                    return Err(Error::PacketAssemblerBufferTooSmall);
-                }
-            }
-            #[cfg(feature = "alloc")]
-            ManagedSlice::Owned(b) => {
-                if offset + data.len() > b.len() {
-                    b.resize(offset + data.len(), 0);
-                }
-            }
+        #[cfg(not(feature = "alloc"))]
+        if self.buffer.len() < offset + data.len() {
+            return Err(AssemblerError);
+        }
+
+        #[cfg(feature = "alloc")]
+        if self.buffer.len() < offset + data.len() {
+            self.buffer.resize(offset + data.len(), 0);
         }
 
         let len = data.len();
         self.buffer[offset..][..len].copy_from_slice(data);
 
         net_debug!(
-            "frag assembler: receiving {} octests at offset {}",
+            "frag assembler: receiving {} octets at offset {}",
             len,
             offset
         );
@@ -133,225 +130,92 @@ impl<'a> PacketAssembler<'a> {
         match self.assembler.add(offset, data.len()) {
             Ok(()) => {
                 net_debug!("assembler: {}", self.assembler);
-                self.is_complete()
+                Ok(())
             }
-            // NOTE(thvdveld): hopefully we wont get too many holes errors I guess?
-            Err(_) => Err(Error::PacketAssemblerTooManyHoles),
+            Err(_) => {
+                net_debug!("packet assembler: too many holes, dropping.");
+                Err(AssemblerError)
+            }
         }
     }
 
-    /// Get an immutable slice of the underlying packet data.
+    /// Get an immutable slice of the underlying packet data, if reassembly complete.
     /// This will mark the assembler as empty, so that it can be reused.
-    ///
-    /// # Errors
-    ///
-    /// - Returns [`Error::PacketAssemblerIncomplete`] when not all the fragments have been collected.
-    pub(crate) fn assemble(&mut self) -> Result<&'_ [u8]> {
-        if !self.is_complete()? {
-            return Err(Error::PacketAssemblerIncomplete);
+    pub(crate) fn assemble(&mut self) -> Option<&'_ [u8]> {
+        if !self.is_complete() {
+            return None;
         }
 
         // NOTE: we can unwrap because `is_complete` already checks this.
         let total_size = self.total_size.unwrap();
-        let a = &self.buffer[..total_size];
-
-        Ok(a)
+        self.reset();
+        Some(&self.buffer[..total_size])
     }
 
     /// Returns `true` when all fragments have been received, otherwise `false`.
-    ///
-    /// # Errors
-    ///
-    /// - Returns [`Error::PacketAssemblerNotInit`] when the assembler was not initialized (try initializing the
-    /// assembler with [`Self::start`]).
-    pub(crate) fn is_complete(&self) -> Result<bool> {
-        match (self.total_size, self.assembler.peek_front()) {
-            (Some(total_size), front) => Ok(front == total_size),
-            _ => Ok(false),
-        }
+    pub(crate) fn is_complete(&self) -> bool {
+        self.total_size == Some(self.assembler.peek_front())
     }
 
-    /// Returns `true` when the packet assembler is empty (free to use).
-    fn is_empty(&self) -> bool {
-        self.assembler.is_empty()
+    /// Returns `true` when the packet assembler is free to use.
+    fn is_free(&self) -> bool {
+        self.key.is_none()
     }
 }
 
 /// Set holding multiple [`PacketAssembler`].
 #[derive(Debug)]
-pub struct PacketAssemblerSet<'a, Key: Eq + Ord + Clone + Copy> {
-    packet_buffer: ManagedSlice<'a, PacketAssembler<'a>>,
-    index_buffer: ManagedMap<'a, Key, usize>,
+pub struct PacketAssemblerSet<K: Eq + Copy> {
+    assemblers: [PacketAssembler<K>; PACKET_ASSEMBLER_COUNT],
 }
 
-impl<'a, K: Eq + Ord + Clone + Copy> PacketAssemblerSet<'a, K> {
+impl<K: Eq + Copy> PacketAssemblerSet<K> {
     /// Create a new set of packet assemblers.
-    ///
-    /// # Panics
-    ///
-    /// This will panic when:
-    ///   - The packet buffer and index buffer don't have the same size or are empty (when they are
-    ///   both borrowed).
-    ///   - The packet buffer is empty (when only the packet buffer is borrowed).
-    ///   - The index buffer is empty (when only the index buffer is borrowed).
-    pub fn new<FB, IB>(packet_buffer: FB, index_buffer: IB) -> Self
-    where
-        FB: Into<ManagedSlice<'a, PacketAssembler<'a>>>,
-        IB: Into<ManagedMap<'a, K, usize>>,
-    {
-        let packet_buffer = packet_buffer.into();
-        let index_buffer = index_buffer.into();
-
-        match (&packet_buffer, &index_buffer) {
-            (ManagedSlice::Borrowed(f), ManagedMap::Borrowed(i)) => {
-                if f.len() != i.len() {
-                    panic!("The amount of places in the index buffer must be the same as the amount of possible fragments assemblers.");
-                }
-            }
-            #[cfg(feature = "alloc")]
-            (ManagedSlice::Borrowed(f), ManagedMap::Owned(_)) => {
-                if f.is_empty() {
-                    panic!("The packet buffer cannot be empty.");
-                }
-            }
-            #[cfg(feature = "alloc")]
-            (ManagedSlice::Owned(_), ManagedMap::Borrowed(i)) => {
-                if i.is_empty() {
-                    panic!("The index buffer cannot be empty.");
-                }
-            }
-            #[cfg(feature = "alloc")]
-            (ManagedSlice::Owned(_), ManagedMap::Owned(_)) => (),
-        }
-
+    pub fn new() -> Self {
         Self {
-            packet_buffer,
-            index_buffer,
+            // TODO: support any PACKET_ASSEMBLER_COUNT
+            assemblers: [
+                PacketAssembler::new(),
+                PacketAssembler::new(),
+                PacketAssembler::new(),
+                PacketAssembler::new(),
+            ],
         }
     }
 
-    /// Reserve a [`PacketAssembler`], which is linked to a specific key.
-    /// Returns the reserved fragments assembler.
+    /// Get a [`PacketAssembler`] for a specific key.
     ///
-    /// # Errors
+    /// If it doesn't exist, it is created, with the `expires_at` timestamp.
     ///
-    /// - Returns [`Error::PacketAssemblerSetFull`] when every [`PacketAssembler`] in the buffer is used (only
-    /// when the non allocating version of is used).
-    pub(crate) fn reserve_with_key(&mut self, key: &K) -> Result<&mut PacketAssembler<'a>> {
-        // Check how many WIP reassemblies we have.
-        // The limit is currently set to 255.
-        if self.index_buffer.len() == u8::MAX as usize {
-            return Err(Error::PacketAssemblerSetFull);
-        }
-
-        if self.packet_buffer.len() == self.index_buffer.len() {
-            match &mut self.packet_buffer {
-                ManagedSlice::Borrowed(_) => return Err(Error::PacketAssemblerSetFull),
-                #[cfg(feature = "alloc")]
-                ManagedSlice::Owned(b) => (),
+    /// If the assembler set is full, in which case an error is returned.
+    pub(crate) fn get(
+        &mut self,
+        key: &K,
+        expires_at: Instant,
+    ) -> Result<&mut PacketAssembler<K>, AssemblerFullError> {
+        let mut empty_slot = None;
+        for slot in &mut self.assemblers {
+            if slot.key.as_ref() == Some(key) {
+                return Ok(slot);
+            }
+            if slot.is_free() {
+                empty_slot = Some(slot)
             }
         }
 
-        let i = self
-            .get_free_packet_assembler()
-            .ok_or(Error::PacketAssemblerSetFull)?;
-
-        // NOTE(thvdveld): this should not fail because we already checked the available space.
-        match self.index_buffer.insert(*key, i) {
-            Ok(_) => Ok(&mut self.packet_buffer[i]),
-            Err(_) => unreachable!(),
-        }
+        let slot = empty_slot.ok_or(AssemblerFullError)?;
+        slot.key = Some(*key);
+        slot.expires_at = expires_at;
+        Ok(slot)
     }
 
-    /// Return the first free packet assembler available from the cache.
-    fn get_free_packet_assembler(&mut self) -> Option<usize> {
-        match &mut self.packet_buffer {
-            ManagedSlice::Borrowed(_) => (),
-            #[cfg(feature = "alloc")]
-            ManagedSlice::Owned(b) => b.push(PacketAssembler::new(alloc::vec![])),
-        }
-
-        self.packet_buffer
-            .iter()
-            .enumerate()
-            .find(|(_, b)| b.is_empty())
-            .map(|(i, _)| i)
-    }
-
-    /// Return a mutable slice to a packet assembler.
-    ///
-    /// # Errors
-    ///
-    /// - Returns [`Error::PacketAssemblerSetKeyNotFound`] when the key was not found in the set.
-    pub(crate) fn get_packet_assembler_mut(&mut self, key: &K) -> Result<&mut PacketAssembler<'a>> {
-        if let Some(i) = self.index_buffer.get(key) {
-            Ok(&mut self.packet_buffer[*i])
-        } else {
-            Err(Error::PacketAssemblerSetKeyNotFound)
-        }
-    }
-
-    /// Return the assembled packet from a packet assembler.
-    /// This also removes it from the set.
-    ///
-    /// # Errors
-    ///
-    /// - Returns [`Error::PacketAssemblerSetKeyNotFound`] when the `key` was not found.
-    /// - Returns [`Error::PacketAssemblerIncomplete`] when the fragments assembler was empty or not fully assembled.
-    pub(crate) fn get_assembled_packet(&mut self, key: &K) -> Result<&[u8]> {
-        if let Some(i) = self.index_buffer.get(key) {
-            let p = self.packet_buffer[*i].assemble()?;
-            self.index_buffer.remove(key);
-            Ok(p)
-        } else {
-            Err(Error::PacketAssemblerSetKeyNotFound)
-        }
-    }
-
-    /// Remove all [`PacketAssembler`]s that are marked as discarded.
-    pub fn remove_discarded(&mut self) {
-        loop {
-            let mut key = None;
-            for (k, i) in self.index_buffer.iter() {
-                if self.packet_buffer[*i].is_empty() {
-                    key = Some(*k);
-                    break;
-                }
-            }
-
-            if let Some(k) = key {
-                self.index_buffer.remove(&k);
-            } else {
-                break;
-            }
-        }
-    }
-
-    /// Mark all [`PacketAssembler`]s as discarded for which `f` returns `Ok(true)`.
-    /// This does not remove them from the buffer.
-    pub fn mark_discarded_when<F>(&mut self, f: F) -> Result<()>
-    where
-        F: Fn(&mut PacketAssembler<'_>) -> Result<bool>,
-    {
-        for (_, i) in &mut self.index_buffer.iter() {
-            let frag = &mut self.packet_buffer[*i];
-            if f(frag)? {
+    /// Remove all [`PacketAssembler`]s that are expired.
+    pub fn remove_expired(&mut self, timestamp: Instant) {
+        for frag in &mut self.assemblers {
+            if !frag.is_free() && frag.expires_at < timestamp {
                 frag.reset();
             }
         }
-
-        Ok(())
-    }
-
-    /// Remove all [`PacketAssembler`]s for which `f` returns `Ok(true)`.
-    pub fn remove_when<F>(&mut self, f: F) -> Result<()>
-    where
-        F: Fn(&mut PacketAssembler<'_>) -> Result<bool>,
-    {
-        self.mark_discarded_when(f)?;
-        self.remove_discarded();
-
-        Ok(())
     }
 }
 
@@ -365,144 +229,102 @@ mod tests {
     }
 
     #[test]
-    fn packet_assembler_buffer_too_small() {
-        let mut storage = [0u8; 1];
-        let mut p_assembler = PacketAssembler::new(&mut storage[..]);
-
-        assert_eq!(
-            p_assembler.start(Some(2), Instant::from_secs(0), 0),
-            Err(Error::PacketAssemblerBufferTooSmall)
-        );
-        assert_eq!(p_assembler.start(Some(1), Instant::from_secs(0), 0), Ok(()));
-
-        let data = b"Hello World!";
-        assert_eq!(
-            p_assembler.add(&data[..], data.len()),
-            Err(Error::PacketAssemblerBufferTooSmall)
-        );
-    }
-
-    #[test]
     fn packet_assembler_overlap() {
-        let mut storage = [0u8; 5];
-        let mut p_assembler = PacketAssembler::new(&mut storage[..]);
+        let mut p_assembler = PacketAssembler::<Key>::new();
 
-        p_assembler
-            .start(Some(5), Instant::from_secs(0), 0)
-            .unwrap();
+        p_assembler.set_total_size(5).unwrap();
+
         let data = b"Rust";
+        p_assembler.add(&data[..], 0);
+        p_assembler.add(&data[..], 1);
 
-        p_assembler.add(&data[..], 0).unwrap();
-
-        assert_eq!(p_assembler.add(&data[..], 1), Ok(true));
+        assert_eq!(p_assembler.assemble(), Some(&b"RRust"[..]))
     }
 
     #[test]
     fn packet_assembler_assemble() {
-        let mut storage = [0u8; 12];
-        let mut p_assembler = PacketAssembler::new(&mut storage[..]);
+        let mut p_assembler = PacketAssembler::<Key>::new();
 
         let data = b"Hello World!";
 
-        p_assembler
-            .start(Some(data.len()), Instant::from_secs(0), 0)
-            .unwrap();
+        p_assembler.set_total_size(data.len()).unwrap();
 
         p_assembler.add(b"Hello ", 0).unwrap();
-        assert_eq!(
-            p_assembler.assemble(),
-            Err(Error::PacketAssemblerIncomplete)
-        );
+        assert_eq!(p_assembler.assemble(), None);
 
         p_assembler.add(b"World!", b"Hello ".len()).unwrap();
 
-        assert_eq!(p_assembler.assemble(), Ok(&b"Hello World!"[..]));
+        assert_eq!(p_assembler.assemble(), Some(&b"Hello World!"[..]));
     }
 
     #[test]
     fn packet_assembler_out_of_order_assemble() {
-        let mut storage = [0u8; 12];
-        let mut p_assembler = PacketAssembler::new(&mut storage[..]);
+        let mut p_assembler = PacketAssembler::<Key>::new();
 
         let data = b"Hello World!";
 
-        p_assembler
-            .start(Some(data.len()), Instant::from_secs(0), 0)
-            .unwrap();
+        p_assembler.set_total_size(data.len()).unwrap();
 
         p_assembler.add(b"World!", b"Hello ".len()).unwrap();
-        assert_eq!(
-            p_assembler.assemble(),
-            Err(Error::PacketAssemblerIncomplete)
-        );
+        assert_eq!(p_assembler.assemble(), None);
 
         p_assembler.add(b"Hello ", 0).unwrap();
 
-        assert_eq!(p_assembler.assemble(), Ok(&b"Hello World!"[..]));
+        assert_eq!(p_assembler.assemble(), Some(&b"Hello World!"[..]));
     }
 
     #[test]
     fn packet_assembler_set() {
         let key = Key { id: 1 };
 
-        let mut set = PacketAssemblerSet::<'_, _>::new(vec![], std::collections::BTreeMap::new());
+        let mut set = PacketAssemblerSet::new();
 
-        if let Err(e) = set.get_packet_assembler_mut(&key) {
-            assert_eq!(e, Error::PacketAssemblerSetKeyNotFound);
-        }
-
-        assert!(set.reserve_with_key(&key).is_ok());
+        assert!(set.get(&key, Instant::ZERO).is_ok());
     }
 
     #[test]
-    fn packet_assembler_set_borrowed() {
-        let mut buf = [0u8, 127];
-        let mut packet_assembler_cache = [PacketAssembler::<'_>::new(&mut buf[..])];
-        let mut packet_index_cache = [None];
-
-        let key = Key { id: 1 };
-
-        let mut set =
-            PacketAssemblerSet::new(&mut packet_assembler_cache[..], &mut packet_index_cache[..]);
-
-        if let Err(e) = set.get_packet_assembler_mut(&key) {
-            assert_eq!(e, Error::PacketAssemblerSetKeyNotFound);
-        }
-
-        assert!(set.reserve_with_key(&key).is_ok());
+    fn packet_assembler_set_full() {
+        let mut set = PacketAssemblerSet::new();
+        set.get(&Key { id: 0 }, Instant::ZERO).unwrap();
+        set.get(&Key { id: 1 }, Instant::ZERO).unwrap();
+        set.get(&Key { id: 2 }, Instant::ZERO).unwrap();
+        set.get(&Key { id: 3 }, Instant::ZERO).unwrap();
+        assert!(set.get(&Key { id: 4 }, Instant::ZERO).is_err());
     }
 
     #[test]
     fn packet_assembler_set_assembling_many() {
-        let mut buf = [0u8, 127];
-        let mut packet_assembler_cache = [PacketAssembler::new(&mut buf[..])];
-        let mut packet_index_cache = [None];
-
-        let mut set =
-            PacketAssemblerSet::new(&mut packet_assembler_cache[..], &mut packet_index_cache[..]);
+        let mut set = PacketAssemblerSet::new();
 
         let key = Key { id: 0 };
-        set.reserve_with_key(&key).unwrap();
-        set.get_packet_assembler_mut(&key)
-            .unwrap()
-            .start(Some(0), Instant::from_secs(0), 0)
-            .unwrap();
-        set.get_assembled_packet(&key).unwrap();
+        let assr = set.get(&key, Instant::ZERO).unwrap();
+        assert_eq!(assr.assemble(), None);
+        assr.set_total_size(0).unwrap();
+        assr.assemble().unwrap();
+
+        // Test that `.assemble()` effectively deletes it.
+        let assr = set.get(&key, Instant::ZERO).unwrap();
+        assert_eq!(assr.assemble(), None);
+        assr.set_total_size(0).unwrap();
+        assr.assemble().unwrap();
 
         let key = Key { id: 1 };
-        set.reserve_with_key(&key).unwrap();
-        set.get_packet_assembler_mut(&key)
-            .unwrap()
-            .start(Some(0), Instant::from_secs(0), 0)
-            .unwrap();
-        set.get_assembled_packet(&key).unwrap();
+        let assr = set.get(&key, Instant::ZERO).unwrap();
+        assr.set_total_size(0).unwrap();
+        assr.assemble().unwrap();
 
         let key = Key { id: 2 };
-        set.reserve_with_key(&key).unwrap();
-        set.get_packet_assembler_mut(&key)
-            .unwrap()
-            .start(Some(0), Instant::from_secs(0), 0)
-            .unwrap();
-        set.get_assembled_packet(&key).unwrap();
+        let assr = set.get(&key, Instant::ZERO).unwrap();
+        assr.set_total_size(0).unwrap();
+        assr.assemble().unwrap();
+
+        let key = Key { id: 2 };
+        let assr = set.get(&key, Instant::ZERO).unwrap();
+        assr.set_total_size(2).unwrap();
+        assr.add(&[0x00], 0).unwrap();
+        assert_eq!(assr.assemble(), None);
+        let assr = set.get(&key, Instant::ZERO).unwrap();
+        assr.add(&[0x01], 1).unwrap();
+        assert_eq!(assr.assemble(), Some(&[0x00, 0x01][..]));
     }
 }

--- a/src/iface/fragmentation.rs
+++ b/src/iface/fragmentation.rs
@@ -93,11 +93,7 @@ impl<'a> PacketAssembler<'a> {
         }
 
         self.assembler = AssemblerState::Assembling {
-            assembler: Assembler::new(if let Some(total_size) = total_size {
-                total_size
-            } else {
-                usize::MAX
-            }),
+            assembler: Assembler::new(),
             total_size,
             expires_at,
             offset_correction,

--- a/src/iface/fragmentation.rs
+++ b/src/iface/fragmentation.rs
@@ -98,6 +98,42 @@ impl<K> PacketAssembler<K> {
         self.expires_at
     }
 
+    pub(crate) fn add_with_fn(
+        &mut self,
+        len: usize,
+        offset: usize,
+        f: impl Fn(&mut [u8]),
+    ) -> Result<(), AssemblerError> {
+        #[cfg(not(feature = "alloc"))]
+        if self.buffer.len() < offset + len {
+            return Err(AssemblerError);
+        }
+
+        #[cfg(feature = "alloc")]
+        if self.buffer.len() < offset + len {
+            self.buffer.resize(offset + len, 0);
+        }
+
+        f(&mut self.buffer[offset..][..len]);
+
+        net_debug!(
+            "frag assembler: receiving {} octets at offset {}",
+            len,
+            offset
+        );
+
+        match self.assembler.add(offset, len) {
+            Ok(()) => {
+                net_debug!("assembler: {}", self.assembler);
+                Ok(())
+            }
+            Err(_) => {
+                net_debug!("packet assembler: too many holes, dropping.");
+                Err(AssemblerError)
+            }
+        }
+    }
+
     /// Add a fragment into the packet that is being reassembled.
     ///
     /// # Errors

--- a/src/iface/interface/ethernet.rs
+++ b/src/iface/interface/ethernet.rs
@@ -15,7 +15,7 @@ impl<'i> InterfaceInner<'i> {
         &mut self,
         sockets: &mut SocketSet,
         frame: &'frame T,
-        _fragments: &'frame mut FragmentsBuffer<'i>,
+        _fragments: &'frame mut FragmentsBuffer,
     ) -> Option<EthernetPacket<'frame>> {
         let eth_frame = check!(EthernetFrame::new_checked(frame));
 

--- a/src/iface/interface/ipv4.rs
+++ b/src/iface/interface/ipv4.rs
@@ -39,7 +39,7 @@ impl<'a> InterfaceInner<'a> {
 
         #[cfg(feature = "proto-ipv4-fragmentation")]
         let ip_payload = {
-            const REASSEMBLY_TIMEOUT: u64 = 90;
+            const REASSEMBLY_TIMEOUT: Duration = Duration::from_secs(90);
 
             let fragments = _fragments.unwrap();
 
@@ -58,11 +58,7 @@ impl<'a> InterfaceInner<'a> {
                             e => check!(e),
                         };
 
-                        check!(p.start(
-                            None,
-                            self.now + Duration::from_secs(REASSEMBLY_TIMEOUT),
-                            0
-                        ));
+                        check!(p.start(None, self.now + REASSEMBLY_TIMEOUT, 0));
 
                         check!(fragments.get_packet_assembler_mut(&key))
                     }
@@ -84,9 +80,6 @@ impl<'a> InterfaceInner<'a> {
                         check!(fragments.get_assembled_packet(&key))
                     }
                     Ok(false) => {
-                        return None;
-                    }
-                    Err(Error::PacketAssemblerOverlap) => {
                         return None;
                     }
                     Err(e) => {

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -40,6 +40,8 @@ const MAX_IP_ADDR_COUNT: usize = 5;
 const MAX_IPV4_MULTICAST_GROUPS: usize = 4;
 
 pub(crate) struct FragmentsBuffer {
+    #[cfg(feature = "proto-sixlowpan")]
+    decompress_buf: [u8; sixlowpan::MAX_DECOMPRESSED_LEN],
     #[cfg(feature = "proto-ipv4-fragmentation")]
     pub(crate) ipv4_fragments: PacketAssemblerSet<Ipv4FragKey>,
     #[cfg(feature = "proto-sixlowpan-fragmentation")]
@@ -645,6 +647,9 @@ let iface = builder.finalize(&mut device);
 
         Interface {
             fragments: FragmentsBuffer {
+                #[cfg(feature = "proto-sixlowpan")]
+                decompress_buf: [0u8; sixlowpan::MAX_DECOMPRESSED_LEN],
+
                 #[cfg(feature = "proto-ipv4-fragmentation")]
                 ipv4_fragments: self.ipv4_fragments,
                 #[cfg(feature = "proto-sixlowpan-fragmentation")]

--- a/src/iface/interface/sixlowpan.rs
+++ b/src/iface/interface/sixlowpan.rs
@@ -274,7 +274,7 @@ impl<'a> InterfaceInner<'a> {
             Ok(false) => None,
             Err(Error::PacketAssemblerOverlap) => {
                 net_trace!("6LoWPAN: overlap in packet");
-                frags.mark_discarded();
+                frags.reset();
                 None
             }
             Err(_) => None,

--- a/src/iface/interface/sixlowpan.rs
+++ b/src/iface/interface/sixlowpan.rs
@@ -250,17 +250,11 @@ impl<'a> InterfaceInner<'a> {
                             &ChecksumCapabilities::ignored(),
                         )?;
 
-                        let mut udp_emit_packet = UdpPacket::new_unchecked(
+                        let mut udp = UdpPacket::new_unchecked(
                             &mut buffer[..udp_repr.0.header_len() + iphc.payload().len()
                                 - udp_repr.header_len()],
                         );
-                        udp_repr.0.emit_header(
-                            &mut udp_emit_packet,
-                            &iphc_repr.src_addr.into(),
-                            &iphc_repr.dst_addr.into(),
-                            ipv6_repr.payload_len - 8,
-                            &ChecksumCapabilities::ignored(),
-                        );
+                        udp_repr.0.emit_header(&mut udp, ipv6_repr.payload_len - 8);
 
                         buffer[8..].copy_from_slice(&iphc.payload()[udp_repr.header_len()..]);
                     }

--- a/src/iface/interface/sixlowpan.rs
+++ b/src/iface/interface/sixlowpan.rs
@@ -272,11 +272,6 @@ impl<'a> InterfaceInner<'a> {
                 }
             }
             Ok(false) => None,
-            Err(Error::PacketAssemblerOverlap) => {
-                net_trace!("6LoWPAN: overlap in packet");
-                frags.reset();
-                None
-            }
             Err(_) => None,
         }
     }

--- a/src/iface/interface/tests.rs
+++ b/src/iface/interface/tests.rs
@@ -1503,10 +1503,7 @@ fn test_echo_request_sixlowpan_128_bytes() {
             &mut sockets,
             &ieee802154_repr,
             &request_first_part_packet.into_inner(),
-            Some((
-                &mut iface.fragments.sixlowpan_fragments,
-                iface.fragments.sixlowpan_fragments_cache_timeout,
-            )),
+            &mut iface.fragments
         ),
         None
     );
@@ -1530,10 +1527,7 @@ fn test_echo_request_sixlowpan_128_bytes() {
         &mut sockets,
         &ieee802154_repr,
         &request_second_part,
-        Some((
-            &mut iface.fragments.sixlowpan_fragments,
-            iface.fragments.sixlowpan_fragments_cache_timeout,
-        )),
+        &mut iface.fragments,
     );
 
     assert_eq!(
@@ -1666,10 +1660,7 @@ fn test_sixlowpan_udp_with_fragmentation() {
             &mut sockets,
             &ieee802154_repr,
             udp_first_part,
-            Some((
-                &mut iface.fragments.sixlowpan_fragments,
-                iface.fragments.sixlowpan_fragments_cache_timeout
-            ))
+            &mut iface.fragments
         ),
         None
     );
@@ -1688,10 +1679,7 @@ fn test_sixlowpan_udp_with_fragmentation() {
             &mut sockets,
             &ieee802154_repr,
             udp_second_part,
-            Some((
-                &mut iface.fragments.sixlowpan_fragments,
-                iface.fragments.sixlowpan_fragments_cache_timeout
-            ))
+            &mut iface.fragments
         ),
         None
     );

--- a/src/iface/interface/tests.rs
+++ b/src/iface/interface/tests.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 #[cfg(feature = "proto-igmp")]
 use std::vec::Vec;
 
@@ -59,9 +58,7 @@ fn create_ip<'a>() -> (Interface<'a>, SocketSet<'a>, Loopback) {
     let iface_builder = InterfaceBuilder::new().ip_addrs(ip_addrs);
 
     #[cfg(feature = "proto-ipv4-fragmentation")]
-    let iface_builder = iface_builder
-        .ipv4_reassembly_buffer(PacketAssemblerSet::new(vec![], BTreeMap::new()))
-        .ipv4_fragmentation_buffer(vec![]);
+    let iface_builder = iface_builder.ipv4_fragmentation_buffer(vec![]);
 
     let iface = iface_builder.finalize(&mut device);
 
@@ -92,14 +89,10 @@ fn create_ethernet<'a>() -> (Interface<'a>, SocketSet<'a>, Loopback) {
         .ip_addrs(ip_addrs);
 
     #[cfg(feature = "proto-sixlowpan-fragmentation")]
-    let iface_builder = iface_builder
-        .sixlowpan_reassembly_buffer(PacketAssemblerSet::new(vec![], BTreeMap::new()))
-        .sixlowpan_fragmentation_buffer(vec![]);
+    let iface_builder = iface_builder.sixlowpan_fragmentation_buffer(vec![]);
 
     #[cfg(feature = "proto-ipv4-fragmentation")]
-    let iface_builder = iface_builder
-        .ipv4_reassembly_buffer(PacketAssemblerSet::new(vec![], BTreeMap::new()))
-        .ipv4_fragmentation_buffer(vec![]);
+    let iface_builder = iface_builder.ipv4_fragmentation_buffer(vec![]);
 
     let iface = iface_builder.finalize(&mut device);
 
@@ -126,9 +119,7 @@ fn create_ieee802154<'a>() -> (Interface<'a>, SocketSet<'a>, Loopback) {
         .ip_addrs(ip_addrs);
 
     #[cfg(feature = "proto-sixlowpan-fragmentation")]
-    let iface_builder = iface_builder
-        .sixlowpan_reassembly_buffer(PacketAssemblerSet::new(vec![], BTreeMap::new()))
-        .sixlowpan_fragmentation_buffer(vec![]);
+    let iface_builder = iface_builder.sixlowpan_fragmentation_buffer(vec![]);
 
     let iface = iface_builder.finalize(&mut device);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,9 +184,6 @@ pub enum Error {
     /// An incoming fragment arrived too late.
     ReassemblyTimeout,
 
-    /// The packet assembler is not initialized, thus it cannot know what the final size of the
-    /// packet would be.
-    PacketAssemblerNotInit,
     /// The buffer of the assembler is to small and thus the final packet wont fit into it.
     PacketAssemblerBufferTooSmall,
     /// The packet assembler did not receive all the fragments for assembling the final packet.
@@ -226,7 +223,6 @@ impl fmt::Display for Error {
             Error::Malformed => write!(f, "malformed packet"),
             Error::Dropped => write!(f, "dropped by socket"),
             Error::ReassemblyTimeout => write!(f, "incoming fragment arrived too late"),
-            Error::PacketAssemblerNotInit => write!(f, "packet assembler was not initialized"),
             Error::PacketAssemblerBufferTooSmall => {
                 write!(f, "packet assembler buffer too small for final packet")
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,18 +184,6 @@ pub enum Error {
     /// An incoming fragment arrived too late.
     ReassemblyTimeout,
 
-    /// The buffer of the assembler is to small and thus the final packet wont fit into it.
-    PacketAssemblerBufferTooSmall,
-    /// The packet assembler did not receive all the fragments for assembling the final packet.
-    PacketAssemblerIncomplete,
-    /// There are too many holes in the packet assembler (should be fixed in the future?).
-    PacketAssemblerTooManyHoles,
-
-    /// The packet assembler set has no place for assembling a new stream of fragments.
-    PacketAssemblerSetFull,
-    /// The key was not found in the packet assembler set.
-    PacketAssemblerSetKeyNotFound,
-
     /// An incoming packet was recognized but some parts are not supported by smoltcp.
     /// E.g. some bit configuration in a packet header is not supported, but is defined in an RFC.
     NotSupported,
@@ -221,18 +209,6 @@ impl fmt::Display for Error {
             Error::Malformed => write!(f, "malformed packet"),
             Error::Dropped => write!(f, "dropped by socket"),
             Error::ReassemblyTimeout => write!(f, "incoming fragment arrived too late"),
-            Error::PacketAssemblerBufferTooSmall => {
-                write!(f, "packet assembler buffer too small for final packet")
-            }
-            Error::PacketAssemblerIncomplete => write!(f, "packet assembler incomplete"),
-            Error::PacketAssemblerTooManyHoles => write!(
-                f,
-                "packet assembler has too many holes (internal smoltcp error)"
-            ),
-            Error::PacketAssemblerSetFull => write!(f, "packet assembler set is full"),
-            Error::PacketAssemblerSetKeyNotFound => {
-                write!(f, "packet assembler set does not find key")
-            }
             Error::NotSupported => write!(f, "not supported by smoltcp"),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,8 +190,6 @@ pub enum Error {
     PacketAssemblerIncomplete,
     /// There are too many holes in the packet assembler (should be fixed in the future?).
     PacketAssemblerTooManyHoles,
-    /// There was an overlap when adding data to the packet assembler.
-    PacketAssemblerOverlap,
 
     /// The packet assembler set has no place for assembling a new stream of fragments.
     PacketAssemblerSetFull,
@@ -231,9 +229,6 @@ impl fmt::Display for Error {
                 f,
                 "packet assembler has too many holes (internal smoltcp error)"
             ),
-            Error::PacketAssemblerOverlap => {
-                write!(f, "overlap when adding data to packet assembler")
-            }
             Error::PacketAssemblerSetFull => write!(f, "packet assembler set is full"),
             Error::PacketAssemblerSetKeyNotFound => {
                 write!(f, "packet assembler set does not find key")

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1822,7 +1822,8 @@ impl<'a> Socket<'a> {
             }
         }
 
-        if let Some(contig_len) = self.assembler.remove_front() {
+        let contig_len = self.assembler.remove_front();
+        if contig_len != 0 {
             debug_assert!(self.assembler.total_size() == self.rx_buffer.capacity());
             // Enqueue the contiguous data octets in front of the buffer.
             tcp_trace!(

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -454,7 +454,7 @@ impl<'a> Socket<'a> {
             state: State::Closed,
             timer: Timer::new(),
             rtte: RttEstimator::default(),
-            assembler: Assembler::new(rx_buffer.capacity()),
+            assembler: Assembler::new(),
             tx_buffer,
             rx_buffer,
             rx_fin_received: false,
@@ -675,7 +675,7 @@ impl<'a> Socket<'a> {
         self.state = State::Closed;
         self.timer = Timer::new();
         self.rtte = RttEstimator::default();
-        self.assembler = Assembler::new(self.rx_buffer.capacity());
+        self.assembler = Assembler::new();
         self.tx_buffer.clear();
         self.rx_buffer.clear();
         self.rx_fin_received = false;
@@ -1800,7 +1800,6 @@ impl<'a> Socket<'a> {
         // Try adding payload octets to the assembler.
         match self.assembler.add(payload_offset, payload_len) {
             Ok(()) => {
-                debug_assert!(self.assembler.total_size() == self.rx_buffer.capacity());
                 // Place payload octets into the buffer.
                 tcp_trace!(
                     "rx buffer: receiving {} octets at offset {}",
@@ -1824,7 +1823,6 @@ impl<'a> Socket<'a> {
 
         let contig_len = self.assembler.remove_front();
         if contig_len != 0 {
-            debug_assert!(self.assembler.total_size() == self.rx_buffer.capacity());
             // Enqueue the contiguous data octets in front of the buffer.
             tcp_trace!(
                 "rx buffer: enqueueing {} octets (now {})",
@@ -3699,7 +3697,7 @@ mod test {
         // Update our scaling parameters for a TCP with a scaled buffer.
         assert_eq!(s.rx_buffer.len(), 0);
         s.rx_buffer = SocketBuffer::new(vec![0; 262143]);
-        s.assembler = Assembler::new(s.rx_buffer.capacity());
+        s.assembler = Assembler::new();
         s.remote_win_scale = Some(0);
         s.remote_last_win = 65535;
         s.remote_win_shift = 2;
@@ -5850,7 +5848,7 @@ mod test {
     fn test_zero_window_ack() {
         let mut s = socket_established();
         s.rx_buffer = SocketBuffer::new(vec![0; 6]);
-        s.assembler = Assembler::new(s.rx_buffer.capacity());
+        s.assembler = Assembler::new();
         send!(
             s,
             TcpRepr {
@@ -5890,7 +5888,7 @@ mod test {
     fn test_zero_window_ack_on_window_growth() {
         let mut s = socket_established();
         s.rx_buffer = SocketBuffer::new(vec![0; 6]);
-        s.assembler = Assembler::new(s.rx_buffer.capacity());
+        s.assembler = Assembler::new();
         send!(
             s,
             TcpRepr {
@@ -5969,7 +5967,7 @@ mod test {
     fn test_announce_window_after_read() {
         let mut s = socket_established();
         s.rx_buffer = SocketBuffer::new(vec![0; 6]);
-        s.assembler = Assembler::new(s.rx_buffer.capacity());
+        s.assembler = Assembler::new();
         send!(
             s,
             TcpRepr {
@@ -6382,7 +6380,7 @@ mod test {
     fn test_buffer_wraparound_rx() {
         let mut s = socket_established();
         s.rx_buffer = SocketBuffer::new(vec![0; 6]);
-        s.assembler = Assembler::new(s.rx_buffer.capacity());
+        s.assembler = Assembler::new();
         send!(
             s,
             TcpRepr {
@@ -6919,7 +6917,7 @@ mod test {
     fn test_doesnt_accept_wrong_port() {
         let mut s = socket_established();
         s.rx_buffer = SocketBuffer::new(vec![0; 6]);
-        s.assembler = Assembler::new(s.rx_buffer.capacity());
+        s.assembler = Assembler::new();
 
         let tcp_repr = TcpRepr {
             seq_number: REMOTE_SEQ + 1,

--- a/src/storage/assembler.rs
+++ b/src/storage/assembler.rs
@@ -137,12 +137,12 @@ impl Assembler {
     }
 
     /// Return length of the front contiguous range without removing it from the assembler
-    pub fn peek_front(&self) -> Option<usize> {
+    pub fn peek_front(&self) -> usize {
         let front = self.front();
         if front.has_hole() {
-            None
+            0
         } else {
-            Some(front.data_size)
+            front.data_size
         }
     }
 
@@ -250,16 +250,16 @@ impl Assembler {
 
     /// Remove a contiguous range from the front of the assembler and `Some(data_size)`,
     /// or return `None` if there is no such range.
-    pub fn remove_front(&mut self) -> Option<usize> {
+    pub fn remove_front(&mut self) -> usize {
         let front = self.front();
         if front.has_hole() {
-            None
+            0
         } else {
             let last_hole = self.remove_contig_at(0);
             last_hole.hole_size += front.data_size;
 
             debug_assert!(front.data_size > 0);
-            Some(front.data_size)
+            front.data_size
         }
     }
 
@@ -452,20 +452,20 @@ mod test {
     #[test]
     fn test_empty_remove_front() {
         let mut assr = contigs![(12, 0)];
-        assert_eq!(assr.remove_front(), None);
+        assert_eq!(assr.remove_front(), 0);
     }
 
     #[test]
     fn test_trailing_hole_remove_front() {
         let mut assr = contigs![(0, 4), (8, 0)];
-        assert_eq!(assr.remove_front(), Some(4));
+        assert_eq!(assr.remove_front(), 4);
         assert_eq!(assr, contigs![(12, 0)]);
     }
 
     #[test]
     fn test_trailing_data_remove_front() {
         let mut assr = contigs![(0, 4), (4, 4)];
-        assert_eq!(assr.remove_front(), Some(4));
+        assert_eq!(assr.remove_front(), 4);
         assert_eq!(assr, contigs![(4, 4), (4, 0)]);
     }
 
@@ -474,7 +474,7 @@ mod test {
         let mut vec = vec![(1, 1); CONTIG_COUNT];
         vec[0] = (0, 2);
         let mut assr = Assembler::from(vec);
-        assert_eq!(assr.remove_front(), Some(2));
+        assert_eq!(assr.remove_front(), 2);
         let mut vec = vec![(1, 1); CONTIG_COUNT];
         vec[CONTIG_COUNT - 1] = (2, 0);
         let exp_assr = Assembler::from(vec);

--- a/src/storage/assembler.rs
+++ b/src/storage/assembler.rs
@@ -114,6 +114,10 @@ impl Assembler {
         Assembler { contigs }
     }
 
+    pub fn clear(&mut self) {
+        self.contigs.fill(Contig::empty());
+    }
+
     fn front(&self) -> Contig {
         self.contigs[0]
     }

--- a/src/storage/assembler.rs
+++ b/src/storage/assembler.rs
@@ -34,13 +34,6 @@ impl Contig {
         }
     }
 
-    fn hole(size: usize) -> Contig {
-        Contig {
-            hole_size: size,
-            data_size: 0,
-        }
-    }
-
     fn hole_and_data(hole_size: usize, data_size: usize) -> Contig {
         Contig {
             hole_size,
@@ -58,14 +51,6 @@ impl Contig {
 
     fn total_size(&self) -> usize {
         self.hole_size + self.data_size
-    }
-
-    fn is_empty(&self) -> bool {
-        self.total_size() == 0
-    }
-
-    fn expand_data_by(&mut self, size: usize) {
-        self.data_size += size;
     }
 
     fn shrink_hole_by(&mut self, size: usize) {
@@ -105,7 +90,7 @@ impl fmt::Display for Assembler {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "[ ")?;
         for contig in self.contigs.iter() {
-            if contig.is_empty() {
+            if !contig.has_data() {
                 break;
             }
             write!(f, "{contig} ")?;
@@ -115,21 +100,18 @@ impl fmt::Display for Assembler {
     }
 }
 
-impl Assembler {
-    /// Create a new buffer assembler for buffers of the given size.
-    pub fn new(size: usize) -> Assembler {
-        #[cfg(not(feature = "alloc"))]
-        let mut contigs = [Contig::empty(); CONTIG_COUNT];
-        #[cfg(feature = "alloc")]
-        let mut contigs = Box::new([Contig::empty(); CONTIG_COUNT]);
-        contigs[0] = Contig::hole(size);
-        Assembler { contigs }
-    }
+// Invariant on Assembler::contigs:
+// - There's an index `i` where all contigs before have data, and all contigs after don't (are unused).
+// - All contigs with data must have hole_size != 0, except the first.
 
-    /// FIXME(whitequark): remove this once I'm certain enough that the assembler works well.
-    #[allow(dead_code)]
-    pub(crate) fn total_size(&self) -> usize {
-        self.contigs.iter().map(|contig| contig.total_size()).sum()
+impl Assembler {
+    /// Create a new buffer assembler.
+    pub fn new() -> Assembler {
+        #[cfg(not(feature = "alloc"))]
+        let contigs = [Contig::empty(); CONTIG_COUNT];
+        #[cfg(feature = "alloc")]
+        let contigs = Box::new([Contig::empty(); CONTIG_COUNT]);
+        Assembler { contigs }
     }
 
     fn front(&self) -> Contig {
@@ -155,30 +137,24 @@ impl Assembler {
         !self.front().has_data()
     }
 
-    /// Remove a contig at the given index, and return a pointer to the first contig
-    /// without data.
-    fn remove_contig_at(&mut self, at: usize) -> &mut Contig {
-        debug_assert!(!self.contigs[at].is_empty());
+    /// Remove a contig at the given index.
+    fn remove_contig_at(&mut self, at: usize) {
+        debug_assert!(self.contigs[at].has_data());
 
         for i in at..self.contigs.len() - 1 {
-            self.contigs[i] = self.contigs[i + 1];
             if !self.contigs[i].has_data() {
-                self.contigs[i + 1] = Contig::empty();
-                return &mut self.contigs[i];
+                return;
             }
+            self.contigs[i] = self.contigs[i + 1];
         }
 
         // Removing the last one.
-        let p = &mut self.contigs[self.contigs.len() - 1];
-        *p = Contig::empty();
-        p
+        self.contigs[self.contigs.len() - 1] = Contig::empty();
     }
 
     /// Add a contig at the given index, and return a pointer to it.
     fn add_contig_at(&mut self, at: usize) -> Result<&mut Contig, TooManyHolesError> {
-        debug_assert!(!self.contigs[at].is_empty());
-
-        if !self.back().is_empty() {
+        if self.back().has_data() {
             return Err(TooManyHolesError);
         }
 
@@ -192,59 +168,82 @@ impl Assembler {
 
     /// Add a new contiguous range to the assembler, and return `Ok(bool)`,
     /// or return `Err(TooManyHolesError)` if too many discontiguities are already recorded.
-    pub fn add(&mut self, mut offset: usize, mut size: usize) -> Result<(), TooManyHolesError> {
-        let mut index = 0;
-        while index != self.contigs.len() && size != 0 {
-            let contig = self.contigs[index];
+    pub fn add(&mut self, mut offset: usize, size: usize) -> Result<(), TooManyHolesError> {
+        if size == 0 {
+            return Ok(());
+        }
 
-            if offset >= contig.total_size() {
-                // The range being added does not cover this contig, skip it.
-                index += 1;
-            } else if offset == 0 && size >= contig.hole_size && index > 0 {
-                // The range being added covers the entire hole in this contig, merge it
-                // into the previous config.
-                self.contigs[index - 1].expand_data_by(contig.total_size());
-                self.remove_contig_at(index);
-                index += 0;
-            } else if offset == 0 && size < contig.hole_size && index > 0 {
-                // The range being added covers a part of the hole in this contig starting
-                // at the beginning, shrink the hole in this contig and expand data in
-                // the previous contig.
-                self.contigs[index - 1].expand_data_by(size);
-                self.contigs[index].shrink_hole_by(size);
-                index += 1;
-            } else if offset <= contig.hole_size && offset + size >= contig.hole_size {
-                // The range being added covers both a part of the hole and a part of the data
-                // in this contig, shrink the hole in this contig.
-                self.contigs[index].shrink_hole_to(offset);
-                index += 1;
-            } else if offset + size >= contig.hole_size {
-                // The range being added covers only a part of the data in this contig, skip it.
-                index += 1;
-            } else if offset + size < contig.hole_size {
-                // The range being added covers a part of the hole but not of the data
-                // in this contig, add a new contig containing the range.
-                {
-                    let inserted = self.add_contig_at(index)?;
-                    *inserted = Contig::hole_and_data(offset, size);
-                }
+        let mut i = 0;
+
+        // Find index of the contig containing the start of the range.
+        loop {
+            if i == self.contigs.len() {
+                // The new range is after all the previous ranges, but there/s no space to add it.
+                return Err(TooManyHolesError);
+            }
+            let contig = &mut self.contigs[i];
+            if !contig.has_data() {
+                // The new range is after all the previous ranges. Add it.
+                *contig = Contig::hole_and_data(offset, size);
+                return Ok(());
+            }
+            if offset <= contig.total_size() {
+                break;
+            }
+            offset -= contig.total_size();
+            i += 1;
+        }
+
+        let contig = &mut self.contigs[i];
+        if offset < contig.hole_size {
+            // Range starts within the hole.
+
+            if offset + size < contig.hole_size {
+                // Range also ends within the hole.
+                let new_contig = self.add_contig_at(i)?;
+                new_contig.hole_size = offset;
+                new_contig.data_size = size;
+
                 // Previous contigs[index] got moved to contigs[index+1]
-                self.contigs[index + 1].shrink_hole_by(offset + size);
-                index += 2;
-            } else {
-                unreachable!()
+                self.contigs[i + 1].shrink_hole_by(offset + size);
+                return Ok(());
             }
 
-            // Skip the portion of the range covered by this contig.
-            if offset >= contig.total_size() {
-                offset = offset.saturating_sub(contig.total_size());
-            } else {
-                size = (offset + size).saturating_sub(contig.total_size());
-                offset = 0;
+            // The range being added covers both a part of the hole and a part of the data
+            // in this contig, shrink the hole in this contig.
+            contig.shrink_hole_to(offset);
+        }
+
+        // coalesce contigs to the right.
+        let mut j = i + 1;
+        while j < self.contigs.len()
+            && self.contigs[j].has_data()
+            && offset + size >= self.contigs[i].total_size() + self.contigs[j].hole_size
+        {
+            self.contigs[i].data_size += self.contigs[j].total_size();
+            j += 1;
+        }
+        let shift = j - i - 1;
+        if shift != 0 {
+            for x in i + 1..self.contigs.len() - shift {
+                if !self.contigs[x].has_data() {
+                    break;
+                }
+                self.contigs[x] = self.contigs[x + shift];
             }
         }
 
-        debug_assert!(size == 0);
+        if offset + size > self.contigs[i].total_size() {
+            // The added range still extends beyond the current contig. Increase data size.
+            let left = offset + size - self.contigs[i].total_size();
+            self.contigs[i].data_size += left;
+
+            // Decrease hole size of the next, if any.
+            if i + 1 < self.contigs.len() && self.contigs[i + 1].has_data() {
+                self.contigs[i + 1].hole_size -= left;
+            }
+        }
+
         Ok(())
     }
 
@@ -252,12 +251,10 @@ impl Assembler {
     /// or return `None` if there is no such range.
     pub fn remove_front(&mut self) -> usize {
         let front = self.front();
-        if front.has_hole() {
+        if front.has_hole() || !front.has_data() {
             0
         } else {
-            let last_hole = self.remove_contig_at(0);
-            last_hole.hole_size += front.data_size;
-
+            self.remove_contig_at(0);
             debug_assert!(front.data_size > 0);
             front.data_size
         }
@@ -348,99 +345,98 @@ mod test {
 
     #[test]
     fn test_new() {
-        let assr = Assembler::new(16);
-        assert_eq!(assr.total_size(), 16);
-        assert_eq!(assr, contigs![(16, 0)]);
+        let assr = Assembler::new();
+        assert_eq!(assr, contigs![]);
     }
 
     #[test]
     fn test_empty_add_full() {
-        let mut assr = Assembler::new(16);
+        let mut assr = Assembler::new();
         assert_eq!(assr.add(0, 16), Ok(()));
         assert_eq!(assr, contigs![(0, 16)]);
     }
 
     #[test]
     fn test_empty_add_front() {
-        let mut assr = Assembler::new(16);
+        let mut assr = Assembler::new();
         assert_eq!(assr.add(0, 4), Ok(()));
-        assert_eq!(assr, contigs![(0, 4), (12, 0)]);
+        assert_eq!(assr, contigs![(0, 4)]);
     }
 
     #[test]
     fn test_empty_add_back() {
-        let mut assr = Assembler::new(16);
+        let mut assr = Assembler::new();
         assert_eq!(assr.add(12, 4), Ok(()));
         assert_eq!(assr, contigs![(12, 4)]);
     }
 
     #[test]
     fn test_empty_add_mid() {
-        let mut assr = Assembler::new(16);
+        let mut assr = Assembler::new();
         assert_eq!(assr.add(4, 8), Ok(()));
-        assert_eq!(assr, contigs![(4, 8), (4, 0)]);
+        assert_eq!(assr, contigs![(4, 8)]);
     }
 
     #[test]
     fn test_partial_add_front() {
-        let mut assr = contigs![(4, 8), (4, 0)];
+        let mut assr = contigs![(4, 8)];
         assert_eq!(assr.add(0, 4), Ok(()));
-        assert_eq!(assr, contigs![(0, 12), (4, 0)]);
+        assert_eq!(assr, contigs![(0, 12)]);
     }
 
     #[test]
     fn test_partial_add_back() {
-        let mut assr = contigs![(4, 8), (4, 0)];
+        let mut assr = contigs![(4, 8)];
         assert_eq!(assr.add(12, 4), Ok(()));
         assert_eq!(assr, contigs![(4, 12)]);
     }
 
     #[test]
     fn test_partial_add_front_overlap() {
-        let mut assr = contigs![(4, 8), (4, 0)];
+        let mut assr = contigs![(4, 8)];
         assert_eq!(assr.add(0, 8), Ok(()));
-        assert_eq!(assr, contigs![(0, 12), (4, 0)]);
+        assert_eq!(assr, contigs![(0, 12)]);
     }
 
     #[test]
     fn test_partial_add_front_overlap_split() {
-        let mut assr = contigs![(4, 8), (4, 0)];
+        let mut assr = contigs![(4, 8)];
         assert_eq!(assr.add(2, 6), Ok(()));
-        assert_eq!(assr, contigs![(2, 10), (4, 0)]);
+        assert_eq!(assr, contigs![(2, 10)]);
     }
 
     #[test]
     fn test_partial_add_back_overlap() {
-        let mut assr = contigs![(4, 8), (4, 0)];
+        let mut assr = contigs![(4, 8)];
         assert_eq!(assr.add(8, 8), Ok(()));
         assert_eq!(assr, contigs![(4, 12)]);
     }
 
     #[test]
     fn test_partial_add_back_overlap_split() {
-        let mut assr = contigs![(4, 8), (4, 0)];
+        let mut assr = contigs![(4, 8)];
         assert_eq!(assr.add(10, 4), Ok(()));
-        assert_eq!(assr, contigs![(4, 10), (2, 0)]);
+        assert_eq!(assr, contigs![(4, 10)]);
     }
 
     #[test]
     fn test_partial_add_both_overlap() {
-        let mut assr = contigs![(4, 8), (4, 0)];
+        let mut assr = contigs![(4, 8)];
         assert_eq!(assr.add(0, 16), Ok(()));
         assert_eq!(assr, contigs![(0, 16)]);
     }
 
     #[test]
     fn test_partial_add_both_overlap_split() {
-        let mut assr = contigs![(4, 8), (4, 0)];
+        let mut assr = contigs![(4, 8)];
         assert_eq!(assr.add(2, 12), Ok(()));
-        assert_eq!(assr, contigs![(2, 12), (2, 0)]);
+        assert_eq!(assr, contigs![(2, 12)]);
     }
 
     #[test]
     fn test_rejected_add_keeps_state() {
-        let mut assr = Assembler::new(CONTIG_COUNT * 20);
-        for c in 1..=CONTIG_COUNT - 1 {
+        let mut assr = Assembler::new();
+        for c in 1..=CONTIG_COUNT {
             assert_eq!(assr.add(c * 10, 3), Ok(()));
         }
         // Maximum of allowed holes is reached
@@ -451,22 +447,22 @@ mod test {
 
     #[test]
     fn test_empty_remove_front() {
-        let mut assr = contigs![(12, 0)];
+        let mut assr = contigs![];
         assert_eq!(assr.remove_front(), 0);
     }
 
     #[test]
     fn test_trailing_hole_remove_front() {
-        let mut assr = contigs![(0, 4), (8, 0)];
+        let mut assr = contigs![(0, 4)];
         assert_eq!(assr.remove_front(), 4);
-        assert_eq!(assr, contigs![(12, 0)]);
+        assert_eq!(assr, contigs![]);
     }
 
     #[test]
     fn test_trailing_data_remove_front() {
         let mut assr = contigs![(0, 4), (4, 4)];
         assert_eq!(assr.remove_front(), 4);
-        assert_eq!(assr, contigs![(4, 4), (4, 0)]);
+        assert_eq!(assr, contigs![(4, 4)]);
     }
 
     #[test]
@@ -476,21 +472,57 @@ mod test {
         let mut assr = Assembler::from(vec);
         assert_eq!(assr.remove_front(), 2);
         let mut vec = vec![(1, 1); CONTIG_COUNT];
-        vec[CONTIG_COUNT - 1] = (2, 0);
+        vec[CONTIG_COUNT - 1] = (0, 0);
         let exp_assr = Assembler::from(vec);
         assert_eq!(assr, exp_assr);
     }
 
     #[test]
+    fn test_shrink_next_hole() {
+        let mut assr = Assembler::new();
+        assert_eq!(assr.add(100, 10), Ok(()));
+        assert_eq!(assr.add(50, 10), Ok(()));
+        assert_eq!(assr.add(40, 30), Ok(()));
+        assert_eq!(assr, contigs![(40, 30), (30, 10)]);
+    }
+
+    #[test]
+    fn test_join_two() {
+        let mut assr = Assembler::new();
+        assert_eq!(assr.add(10, 10), Ok(()));
+        assert_eq!(assr.add(50, 10), Ok(()));
+        assert_eq!(assr.add(15, 40), Ok(()));
+        assert_eq!(assr, contigs![(10, 50)]);
+    }
+
+    #[test]
+    fn test_join_two_reversed() {
+        let mut assr = Assembler::new();
+        assert_eq!(assr.add(50, 10), Ok(()));
+        assert_eq!(assr.add(10, 10), Ok(()));
+        assert_eq!(assr.add(15, 40), Ok(()));
+        assert_eq!(assr, contigs![(10, 50)]);
+    }
+
+    #[test]
+    fn test_join_two_overlong() {
+        let mut assr = Assembler::new();
+        assert_eq!(assr.add(50, 10), Ok(()));
+        assert_eq!(assr.add(10, 10), Ok(()));
+        assert_eq!(assr.add(15, 60), Ok(()));
+        assert_eq!(assr, contigs![(10, 65)]);
+    }
+
+    #[test]
     fn test_iter_empty() {
-        let assr = Assembler::new(16);
+        let assr = Assembler::new();
         let segments: Vec<_> = assr.iter_data(10).collect();
         assert_eq!(segments, vec![]);
     }
 
     #[test]
     fn test_iter_full() {
-        let mut assr = Assembler::new(16);
+        let mut assr = Assembler::new();
         assert_eq!(assr.add(0, 16), Ok(()));
         let segments: Vec<_> = assr.iter_data(10).collect();
         assert_eq!(segments, vec![(10, 26)]);
@@ -498,7 +530,7 @@ mod test {
 
     #[test]
     fn test_iter_offset() {
-        let mut assr = Assembler::new(16);
+        let mut assr = Assembler::new();
         assert_eq!(assr.add(0, 16), Ok(()));
         let segments: Vec<_> = assr.iter_data(100).collect();
         assert_eq!(segments, vec![(100, 116)]);
@@ -506,7 +538,7 @@ mod test {
 
     #[test]
     fn test_iter_one_front() {
-        let mut assr = Assembler::new(16);
+        let mut assr = Assembler::new();
         assert_eq!(assr.add(0, 4), Ok(()));
         let segments: Vec<_> = assr.iter_data(10).collect();
         assert_eq!(segments, vec![(10, 14)]);
@@ -514,7 +546,7 @@ mod test {
 
     #[test]
     fn test_iter_one_back() {
-        let mut assr = Assembler::new(16);
+        let mut assr = Assembler::new();
         assert_eq!(assr.add(12, 4), Ok(()));
         let segments: Vec<_> = assr.iter_data(10).collect();
         assert_eq!(segments, vec![(22, 26)]);
@@ -522,7 +554,7 @@ mod test {
 
     #[test]
     fn test_iter_one_mid() {
-        let mut assr = Assembler::new(16);
+        let mut assr = Assembler::new();
         assert_eq!(assr.add(4, 8), Ok(()));
         let segments: Vec<_> = assr.iter_data(10).collect();
         assert_eq!(segments, vec![(14, 22)]);
@@ -530,30 +562,83 @@ mod test {
 
     #[test]
     fn test_iter_one_trailing_gap() {
-        let assr = contigs![(4, 8), (4, 0)];
+        let assr = contigs![(4, 8)];
         let segments: Vec<_> = assr.iter_data(100).collect();
         assert_eq!(segments, vec![(104, 112)]);
     }
 
     #[test]
     fn test_iter_two_split() {
-        let assr = contigs![(2, 6), (4, 1), (1, 0)];
+        let assr = contigs![(2, 6), (4, 1)];
         let segments: Vec<_> = assr.iter_data(100).collect();
         assert_eq!(segments, vec![(102, 108), (112, 113)]);
     }
 
     #[test]
     fn test_iter_three_split() {
-        let assr = contigs![(2, 6), (2, 1), (2, 2), (1, 0)];
+        let assr = contigs![(2, 6), (2, 1), (2, 2)];
         let segments: Vec<_> = assr.iter_data(100).collect();
         assert_eq!(segments, vec![(102, 108), (110, 111), (113, 115)]);
     }
 
     #[test]
     fn test_issue_694() {
-        let mut assr = Assembler::new(16);
+        let mut assr = Assembler::new();
         assert_eq!(assr.add(0, 1), Ok(()));
         assert_eq!(assr.add(2, 1), Ok(()));
         assert_eq!(assr.add(1, 1), Ok(()));
+    }
+
+    // Test against an obviously-correct but inefficient bitmap impl.
+    #[test]
+    fn test_random() {
+        use rand::Rng;
+
+        for _ in 0..1000 {
+            println!("===");
+            let mut assr = Assembler::new();
+            let mut map = [false; 128];
+
+            for _ in 0..30 {
+                let offset = rand::thread_rng().gen_range(0..80);
+                let size = rand::thread_rng().gen_range(0..47);
+
+                println!("add {}..{} {}", offset, offset + size, size);
+                // Real impl
+                let res = assr.add(offset, size);
+
+                // Bitmap impl
+                let mut map2 = map;
+                map2[offset..][..size].fill(true);
+
+                let mut contigs = vec![];
+                let mut hole: usize = 0;
+                let mut data: usize = 0;
+                for b in map2 {
+                    if b {
+                        data += 1;
+                    } else {
+                        if data != 0 {
+                            contigs.push((hole, data));
+                            hole = 0;
+                            data = 0;
+                        }
+                        hole += 1;
+                    }
+                }
+
+                // Compare.
+                let wanted_res = if contigs.len() > CONTIG_COUNT {
+                    Err(TooManyHolesError)
+                } else {
+                    Ok(())
+                };
+                assert_eq!(res, wanted_res);
+                if res.is_ok() {
+                    map = map2;
+                    assert_eq!(assr, Assembler::from(contigs));
+                }
+            }
+        }
     }
 }

--- a/src/wire/sixlowpan.rs
+++ b/src/wire/sixlowpan.rs
@@ -2139,9 +2139,6 @@ pub mod nhc {
 
 #[cfg(test)]
 mod test {
-    use crate::phy::ChecksumCapabilities;
-    use crate::time::Duration;
-
     use super::*;
 
     #[test]
@@ -2178,13 +2175,16 @@ mod test {
 
     #[test]
     fn sixlowpan_three_fragments() {
-        use crate::iface::ReassemblyBuffer;
-        use crate::time::Instant;
         use crate::wire::ieee802154::Frame as Ieee802154Frame;
         use crate::wire::ieee802154::Repr as Ieee802154Repr;
         use crate::wire::Ieee802154Address;
 
-        let mut frags_cache = ReassemblyBuffer::new();
+        let key = frag::Key {
+            ll_src_addr: Ieee802154Address::Extended([50, 147, 130, 47, 40, 8, 62, 217]),
+            ll_dst_addr: Ieee802154Address::Extended([26, 11, 66, 66, 66, 66, 66, 66]),
+            datagram_size: 307,
+            datagram_tag: 63,
+        };
 
         let frame1: &[u8] = &[
             0x41, 0xcc, 0x92, 0xef, 0xbe, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x0b, 0x1a, 0xd9,
@@ -2214,18 +2214,7 @@ mod test {
         assert_eq!(frag.datagram_tag(), 0x003f);
         assert_eq!(frag.datagram_offset(), 0);
 
-        let key = frag.get_key(&ieee802154_repr);
-
-        let uncompressed = 40 + 8;
-        let compressed = 5 + 7;
-
-        let assr = frags_cache
-            .get(&key, Instant::now() + Duration::from_secs(60))
-            .unwrap();
-        assr.set_total_size(frag.datagram_size() as usize - uncompressed + compressed)
-            .unwrap();
-        assr.set_offset_correction(-((uncompressed - compressed) as isize));
-        assr.add(frag.payload(), 0).unwrap();
+        assert_eq!(frag.get_key(&ieee802154_repr), key);
 
         let frame2: &[u8] = &[
             0x41, 0xcc, 0x93, 0xef, 0xbe, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x0b, 0x1a, 0xd9,
@@ -2255,13 +2244,7 @@ mod test {
         assert_eq!(frag.datagram_tag(), 0x003f);
         assert_eq!(frag.datagram_offset(), 136 / 8);
 
-        let key = frag.get_key(&ieee802154_repr);
-
-        let assr = frags_cache
-            .get(&key, Instant::now() + Duration::from_secs(60))
-            .unwrap();
-        assr.add(frag.payload(), frag.datagram_offset() as usize * 8)
-            .unwrap();
+        assert_eq!(frag.get_key(&ieee802154_repr), key);
 
         let frame3: &[u8] = &[
             0x41, 0xcc, 0x94, 0xef, 0xbe, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x0b, 0x1a, 0xd9,
@@ -2290,69 +2273,6 @@ mod test {
         assert_eq!(frag.datagram_tag(), 0x003f);
         assert_eq!(frag.datagram_offset(), 232 / 8);
 
-        let key = frag.get_key(&ieee802154_repr);
-
-        let assr = frags_cache
-            .get(&key, Instant::now() + Duration::from_secs(60))
-            .unwrap();
-        assr.add(frag.payload(), frag.datagram_offset() as usize * 8)
-            .unwrap();
-
-        let assembled_packet = assr.assemble().unwrap();
-
-        let sixlowpan_frame = SixlowpanPacket::dispatch(assembled_packet).unwrap();
-
-        let iphc = if let SixlowpanPacket::IphcHeader = sixlowpan_frame {
-            iphc::Packet::new_checked(assembled_packet).unwrap()
-        } else {
-            unreachable!()
-        };
-
-        let iphc_repr = iphc::Repr::parse(
-            &iphc,
-            ieee802154_repr.src_addr,
-            ieee802154_repr.dst_addr,
-            &[],
-        )
-        .unwrap();
-
-        assert_eq!(
-            iphc_repr.dst_addr,
-            ipv6::Address::from_bytes(&[
-                0xfe, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x18, 0xb, 0x42, 0x42, 0x42, 0x42, 0x42,
-                0x42,
-            ]),
-        );
-        assert_eq!(
-            iphc_repr.ll_dst_addr,
-            Some(Ieee802154Address::from_bytes(&[
-                0x1a, 0xb, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42,
-            ])),
-        );
-        assert_eq!(iphc_repr.next_header, NextHeader::Compressed);
-        assert_eq!(iphc_repr.hop_limit, 64);
-
-        let sixlowpan_frame = nhc::NhcPacket::dispatch(iphc.payload()).unwrap();
-
-        let udp_hdr = if let nhc::NhcPacket::UdpHeader = sixlowpan_frame {
-            nhc::UdpNhcPacket::new_checked(iphc.payload()).unwrap()
-        } else {
-            unreachable!()
-        };
-
-        let payload = udp_hdr.payload();
-        assert_eq!(String::from_utf8_lossy(payload), "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam dui odio, iaculis vel rutrum at, tristique non nunc erat curae. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam dui odio, iaculis vel rutrum at, tristique non nunc erat curae. \n");
-
-        let udp_repr = nhc::UdpNhcRepr::parse(
-            &udp_hdr,
-            &iphc_repr.src_addr,
-            &iphc_repr.dst_addr,
-            &ChecksumCapabilities::default(),
-        )
-        .unwrap();
-
-        assert_eq!(udp_repr.src_port, 53855);
-        assert_eq!(udp_repr.dst_port, 6969);
-        assert_eq!(udp_hdr.checksum(), Some(0xb46b));
+        assert_eq!(frag.get_key(&ieee802154_repr), key);
     }
 }

--- a/src/wire/sixlowpan.rs
+++ b/src/wire/sixlowpan.rs
@@ -230,10 +230,10 @@ pub mod frag {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct Key {
-        ll_src_addr: Ieee802154Address,
-        ll_dst_addr: Ieee802154Address,
-        datagram_size: u16,
-        datagram_tag: u16,
+        pub(crate) ll_src_addr: Ieee802154Address,
+        pub(crate) ll_dst_addr: Ieee802154Address,
+        pub(crate) datagram_size: u16,
+        pub(crate) datagram_tag: u16,
     }
 
     /// A read/write wrapper around a 6LoWPAN Fragment header.

--- a/src/wire/udp.rs
+++ b/src/wire/udp.rs
@@ -251,27 +251,18 @@ impl Repr {
     }
 
     /// Emit a high-level representation into an User Datagram Protocol packet.
-    pub fn emit_header<T: ?Sized>(
-        &self,
-        packet: &mut Packet<&mut T>,
-        src_addr: &IpAddress,
-        dst_addr: &IpAddress,
-        payload_len: usize,
-        checksum_caps: &ChecksumCapabilities,
-    ) where
+    ///
+    /// This never calculates the checksum, and is intended for internal-use only,
+    /// not for packets that are going to be actually sent over the network. For
+    /// example, when decompressing 6lowpan.
+    pub(crate) fn emit_header<T: ?Sized>(&self, packet: &mut Packet<&mut T>, payload_len: usize)
+    where
         T: AsRef<[u8]> + AsMut<[u8]>,
     {
         packet.set_src_port(self.src_port);
         packet.set_dst_port(self.dst_port);
         packet.set_len((HEADER_LEN + payload_len) as u16);
-
-        if checksum_caps.udp.tx() {
-            packet.fill_checksum(src_addr, dst_addr)
-        } else {
-            // make sure we get a consistently zeroed checksum,
-            // since implementations might rely on it
-            packet.set_checksum(0);
-        }
+        packet.set_checksum(0);
     }
 
     /// Emit a high-level representation into an User Datagram Protocol packet.


### PR DESCRIPTION
Some refactors trying to simplify the data structures and API for the assemblers. See individual commit messages for details.

@thvdveld since you wrote the original code: Could you take a look? Is there anything I might have missed?

One thing that's wrong for now is the offset correction. Previously, the PacketAssembler was initialized when receiving the first fragment, with the right offset correction, and non-first fragments were discarded if they arrived first. The new API has only `.get()` which creates the assembler if it doesn't exist, so now non-first fragments will still be processed, but with the wrong offset correction. This is a problem, because only the first packet has enough info to learn the offset correction, right? Perhaps what we're supposed to do is decompress the headers before writing them to the assembler? 