### PR TITLE
iface: unify ipv4/6lowpan fragmentation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,12 +45,12 @@ defmt = [ "dep:defmt", "heapless/defmt", "heapless/defmt-impl" ]
 "phy-tuntap_interface" = ["std", "libc", "medium-ethernet"]
 
 "proto-ipv4" = []
-"proto-ipv4-fragmentation" = ["proto-ipv4"]
+"proto-ipv4-fragmentation" = ["proto-ipv4", "_proto-fragmentation"]
 "proto-igmp" = ["proto-ipv4"]
 "proto-dhcpv4" = ["proto-ipv4"]
 "proto-ipv6" = []
 "proto-sixlowpan" = ["proto-ipv6"]
-"proto-sixlowpan-fragmentation" = ["proto-sixlowpan"]
+"proto-sixlowpan-fragmentation" = ["proto-sixlowpan", "_proto-fragmentation"]
 "proto-dns" = []
 
 "socket" = []
@@ -73,6 +73,12 @@ default = [
   "socket-raw", "socket-icmp", "socket-udp", "socket-tcp", "socket-dhcpv4", "socket-dns", "socket-mdns",
   "async"
 ]
+
+# Private features
+# Features starting with "_" are considered private. They should not be enabled by 
+# other crates, and they are not considered semver-stable.
+
+"_proto-fragmentation" = []
 
 [[example]]
 name = "packet2pcap"

--- a/src/iface/interface/ethernet.rs
+++ b/src/iface/interface/ethernet.rs
@@ -34,13 +34,8 @@ impl InterfaceInner {
             EthernetProtocol::Ipv4 => {
                 let ipv4_packet = check!(Ipv4Packet::new_checked(eth_frame.payload()));
 
-                self.process_ipv4(
-                    sockets,
-                    &ipv4_packet,
-                    #[cfg(feature = "proto-ipv4-fragmentation")]
-                    &mut fragments.assembler,
-                )
-                .map(EthernetPacket::Ip)
+                self.process_ipv4(sockets, &ipv4_packet, fragments)
+                    .map(EthernetPacket::Ip)
             }
             #[cfg(feature = "proto-ipv6")]
             EthernetProtocol::Ipv6 => {

--- a/src/iface/interface/ethernet.rs
+++ b/src/iface/interface/ethernet.rs
@@ -15,7 +15,7 @@ impl InterfaceInner {
         &mut self,
         sockets: &mut SocketSet,
         frame: &'frame T,
-        _fragments: &'frame mut FragmentsBuffer,
+        fragments: &'frame mut FragmentsBuffer,
     ) -> Option<EthernetPacket<'frame>> {
         let eth_frame = check!(EthernetFrame::new_checked(frame));
 
@@ -34,17 +34,13 @@ impl InterfaceInner {
             EthernetProtocol::Ipv4 => {
                 let ipv4_packet = check!(Ipv4Packet::new_checked(eth_frame.payload()));
 
-                #[cfg(feature = "proto-ipv4-fragmentation")]
-                {
-                    self.process_ipv4(sockets, &ipv4_packet, Some(&mut _fragments.ipv4_fragments))
-                        .map(EthernetPacket::Ip)
-                }
-
-                #[cfg(not(feature = "proto-ipv4-fragmentation"))]
-                {
-                    self.process_ipv4(sockets, &ipv4_packet, None)
-                        .map(EthernetPacket::Ip)
-                }
+                self.process_ipv4(
+                    sockets,
+                    &ipv4_packet,
+                    #[cfg(feature = "proto-ipv4-fragmentation")]
+                    &mut fragments.assembler,
+                )
+                .map(EthernetPacket::Ip)
             }
             #[cfg(feature = "proto-ipv6")]
             EthernetProtocol::Ipv6 => {

--- a/src/iface/interface/igmp.rs
+++ b/src/iface/interface/igmp.rs
@@ -51,7 +51,9 @@ impl Interface {
                         .ok_or(MulticastError::Exhausted)?;
 
                     // NOTE(unwrap): packet destination is multicast, which is always routable and doesn't require neighbor discovery.
-                    self.inner.dispatch_ip(tx_token, pkt, None).unwrap();
+                    self.inner
+                        .dispatch_ip(tx_token, pkt, &mut self.fragmenter)
+                        .unwrap();
 
                     Ok(true)
                 } else {
@@ -91,7 +93,9 @@ impl Interface {
                         .ok_or(MulticastError::Exhausted)?;
 
                     // NOTE(unwrap): packet destination is multicast, which is always routable and doesn't require neighbor discovery.
-                    self.inner.dispatch_ip(tx_token, pkt, None).unwrap();
+                    self.inner
+                        .dispatch_ip(tx_token, pkt, &mut self.fragmenter)
+                        .unwrap();
 
                     Ok(true)
                 } else {
@@ -125,7 +129,9 @@ impl Interface {
                     // Send initial membership report
                     if let Some(tx_token) = device.transmit(self.inner.now) {
                         // NOTE(unwrap): packet destination is multicast, which is always routable and doesn't require neighbor discovery.
-                        self.inner.dispatch_ip(tx_token, pkt, None).unwrap();
+                        self.inner
+                            .dispatch_ip(tx_token, pkt, &mut self.fragmenter)
+                            .unwrap();
                     } else {
                         return false;
                     }
@@ -153,7 +159,9 @@ impl Interface {
                             // Send initial membership report
                             if let Some(tx_token) = device.transmit(self.inner.now) {
                                 // NOTE(unwrap): packet destination is multicast, which is always routable and doesn't require neighbor discovery.
-                                self.inner.dispatch_ip(tx_token, pkt, None).unwrap();
+                                self.inner
+                                    .dispatch_ip(tx_token, pkt, &mut self.fragmenter)
+                                    .unwrap();
                             } else {
                                 return false;
                             }

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -51,7 +51,7 @@ pub(crate) struct FragmentsBuffer {
     #[cfg(feature = "proto-sixlowpan-fragmentation")]
     sixlowpan_fragments: PacketAssemblerSet<SixlowpanFragKey>,
     #[cfg(feature = "proto-sixlowpan-fragmentation")]
-    sixlowpan_fragments_cache_timeout: Duration,
+    sixlowpan_reassembly_timeout: Duration,
 }
 
 pub(crate) struct OutPackets {
@@ -563,7 +563,7 @@ impl Interface {
                 #[cfg(feature = "proto-sixlowpan-fragmentation")]
                 sixlowpan_fragments: PacketAssemblerSet::new(),
                 #[cfg(feature = "proto-sixlowpan-fragmentation")]
-                sixlowpan_fragments_cache_timeout: Duration::from_secs(60),
+                sixlowpan_reassembly_timeout: Duration::from_secs(60),
             },
             out_packets: OutPackets {
                 #[cfg(feature = "proto-ipv4-fragmentation")]
@@ -736,7 +736,7 @@ impl Interface {
     /// Currently used only for 6LoWPAN, will be used for IPv4 in the future as well.
     #[cfg(feature = "proto-sixlowpan-fragmentation")]
     pub fn reassembly_timeout(&self) -> Duration {
-        self.fragments.sixlowpan_fragments_cache_timeout
+        self.fragments.sixlowpan_reassembly_timeout
     }
 
     /// Set the packet reassembly timeout.
@@ -747,7 +747,7 @@ impl Interface {
         if timeout > Duration::from_secs(60) {
             net_debug!("RFC 4944 specifies that the reassembly timeout MUST be set to a maximum of 60 seconds");
         }
-        self.fragments.sixlowpan_fragments_cache_timeout = timeout;
+        self.fragments.sixlowpan_reassembly_timeout = timeout;
     }
 
     /// Transmit packets queued in the given sockets, and receive packets queued

--- a/src/iface/interface/sixlowpan.rs
+++ b/src/iface/interface/sixlowpan.rs
@@ -98,6 +98,7 @@ impl InterfaceInner {
         f: &'output mut FragmentsBuffer,
     ) -> Option<&'output [u8]> {
         use crate::iface::fragmentation::{AssemblerError, AssemblerFullError};
+        use crate::iface::interface::FragKey;
 
         // We have a fragment header, which means we cannot process the 6LoWPAN packet,
         // unless we have a complete one after processing this fragment.
@@ -105,7 +106,7 @@ impl InterfaceInner {
 
         // The key specifies to which 6LoWPAN fragment it belongs too.
         // It is based on the link layer addresses, the tag and the size.
-        let key = frag.get_key(ieee802154_repr);
+        let key = FragKey::Sixlowpan(frag.get_key(ieee802154_repr));
 
         // The offset of this fragment in increments of 8 octets.
         let offset = frag.datagram_offset() as usize * 8;
@@ -116,7 +117,7 @@ impl InterfaceInner {
         // We also pass the header size, since this is needed when other fragments
         // (other than the first one) are added.
         let frag_slot = match f
-            .sixlowpan_fragments
+            .assembler
             .get(&key, self.now + f.sixlowpan_reassembly_timeout)
         {
             Ok(frag) => frag,

--- a/src/iface/interface/sixlowpan.rs
+++ b/src/iface/interface/sixlowpan.rs
@@ -1,12 +1,4 @@
-use super::check;
-use super::FragmentsBuffer;
-use super::InterfaceInner;
-use super::IpPacket;
-use super::OutPackets;
-use super::SocketSet;
-
-#[cfg(feature = "proto-sixlowpan-fragmentation")]
-use super::SixlowpanOutPacket;
+use super::*;
 
 use crate::phy::ChecksumCapabilities;
 use crate::phy::TxToken;
@@ -98,7 +90,6 @@ impl InterfaceInner {
         f: &'output mut FragmentsBuffer,
     ) -> Option<&'output [u8]> {
         use crate::iface::fragmentation::{AssemblerError, AssemblerFullError};
-        use crate::iface::interface::FragKey;
 
         // We have a fragment header, which means we cannot process the 6LoWPAN packet,
         // unless we have a complete one after processing this fragment.
@@ -275,7 +266,7 @@ impl InterfaceInner {
         ll_dst_a: Ieee802154Address,
         tx_token: Tx,
         packet: IpPacket,
-        _out_packet: Option<&mut OutPackets>,
+        frag: &mut Fragmenter,
     ) {
         // We first need to convert the IPv6 packet to a 6LoWPAN compressed packet.
         // Whenever this packet is to big to fit in the IEEE802.15.4 packet, then we need to
@@ -365,14 +356,14 @@ impl InterfaceInner {
             #[cfg(feature = "proto-sixlowpan-fragmentation")]
             {
                 // The packet does not fit in one Ieee802154 frame, so we need fragmentation.
-                // We do this by emitting everything in the `out_packet.buffer` from the interface.
+                // We do this by emitting everything in the `frag.buffer` from the interface.
                 // After emitting everything into that buffer, we send the first fragment heere.
-                // When `poll` is called again, we check if out_packet was fully sent, otherwise we
-                // call `dispatch_ieee802154_out_packet`, which will transmit the other fragments.
+                // When `poll` is called again, we check if frag was fully sent, otherwise we
+                // call `dispatch_ieee802154_frag`, which will transmit the other fragments.
 
-                // `dispatch_ieee802154_out_packet` requires some information about the total packet size,
+                // `dispatch_ieee802154_frag` requires some information about the total packet size,
                 // the link local source and destination address...
-                let pkt = &mut _out_packet.unwrap().sixlowpan_out_packet;
+                let pkt = frag;
 
                 if pkt.buffer.len() < total_size {
                     net_debug!(
@@ -382,8 +373,8 @@ impl InterfaceInner {
                     return;
                 }
 
-                pkt.ll_dst_addr = ll_dst_a;
-                pkt.ll_src_addr = ll_src_a;
+                pkt.sixlowpan.ll_dst_addr = ll_dst_a;
+                pkt.sixlowpan.ll_src_addr = ll_src_a;
 
                 let mut iphc_packet =
                     SixlowpanIphcPacket::new_unchecked(&mut pkt.buffer[..iphc_repr.buffer_len()]);
@@ -436,20 +427,20 @@ impl InterfaceInner {
 
                 // The datagram size that we need to set in the first fragment header is equal to the
                 // IPv6 payload length + 40.
-                pkt.datagram_size = (packet.ip_repr().payload_len() + 40) as u16;
+                pkt.sixlowpan.datagram_size = (packet.ip_repr().payload_len() + 40) as u16;
 
                 // We generate a random tag.
                 let tag = self.get_sixlowpan_fragment_tag();
                 // We save the tag for the other fragments that will be created when calling `poll`
                 // multiple times.
-                pkt.datagram_tag = tag;
+                pkt.sixlowpan.datagram_tag = tag;
 
                 let frag1 = SixlowpanFragRepr::FirstFragment {
-                    size: pkt.datagram_size,
+                    size: pkt.sixlowpan.datagram_size,
                     tag,
                 };
                 let fragn = SixlowpanFragRepr::Fragment {
-                    size: pkt.datagram_size,
+                    size: pkt.sixlowpan.datagram_size,
                     tag,
                     offset: 0,
                 };
@@ -465,10 +456,10 @@ impl InterfaceInner {
                 let frag1_size =
                     (125 - ieee_len - frag1.buffer_len() + header_diff) / 8 * 8 - (header_diff);
 
-                pkt.fragn_size = (125 - ieee_len - fragn.buffer_len()) / 8 * 8;
+                pkt.sixlowpan.fragn_size = (125 - ieee_len - fragn.buffer_len()) / 8 * 8;
 
                 pkt.sent_bytes = frag1_size;
-                pkt.datagram_offset = frag1_size + header_diff;
+                pkt.sixlowpan.datagram_offset = frag1_size + header_diff;
 
                 tx_token.consume(ieee_len + frag1.buffer_len() + frag1_size, |mut tx_buf| {
                     // Add the IEEE header.
@@ -553,10 +544,10 @@ impl InterfaceInner {
         feature = "medium-ieee802154",
         feature = "proto-sixlowpan-fragmentation"
     ))]
-    pub(super) fn dispatch_ieee802154_out_packet<Tx: TxToken>(
+    pub(super) fn dispatch_ieee802154_frag<Tx: TxToken>(
         &mut self,
         tx_token: Tx,
-        pkt: &mut SixlowpanOutPacket,
+        frag: &mut Fragmenter,
     ) {
         // Create the IEEE802.15.4 header.
         let ieee_repr = Ieee802154Repr {
@@ -568,20 +559,20 @@ impl InterfaceInner {
             pan_id_compression: true,
             frame_version: Ieee802154FrameVersion::Ieee802154_2003,
             dst_pan_id: self.pan_id,
-            dst_addr: Some(pkt.ll_dst_addr),
+            dst_addr: Some(frag.sixlowpan.ll_dst_addr),
             src_pan_id: self.pan_id,
-            src_addr: Some(pkt.ll_src_addr),
+            src_addr: Some(frag.sixlowpan.ll_src_addr),
         };
 
         // Create the FRAG_N header.
         let fragn = SixlowpanFragRepr::Fragment {
-            size: pkt.datagram_size,
-            tag: pkt.datagram_tag,
-            offset: (pkt.datagram_offset / 8) as u8,
+            size: frag.sixlowpan.datagram_size,
+            tag: frag.sixlowpan.datagram_tag,
+            offset: (frag.sixlowpan.datagram_offset / 8) as u8,
         };
 
         let ieee_len = ieee_repr.buffer_len();
-        let frag_size = (pkt.packet_len - pkt.sent_bytes).min(pkt.fragn_size);
+        let frag_size = (frag.packet_len - frag.sent_bytes).min(frag.sixlowpan.fragn_size);
 
         tx_token.consume(
             ieee_repr.buffer_len() + fragn.buffer_len() + frag_size,
@@ -596,10 +587,10 @@ impl InterfaceInner {
                 tx_buf = &mut tx_buf[fragn.buffer_len()..];
 
                 // Add the buffer part
-                tx_buf[..frag_size].copy_from_slice(&pkt.buffer[pkt.sent_bytes..][..frag_size]);
+                tx_buf[..frag_size].copy_from_slice(&frag.buffer[frag.sent_bytes..][..frag_size]);
 
-                pkt.sent_bytes += frag_size;
-                pkt.datagram_offset += frag_size;
+                frag.sent_bytes += frag_size;
+                frag.sixlowpan.datagram_offset += frag_size;
             },
         );
     }

--- a/src/iface/interface/sixlowpan.rs
+++ b/src/iface/interface/sixlowpan.rs
@@ -107,10 +107,7 @@ impl InterfaceInner {
         // This information is the total size of the packet when it is fully assmbled.
         // We also pass the header size, since this is needed when other fragments
         // (other than the first one) are added.
-        let frag_slot = match f
-            .assembler
-            .get(&key, self.now + f.sixlowpan_reassembly_timeout)
-        {
+        let frag_slot = match f.assembler.get(&key, self.now + f.reassembly_timeout) {
             Ok(frag) => frag,
             Err(AssemblerFullError) => {
                 net_debug!("No available packet assembler for fragmented packet");

--- a/src/iface/interface/sixlowpan.rs
+++ b/src/iface/interface/sixlowpan.rs
@@ -117,7 +117,7 @@ impl InterfaceInner {
         // (other than the first one) are added.
         let frag_slot = match f
             .sixlowpan_fragments
-            .get(&key, self.now + f.sixlowpan_fragments_cache_timeout)
+            .get(&key, self.now + f.sixlowpan_reassembly_timeout)
         {
             Ok(frag) => frag,
             Err(AssemblerFullError) => {

--- a/src/iface/interface/tests.rs
+++ b/src/iface/interface/tests.rs
@@ -168,12 +168,9 @@ fn test_no_icmp_no_unicast_ipv4() {
     // broadcast address
 
     assert_eq!(
-        iface.inner.process_ipv4(
-            &mut sockets,
-            &frame,
-            #[cfg(feature = "proto-ipv4-fragmentation")]
-            &mut iface.fragments.assembler
-        ),
+        iface
+            .inner
+            .process_ipv4(&mut sockets, &frame, &mut iface.fragments),
         None
     );
 }
@@ -254,12 +251,9 @@ fn test_icmp_error_no_payload() {
     // And we correctly handle no payload.
 
     assert_eq!(
-        iface.inner.process_ipv4(
-            &mut sockets,
-            &frame,
-            #[cfg(feature = "proto-ipv4-fragmentation")]
-            &mut iface.fragments.assembler
-        ),
+        iface
+            .inner
+            .process_ipv4(&mut sockets, &frame, &mut iface.fragments),
         Some(expected_repr)
     );
 }
@@ -564,12 +558,9 @@ fn test_handle_ipv4_broadcast() {
     let expected_packet = IpPacket::Icmpv4((expected_ipv4_repr, expected_icmpv4_repr));
 
     assert_eq!(
-        iface.inner.process_ipv4(
-            &mut sockets,
-            &frame,
-            #[cfg(feature = "proto-ipv4-fragmentation")]
-            &mut iface.fragments.assembler
-        ),
+        iface
+            .inner
+            .process_ipv4(&mut sockets, &frame, &mut iface.fragments),
         Some(expected_packet)
     );
 }
@@ -1268,12 +1259,9 @@ fn test_raw_socket_no_reply() {
     };
 
     assert_eq!(
-        iface.inner.process_ipv4(
-            &mut sockets,
-            &frame,
-            #[cfg(feature = "proto-ipv4-fragmentation")]
-            &mut iface.fragments.assembler
-        ),
+        iface
+            .inner
+            .process_ipv4(&mut sockets, &frame, &mut iface.fragments),
         None
     );
 }
@@ -1357,12 +1345,9 @@ fn test_raw_socket_with_udp_socket() {
     };
 
     assert_eq!(
-        iface.inner.process_ipv4(
-            &mut sockets,
-            &frame,
-            #[cfg(feature = "proto-ipv4-fragmentation")]
-            &mut iface.fragments.assembler
-        ),
+        iface
+            .inner
+            .process_ipv4(&mut sockets, &frame, &mut iface.fragments),
         None
     );
 

--- a/src/iface/interface/tests.rs
+++ b/src/iface/interface/tests.rs
@@ -749,7 +749,8 @@ fn test_handle_valid_arp_request() {
         iface.inner.lookup_hardware_addr(
             MockTxToken,
             &IpAddress::Ipv4(local_ip_addr),
-            &IpAddress::Ipv4(remote_ip_addr)
+            &IpAddress::Ipv4(remote_ip_addr),
+            &mut iface.fragmenter,
         ),
         Ok((HardwareAddress::Ethernet(remote_hw_addr), MockTxToken))
     );
@@ -821,7 +822,8 @@ fn test_handle_valid_ndisc_request() {
         iface.inner.lookup_hardware_addr(
             MockTxToken,
             &IpAddress::Ipv6(local_ip_addr),
-            &IpAddress::Ipv6(remote_ip_addr)
+            &IpAddress::Ipv6(remote_ip_addr),
+            &mut iface.fragmenter,
         ),
         Ok((HardwareAddress::Ethernet(remote_hw_addr), MockTxToken))
     );
@@ -865,7 +867,8 @@ fn test_handle_other_arp_request() {
         iface.inner.lookup_hardware_addr(
             MockTxToken,
             &IpAddress::Ipv4(Ipv4Address([0x7f, 0x00, 0x00, 0x01])),
-            &IpAddress::Ipv4(remote_ip_addr)
+            &IpAddress::Ipv4(remote_ip_addr),
+            &mut iface.fragmenter,
         ),
         Err(DispatchError::NeighborPending)
     );
@@ -923,7 +926,8 @@ fn test_arp_flush_after_update_ip() {
         iface.inner.lookup_hardware_addr(
             MockTxToken,
             &IpAddress::Ipv4(local_ip_addr),
-            &IpAddress::Ipv4(remote_ip_addr)
+            &IpAddress::Ipv4(remote_ip_addr),
+            &mut iface.fragmenter,
         ),
         Ok((HardwareAddress::Ethernet(remote_hw_addr), MockTxToken))
     );
@@ -1527,7 +1531,7 @@ fn test_echo_request_sixlowpan_128_bytes() {
         Ieee802154Address::default(),
         tx_token,
         result.unwrap(),
-        Some(&mut iface.out_packets),
+        &mut iface.fragmenter,
     );
 
     assert_eq!(
@@ -1677,7 +1681,7 @@ fn test_sixlowpan_udp_with_fragmentation() {
             },
             udp_data,
         )),
-        Some(&mut iface.out_packets),
+        &mut iface.fragmenter,
     );
 
     iface.poll(Instant::now(), &mut device, &mut sockets);

--- a/src/iface/interface/tests.rs
+++ b/src/iface/interface/tests.rs
@@ -167,14 +167,12 @@ fn test_no_icmp_no_unicast_ipv4() {
     // ICMP error response when the destination address is a
     // broadcast address
 
-    #[cfg(not(feature = "proto-ipv4-fragmentation"))]
-    assert_eq!(iface.inner.process_ipv4(&mut sockets, &frame, None), None);
-    #[cfg(feature = "proto-ipv4-fragmentation")]
     assert_eq!(
         iface.inner.process_ipv4(
             &mut sockets,
             &frame,
-            Some(&mut iface.fragments.ipv4_fragments)
+            #[cfg(feature = "proto-ipv4-fragmentation")]
+            &mut iface.fragments.assembler
         ),
         None
     );
@@ -255,18 +253,12 @@ fn test_icmp_error_no_payload() {
     // Ensure that the unknown protocol triggers an error response.
     // And we correctly handle no payload.
 
-    #[cfg(not(feature = "proto-ipv4-fragmentation"))]
-    assert_eq!(
-        iface.inner.process_ipv4(&mut sockets, &frame, None),
-        Some(expected_repr)
-    );
-
-    #[cfg(feature = "proto-ipv4-fragmentation")]
     assert_eq!(
         iface.inner.process_ipv4(
             &mut sockets,
             &frame,
-            Some(&mut iface.fragments.ipv4_fragments)
+            #[cfg(feature = "proto-ipv4-fragmentation")]
+            &mut iface.fragments.assembler
         ),
         Some(expected_repr)
     );
@@ -571,18 +563,12 @@ fn test_handle_ipv4_broadcast() {
     };
     let expected_packet = IpPacket::Icmpv4((expected_ipv4_repr, expected_icmpv4_repr));
 
-    #[cfg(not(feature = "proto-ipv4-fragmentation"))]
-    assert_eq!(
-        iface.inner.process_ipv4(&mut sockets, &frame, None),
-        Some(expected_packet)
-    );
-
-    #[cfg(feature = "proto-ipv4-fragmentation")]
     assert_eq!(
         iface.inner.process_ipv4(
             &mut sockets,
             &frame,
-            Some(&mut iface.fragments.ipv4_fragments)
+            #[cfg(feature = "proto-ipv4-fragmentation")]
+            &mut iface.fragments.assembler
         ),
         Some(expected_packet)
     );
@@ -1277,14 +1263,12 @@ fn test_raw_socket_no_reply() {
         Ipv4Packet::new_unchecked(&bytes)
     };
 
-    #[cfg(not(feature = "proto-ipv4-fragmentation"))]
-    assert_eq!(iface.inner.process_ipv4(&mut sockets, &frame, None), None);
-    #[cfg(feature = "proto-ipv4-fragmentation")]
     assert_eq!(
         iface.inner.process_ipv4(
             &mut sockets,
             &frame,
-            Some(&mut iface.fragments.ipv4_fragments)
+            #[cfg(feature = "proto-ipv4-fragmentation")]
+            &mut iface.fragments.assembler
         ),
         None
     );
@@ -1368,14 +1352,12 @@ fn test_raw_socket_with_udp_socket() {
         Ipv4Packet::new_unchecked(&bytes)
     };
 
-    #[cfg(not(feature = "proto-ipv4-fragmentation"))]
-    assert_eq!(iface.inner.process_ipv4(&mut sockets, &frame, None), None);
-    #[cfg(feature = "proto-ipv4-fragmentation")]
     assert_eq!(
         iface.inner.process_ipv4(
             &mut sockets,
             &frame,
-            Some(&mut iface.fragments.ipv4_fragments)
+            #[cfg(feature = "proto-ipv4-fragmentation")]
+            &mut iface.fragments.assembler
         ),
         None
     );

--- a/src/iface/socket_meta.rs
+++ b/src/iface/socket_meta.rs
@@ -9,10 +9,11 @@ use crate::{
 ///
 /// This enum tracks whether the socket should be polled based on the neighbor
 /// it is going to send packets to.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 enum NeighborState {
     /// Socket can be polled immediately.
+    #[default]
     Active,
     /// Socket should not be polled until either `silent_until` passes or
     /// `neighbor` appears in the neighbor cache.
@@ -20,12 +21,6 @@ enum NeighborState {
         neighbor: IpAddress,
         silent_until: Instant,
     },
-}
-
-impl Default for NeighborState {
-    fn default() -> Self {
-        NeighborState::Active
-    }
 }
 
 /// Network socket metadata.

--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -131,10 +131,11 @@ pub use self::tracer::Tracer;
 pub use self::tuntap_interface::TunTapInterface;
 
 /// A description of checksum behavior for a particular protocol.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Checksum {
     /// Verify checksum when receiving and compute checksum when sending.
+    #[default]
     Both,
     /// Verify checksum when receiving.
     Rx,
@@ -142,12 +143,6 @@ pub enum Checksum {
     Tx,
     /// Ignore checksum completely.
     None,
-}
-
-impl Default for Checksum {
-    fn default() -> Checksum {
-        Checksum::Both
-    }
 }
 
 impl Checksum {

--- a/src/socket/icmp.rs
+++ b/src/socket/icmp.rs
@@ -43,9 +43,10 @@ pub enum RecvError {
 /// more details.
 ///
 /// [IcmpSocket::bind]: struct.IcmpSocket.html#method.bind
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Endpoint {
+    #[default]
     Unspecified,
     Ident(u16),
     Udp(IpListenEndpoint),
@@ -58,12 +59,6 @@ impl Endpoint {
             Endpoint::Udp(endpoint) => endpoint.port != 0,
             Endpoint::Unspecified => false,
         }
-    }
-}
-
-impl Default for Endpoint {
-    fn default() -> Endpoint {
-        Endpoint::Unspecified
     }
 }
 

--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -27,6 +27,7 @@ pub const MIN_MTU: usize = 576;
 pub const ADDR_SIZE: usize = 4;
 
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Key {
     id: u16,
     src_addr: Address,


### PR DESCRIPTION
    If you enable both ipv4 and 6lowpan on the same binary, an Interface
    had twice the needed buffers, one copy for ipv4 and another
    for 6lowpan. Only one of both was used at a time.
    
    Now interfaces have a single set of buffers, used for either medium.