### PR TITLE
Add peek and peek_slice functions to RawSocket

### DIFF
--- a/src/socket/raw.rs
+++ b/src/socket/raw.rs
@@ -566,6 +566,22 @@ mod test {
                     assert!(socket.accepts(&$hdr));
                     socket.process(&mut cx, &$hdr, &buffer);
                 }
+
+                #[test]
+                fn test_peek_truncated_slice() {
+                    let mut socket = $socket(buffer(1), buffer(0));
+                    let mut cx = Context::mock();
+
+                    assert!(socket.accepts(&$hdr));
+                    socket.process(&mut cx, &$hdr, &$payload);
+
+                    let mut slice = [0; 4];
+                    assert_eq!(socket.peek_slice(&mut slice[..]), Ok(4));
+                    assert_eq!(&slice, &$packet[..slice.len()]);
+                    assert_eq!(socket.recv_slice(&mut slice[..]), Ok(4));
+                    assert_eq!(&slice, &$packet[..slice.len()]);
+                    assert_eq!(socket.peek_slice(&mut slice[..]), Err(RecvError::Exhausted));
+                }
             }
         };
     }
@@ -691,6 +707,59 @@ mod test {
             );
             assert_eq!(socket.recv(), Ok(&ipv6_locals::PACKET_BYTES[..]));
             assert!(!socket.can_recv());
+        }
+    }
+
+    #[test]
+    fn test_peek_process() {
+        #[cfg(feature = "proto-ipv4")]
+        {
+            let mut socket = ipv4_locals::socket(buffer(1), buffer(0));
+            let mut cx = Context::mock();
+
+            let mut cksumd_packet = ipv4_locals::PACKET_BYTES;
+            Ipv4Packet::new_unchecked(&mut cksumd_packet).fill_checksum();
+
+            assert_eq!(socket.peek(), Err(RecvError::Exhausted));
+            assert!(socket.accepts(&ipv4_locals::HEADER_REPR));
+            socket.process(
+                &mut cx,
+                &ipv4_locals::HEADER_REPR,
+                &ipv4_locals::PACKET_PAYLOAD,
+            );
+
+            assert!(socket.accepts(&ipv4_locals::HEADER_REPR));
+            socket.process(
+                &mut cx,
+                &ipv4_locals::HEADER_REPR,
+                &ipv4_locals::PACKET_PAYLOAD,
+            );
+            assert_eq!(socket.peek(), Ok(&cksumd_packet[..]));
+            assert_eq!(socket.recv(), Ok(&cksumd_packet[..]));
+            assert_eq!(socket.peek(), Err(RecvError::Exhausted));
+        }
+        #[cfg(feature = "proto-ipv6")]
+        {
+            let mut socket = ipv6_locals::socket(buffer(1), buffer(0));
+            let mut cx = Context::mock();
+
+            assert_eq!(socket.peek(), Err(RecvError::Exhausted));
+            assert!(socket.accepts(&ipv6_locals::HEADER_REPR));
+            socket.process(
+                &mut cx,
+                &ipv6_locals::HEADER_REPR,
+                &ipv6_locals::PACKET_PAYLOAD,
+            );
+
+            assert!(socket.accepts(&ipv6_locals::HEADER_REPR));
+            socket.process(
+                &mut cx,
+                &ipv6_locals::HEADER_REPR,
+                &ipv6_locals::PACKET_PAYLOAD,
+            );
+            assert_eq!(socket.peek(), Ok(&ipv6_locals::PACKET_BYTES[..]));
+            assert_eq!(socket.recv(), Ok(&ipv6_locals::PACKET_BYTES[..]));
+            assert_eq!(socket.peek(), Err(RecvError::Exhausted));
         }
     }
 

--- a/src/socket/raw.rs
+++ b/src/socket/raw.rs
@@ -253,18 +253,16 @@ impl<'a> Socket<'a> {
     ///
     /// It returns `Err(Error::Exhausted)` if the receive buffer is empty.
     pub fn peek(&mut self) -> Result<&[u8], RecvError> {
-        self.rx_buffer
-            .peek()
-            .map_err(|_| RecvError::Exhausted)
-            .map(|((), payload_buf)| {
-                net_trace!(
-                    "raw:{}:{}: peek {} buffered octets",
-                    self.ip_version,
-                    self.ip_protocol,
-                    payload_buf.len()
-                );
-                payload_buf
-            })
+        let ((), packet_buf) = self.rx_buffer.peek().map_err(|_| RecvError::Exhausted)?;
+
+        net_trace!(
+            "raw:{}:{}: receive {} buffered octets",
+            self.ip_version,
+            self.ip_protocol,
+            packet_buf.len()
+        );
+
+        Ok(packet_buf)
     }
 
     /// Peek at a packet in the receive buffer, copy the payload into the given slice,

--- a/src/socket/raw.rs
+++ b/src/socket/raw.rs
@@ -253,8 +253,10 @@ impl<'a> Socket<'a> {
     ///
     /// It returns `Err(Error::Exhausted)` if the receive buffer is empty.
     pub fn peek(&mut self) -> Result<&[u8], RecvError> {
-        self.rx_buffer.peek().map_err(|_| RecvError::Exhausted).map(
-            |((), payload_buf)| {
+        self.rx_buffer
+            .peek()
+            .map_err(|_| RecvError::Exhausted)
+            .map(|((), payload_buf)| {
                 net_trace!(
                     "raw:{}:{}: peek {} buffered octets",
                     self.ip_version,
@@ -262,8 +264,7 @@ impl<'a> Socket<'a> {
                     payload_buf.len()
                 );
                 payload_buf
-            },
-        )
+            })
     }
 
     /// Peek at a packet in the receive buffer, copy the payload into the given slice,


### PR DESCRIPTION
This adds the `peek` and `peek_slice` functions to raw sockets, same as was added to UDP sockets in #278 