### PR TITLE
Remove unneeded ref patterns and destructures.

### DIFF
--- a/fuzz/fuzz_targets/dhcp_header.rs
+++ b/fuzz/fuzz_targets/dhcp_header.rs
@@ -4,7 +4,7 @@ use smoltcp::wire::{DhcpPacket, DhcpRepr};
 
 fuzz_target!(|data: &[u8]| {
     let _ = match DhcpPacket::new_checked(data) {
-        Ok(ref packet) => match DhcpRepr::parse(packet) {
+        Ok(packet) => match DhcpRepr::parse(packet) {
             Ok(dhcp_repr) => {
                 let mut dhcp_payload = vec![0; dhcp_repr.buffer_len()];
                 match DhcpPacket::new_checked(&mut dhcp_payload[..]) {

--- a/fuzz/fuzz_targets/ieee802154_header.rs
+++ b/fuzz/fuzz_targets/ieee802154_header.rs
@@ -3,7 +3,7 @@ use libfuzzer_sys::fuzz_target;
 use smoltcp::wire::{Ieee802154Frame, Ieee802154Repr};
 
 fuzz_target!(|data: &[u8]| {
-    if let Ok(ref frame) = Ieee802154Frame::new_checked(data) {
+    if let Ok(frame) = Ieee802154Frame::new_checked(data) {
         if let Ok(repr) = Ieee802154Repr::parse(frame) {
             // The buffer len returns only the length required for emitting the header
             // and does not take into account the length of the payload.

--- a/src/iface/socket_set.rs
+++ b/src/iface/socket_set.rs
@@ -77,10 +77,10 @@ impl<'a> SocketSet<'a> {
             }
         }
 
-        match self.sockets {
+        match &mut self.sockets {
             ManagedSlice::Borrowed(_) => panic!("adding a socket to a full SocketSet"),
             #[cfg(feature = "alloc")]
-            ManagedSlice::Owned(ref mut sockets) => {
+            ManagedSlice::Owned(sockets) => {
                 sockets.push(SocketStorage { inner: None });
                 let index = sockets.len() - 1;
                 put(index, &mut sockets[index], socket)

--- a/src/phy/fuzz_injector.rs
+++ b/src/phy/fuzz_injector.rs
@@ -62,18 +62,13 @@ where
     }
 
     fn receive(&mut self, timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
-        let &mut Self {
-            ref mut inner,
-            ref fuzz_rx,
-            ref fuzz_tx,
-        } = self;
-        inner.receive(timestamp).map(|(rx_token, tx_token)| {
+        self.inner.receive(timestamp).map(|(rx_token, tx_token)| {
             let rx = RxToken {
-                fuzzer: fuzz_rx,
+                fuzzer: &mut self.fuzz_rx,
                 token: rx_token,
             };
             let tx = TxToken {
-                fuzzer: fuzz_tx,
+                fuzzer: &mut self.fuzz_tx,
                 token: tx_token,
             };
             (rx, tx)
@@ -81,13 +76,8 @@ where
     }
 
     fn transmit(&mut self, timestamp: Instant) -> Option<Self::TxToken<'_>> {
-        let &mut Self {
-            ref mut inner,
-            fuzz_rx: _,
-            ref fuzz_tx,
-        } = self;
-        inner.transmit(timestamp).map(|token| TxToken {
-            fuzzer: fuzz_tx,
+        self.inner.transmit(timestamp).map(|token| TxToken {
+            fuzzer: &mut self.fuzz_tx,
             token: token,
         })
     }

--- a/src/phy/raw_socket.rs
+++ b/src/phy/raw_socket.rs
@@ -81,7 +81,7 @@ impl Device for RawSocket {
                 };
                 Some((rx, tx))
             }
-            Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => None,
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => None,
             Err(err) => panic!("{}", err),
         }
     }

--- a/src/phy/tracer.rs
+++ b/src/phy/tracer.rs
@@ -54,22 +54,17 @@ impl<D: Device> Device for Tracer<D> {
     }
 
     fn receive(&mut self, timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
-        let &mut Self {
-            ref mut inner,
-            writer,
-            ..
-        } = self;
-        let medium = inner.capabilities().medium;
-        inner.receive(timestamp).map(|(rx_token, tx_token)| {
+        let medium = self.inner.capabilities().medium;
+        self.inner.receive(timestamp).map(|(rx_token, tx_token)| {
             let rx = RxToken {
                 token: rx_token,
-                writer,
+                writer: self.writer,
                 medium,
                 timestamp,
             };
             let tx = TxToken {
                 token: tx_token,
-                writer,
+                writer: self.writer,
                 medium,
                 timestamp,
             };
@@ -78,15 +73,11 @@ impl<D: Device> Device for Tracer<D> {
     }
 
     fn transmit(&mut self, timestamp: Instant) -> Option<Self::TxToken<'_>> {
-        let &mut Self {
-            ref mut inner,
-            writer,
-        } = self;
-        let medium = inner.capabilities().medium;
-        inner.transmit(timestamp).map(|tx_token| TxToken {
+        let medium = self.inner.capabilities().medium;
+        self.inner.transmit(timestamp).map(|tx_token| TxToken {
             token: tx_token,
             medium,
-            writer,
+            writer: self.writer,
             timestamp,
         })
     }

--- a/src/phy/tuntap_interface.rs
+++ b/src/phy/tuntap_interface.rs
@@ -63,7 +63,7 @@ impl Device for TunTapInterface {
                 };
                 Some((rx, tx))
             }
-            Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => None,
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => None,
             Err(err) => panic!("{}", err),
         }
     }

--- a/src/socket/dns.rs
+++ b/src/socket/dns.rs
@@ -182,10 +182,10 @@ impl<'a> Socket<'a> {
             }
         }
 
-        match self.queries {
+        match &mut self.queries {
             ManagedSlice::Borrowed(_) => None,
             #[cfg(feature = "alloc")]
-            ManagedSlice::Owned(ref mut queries) => {
+            ManagedSlice::Owned(queries) => {
                 queries.push(None);
                 let index = queries.len() - 1;
                 Some(QueryHandle(index))

--- a/src/socket/icmp.rs
+++ b/src/socket/icmp.rs
@@ -446,7 +446,7 @@ impl<'a> Socket<'a> {
     pub(crate) fn process(&mut self, _cx: &mut Context, ip_repr: &IpRepr, icmp_repr: &IcmpRepr) {
         match *icmp_repr {
             #[cfg(feature = "proto-ipv4")]
-            IcmpRepr::Ipv4(ref icmp_repr) => {
+            IcmpRepr::Ipv4(icmp_repr) => {
                 net_trace!("icmp: receiving {} octets", icmp_repr.buffer_len());
 
                 match self
@@ -463,7 +463,7 @@ impl<'a> Socket<'a> {
                 }
             }
             #[cfg(feature = "proto-ipv6")]
-            IcmpRepr::Ipv6(ref icmp_repr) => {
+            IcmpRepr::Ipv6(icmp_repr) => {
                 net_trace!("icmp: receiving {} octets", icmp_repr.buffer_len());
 
                 match self

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -273,10 +273,7 @@ impl Timer {
     }
 
     fn set_keep_alive(&mut self) {
-        if let Timer::Idle {
-            ref mut keep_alive_at,
-        } = *self
-        {
+        if let Timer::Idle { keep_alive_at } = self {
             if keep_alive_at.is_none() {
                 *keep_alive_at = Some(Instant::from_millis(0))
             }
@@ -284,10 +281,7 @@ impl Timer {
     }
 
     fn rewind_keep_alive(&mut self, timestamp: Instant, interval: Option<Duration>) {
-        if let Timer::Idle {
-            ref mut keep_alive_at,
-        } = *self
-        {
+        if let Timer::Idle { keep_alive_at } = self {
             *keep_alive_at = interval.map(|interval| timestamp + interval)
         }
     }
@@ -1734,9 +1728,9 @@ impl<'a> Socket<'a> {
                 // Duplicate ACK if payload empty and ACK doesn't move send window ->
                 // Increment duplicate ACK count and set for retransmit if we just received
                 // the third duplicate ACK
-                Some(ref last_rx_ack)
+                Some(last_rx_ack)
                     if repr.payload.is_empty()
-                        && *last_rx_ack == ack_number
+                        && last_rx_ack == ack_number
                         && ack_number < self.remote_last_seq =>
                 {
                     // Increment duplicate ACK count

--- a/src/wire/ieee802154.rs
+++ b/src/wire/ieee802154.rs
@@ -637,21 +637,21 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Frame<T> {
 
     /// Set the destination address.
     #[inline]
-    pub fn set_dst_addr(&mut self, mut value: Address) {
+    pub fn set_dst_addr(&mut self, value: Address) {
         match value {
             Address::Absent => self.set_dst_addressing_mode(AddressingMode::Absent),
-            Address::Short(ref mut value) => {
+            Address::Short(mut value) => {
                 value.reverse();
                 self.set_dst_addressing_mode(AddressingMode::Short);
                 let data = self.buffer.as_mut();
-                data[field::ADDRESSING][2..2 + 2].copy_from_slice(value);
+                data[field::ADDRESSING][2..2 + 2].copy_from_slice(&value);
                 value.reverse();
             }
-            Address::Extended(ref mut value) => {
+            Address::Extended(mut value) => {
                 value.reverse();
                 self.set_dst_addressing_mode(AddressingMode::Extended);
                 let data = &mut self.buffer.as_mut()[field::ADDRESSING];
-                data[2..2 + 8].copy_from_slice(value);
+                data[2..2 + 8].copy_from_slice(&value);
                 value.reverse();
             }
         }
@@ -683,7 +683,7 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Frame<T> {
 
     /// Set the source address.
     #[inline]
-    pub fn set_src_addr(&mut self, mut value: Address) {
+    pub fn set_src_addr(&mut self, value: Address) {
         let offset = match self.dst_addressing_mode() {
             AddressingMode::Absent => 0,
             AddressingMode::Short => 2,
@@ -695,18 +695,18 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Frame<T> {
 
         match value {
             Address::Absent => self.set_src_addressing_mode(AddressingMode::Absent),
-            Address::Short(ref mut value) => {
+            Address::Short(mut value) => {
                 value.reverse();
                 self.set_src_addressing_mode(AddressingMode::Short);
                 let data = &mut self.buffer.as_mut()[field::ADDRESSING];
-                data[offset..offset + 2].copy_from_slice(value);
+                data[offset..offset + 2].copy_from_slice(&value);
                 value.reverse();
             }
-            Address::Extended(ref mut value) => {
+            Address::Extended(mut value) => {
                 value.reverse();
                 self.set_src_addressing_mode(AddressingMode::Extended);
                 let data = &mut self.buffer.as_mut()[field::ADDRESSING];
-                data[offset..offset + 8].copy_from_slice(value);
+                data[offset..offset + 8].copy_from_slice(&value);
                 value.reverse();
             }
         }

--- a/src/wire/ip.rs
+++ b/src/wire/ip.rs
@@ -116,17 +116,17 @@ impl Address {
 
     /// Return an address as a sequence of octets, in big-endian.
     pub const fn as_bytes(&self) -> &[u8] {
-        match *self {
+        match self {
             #[cfg(feature = "proto-ipv4")]
-            Address::Ipv4(ref addr) => addr.as_bytes(),
+            Address::Ipv4(addr) => addr.as_bytes(),
             #[cfg(feature = "proto-ipv6")]
-            Address::Ipv6(ref addr) => addr.as_bytes(),
+            Address::Ipv6(addr) => addr.as_bytes(),
         }
     }
 
     /// Query whether the address is a valid unicast address.
     pub fn is_unicast(&self) -> bool {
-        match *self {
+        match self {
             #[cfg(feature = "proto-ipv4")]
             Address::Ipv4(addr) => addr.is_unicast(),
             #[cfg(feature = "proto-ipv6")]
@@ -136,7 +136,7 @@ impl Address {
 
     /// Query whether the address is a valid multicast address.
     pub const fn is_multicast(&self) -> bool {
-        match *self {
+        match self {
             #[cfg(feature = "proto-ipv4")]
             Address::Ipv4(addr) => addr.is_multicast(),
             #[cfg(feature = "proto-ipv6")]
@@ -146,7 +146,7 @@ impl Address {
 
     /// Query whether the address is the broadcast address.
     pub fn is_broadcast(&self) -> bool {
-        match *self {
+        match self {
             #[cfg(feature = "proto-ipv4")]
             Address::Ipv4(addr) => addr.is_broadcast(),
             #[cfg(feature = "proto-ipv6")]
@@ -156,7 +156,7 @@ impl Address {
 
     /// Query whether the address falls into the "unspecified" range.
     pub fn is_unspecified(&self) -> bool {
-        match *self {
+        match self {
             #[cfg(feature = "proto-ipv4")]
             Address::Ipv4(addr) => addr.is_unspecified(),
             #[cfg(feature = "proto-ipv6")]


### PR DESCRIPTION
This brings the code to a more modern Rust style.

- Dstructuring is not so necessary nowadays, with the borrow checker being smarter, especially around partial captures in closures.
- "ref" is barely needed anymore, with [match ergonomics](https://rust-lang.github.io/rfcs/2005-match-ergonomics.html).

bors r+