### PR TITLE
Modify `hardware_addr` and `neighbor_cache` to be not `Option`

### DIFF
--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -88,11 +88,14 @@ fn main() {
     let tcp2_tx_buffer = tcp::SocketBuffer::new(vec![0; 65535]);
     let tcp2_socket = tcp::Socket::new(tcp2_rx_buffer, tcp2_tx_buffer);
 
-    let mut config = Config::new();
+    let mut config = match device.capabilities().medium {
+        Medium::Ethernet => {
+            Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
+        }
+        Medium::Ip => Config::new(smoltcp::wire::HardwareAddress::Ip),
+        Medium::Ieee802154 => todo!(),
+    };
     config.random_seed = rand::random();
-    if device.capabilities().medium == Medium::Ethernet {
-        config.hardware_addr = Some(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into());
-    }
 
     let mut iface = Interface::new(config, &mut device);
     iface.update_ip_addrs(|ip_addrs| {

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -29,11 +29,14 @@ fn main() {
     let port = u16::from_str(&matches.free[1]).expect("invalid port format");
 
     // Create interface
-    let mut config = Config::new();
+    let mut config = match device.capabilities().medium {
+        Medium::Ethernet => {
+            Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
+        }
+        Medium::Ip => Config::new(smoltcp::wire::HardwareAddress::Ip),
+        Medium::Ieee802154 => todo!(),
+    };
     config.random_seed = rand::random();
-    if device.capabilities().medium == Medium::Ethernet {
-        config.hardware_addr = Some(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into());
-    }
 
     let mut iface = Interface::new(config, &mut device);
     iface.update_ip_addrs(|ip_addrs| {

--- a/examples/dhcp_client.rs
+++ b/examples/dhcp_client.rs
@@ -28,11 +28,14 @@ fn main() {
         utils::parse_middleware_options(&mut matches, device, /*loopback=*/ false);
 
     // Create interface
-    let mut config = Config::new();
+    let mut config = match device.capabilities().medium {
+        Medium::Ethernet => {
+            Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
+        }
+        Medium::Ip => Config::new(smoltcp::wire::HardwareAddress::Ip),
+        Medium::Ieee802154 => todo!(),
+    };
     config.random_seed = rand::random();
-    if device.capabilities().medium == Medium::Ethernet {
-        config.hardware_addr = Some(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into());
-    }
     let mut iface = Interface::new(config, &mut device);
 
     // Create sockets

--- a/examples/dns.rs
+++ b/examples/dns.rs
@@ -24,11 +24,14 @@ fn main() {
     let name = &matches.free[0];
 
     // Create interface
-    let mut config = Config::new();
+    let mut config = match device.capabilities().medium {
+        Medium::Ethernet => {
+            Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
+        }
+        Medium::Ip => Config::new(smoltcp::wire::HardwareAddress::Ip),
+        Medium::Ieee802154 => todo!(),
+    };
     config.random_seed = rand::random();
-    if device.capabilities().medium == Medium::Ethernet {
-        config.hardware_addr = Some(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into());
-    }
 
     let mut iface = Interface::new(config, &mut device);
     iface.update_ip_addrs(|ip_addrs| {

--- a/examples/httpclient.rs
+++ b/examples/httpclient.rs
@@ -29,11 +29,14 @@ fn main() {
     let url = Url::parse(&matches.free[1]).expect("invalid url format");
 
     // Create interface
-    let mut config = Config::new();
+    let mut config = match device.capabilities().medium {
+        Medium::Ethernet => {
+            Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
+        }
+        Medium::Ip => Config::new(smoltcp::wire::HardwareAddress::Ip),
+        Medium::Ieee802154 => todo!(),
+    };
     config.random_seed = rand::random();
-    if device.capabilities().medium == Medium::Ethernet {
-        config.hardware_addr = Some(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into());
-    }
 
     let mut iface = Interface::new(config, &mut device);
     iface.update_ip_addrs(|ip_addrs| {

--- a/examples/loopback.rs
+++ b/examples/loopback.rs
@@ -10,7 +10,7 @@ use core::str;
 use log::{debug, error, info};
 
 use smoltcp::iface::{Config, Interface, SocketSet};
-use smoltcp::phy::{Loopback, Medium};
+use smoltcp::phy::{Device, Loopback, Medium};
 use smoltcp::socket::tcp;
 use smoltcp::time::{Duration, Instant};
 use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr};
@@ -83,8 +83,13 @@ fn main() {
     };
 
     // Create interface
-    let mut config = Config::new();
-    config.hardware_addr = Some(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into());
+    let mut config = match device.capabilities().medium {
+        Medium::Ethernet => {
+            Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
+        }
+        Medium::Ip => Config::new(smoltcp::wire::HardwareAddress::Ip),
+        Medium::Ieee802154 => todo!(),
+    };
 
     let mut iface = Interface::new(config, &mut device);
     iface.update_ip_addrs(|ip_addrs| {

--- a/examples/multicast.rs
+++ b/examples/multicast.rs
@@ -28,11 +28,14 @@ fn main() {
         utils::parse_middleware_options(&mut matches, device, /*loopback=*/ false);
 
     // Create interface
-    let mut config = Config::new();
+    let mut config = match device.capabilities().medium {
+        Medium::Ethernet => {
+            Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
+        }
+        Medium::Ip => Config::new(smoltcp::wire::HardwareAddress::Ip),
+        Medium::Ieee802154 => todo!(),
+    };
     config.random_seed = rand::random();
-    if device.capabilities().medium == Medium::Ethernet {
-        config.hardware_addr = Some(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into());
-    }
 
     let mut iface = Interface::new(config, &mut device);
     iface.update_ip_addrs(|ip_addrs| {

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -105,11 +105,14 @@ fn main() {
     );
 
     // Create interface
-    let mut config = Config::new();
+    let mut config = match device.capabilities().medium {
+        Medium::Ethernet => {
+            Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
+        }
+        Medium::Ip => Config::new(smoltcp::wire::HardwareAddress::Ip),
+        Medium::Ieee802154 => todo!(),
+    };
     config.random_seed = rand::random();
-    if device.capabilities().medium == Medium::Ethernet {
-        config.hardware_addr = Some(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into());
-    }
 
     let mut iface = Interface::new(config, &mut device);
     iface.update_ip_addrs(|ip_addrs| {

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -24,11 +24,15 @@ fn main() {
         utils::parse_middleware_options(&mut matches, device, /*loopback=*/ false);
 
     // Create interface
-    let mut config = Config::new();
+    let mut config = match device.capabilities().medium {
+        Medium::Ethernet => {
+            Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
+        }
+        Medium::Ip => Config::new(smoltcp::wire::HardwareAddress::Ip),
+        Medium::Ieee802154 => todo!(),
+    };
+
     config.random_seed = rand::random();
-    if device.capabilities().medium == Medium::Ethernet {
-        config.hardware_addr = Some(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into());
-    }
 
     let mut iface = Interface::new(config, &mut device);
     iface.update_ip_addrs(|ip_addrs| {

--- a/examples/sixlowpan.rs
+++ b/examples/sixlowpan.rs
@@ -47,11 +47,11 @@ use std::os::unix::io::AsRawFd;
 use std::str;
 
 use smoltcp::iface::{Config, Interface, SocketSet};
-use smoltcp::phy::{wait as phy_wait, Medium, RawSocket};
+use smoltcp::phy::{wait as phy_wait, Device, Medium, RawSocket};
 use smoltcp::socket::tcp;
 use smoltcp::socket::udp;
 use smoltcp::time::Instant;
-use smoltcp::wire::{Ieee802154Address, Ieee802154Pan, IpAddress, IpCidr};
+use smoltcp::wire::{EthernetAddress, Ieee802154Address, Ieee802154Pan, IpAddress, IpCidr};
 
 fn main() {
     utils::setup_logging("");
@@ -67,10 +67,16 @@ fn main() {
         utils::parse_middleware_options(&mut matches, device, /*loopback=*/ false);
 
     // Create interface
-    let mut config = Config::new();
+    let mut config = match device.capabilities().medium {
+        Medium::Ethernet => {
+            Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into())
+        }
+        Medium::Ip => Config::new(smoltcp::wire::HardwareAddress::Ip),
+        Medium::Ieee802154 => Config::new(
+            Ieee802154Address::Extended([0x1a, 0x0b, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42]).into(),
+        ),
+    };
     config.random_seed = rand::random();
-    config.hardware_addr =
-        Some(Ieee802154Address::Extended([0x1a, 0x0b, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42]).into());
     config.pan_id = Some(Ieee802154Pan(0xbeef));
 
     let mut iface = Interface::new(config, &mut device);

--- a/src/iface/interface/ethernet.rs
+++ b/src/iface/interface/ethernet.rs
@@ -22,7 +22,7 @@ impl InterfaceInner {
         // Ignore any packets not directed to our hardware address or any of the multicast groups.
         if !eth_frame.dst_addr().is_broadcast()
             && !eth_frame.dst_addr().is_multicast()
-            && HardwareAddress::Ethernet(eth_frame.dst_addr()) != self.hardware_addr.unwrap()
+            && HardwareAddress::Ethernet(eth_frame.dst_addr()) != self.hardware_addr
         {
             return None;
         }
@@ -64,7 +64,7 @@ impl InterfaceInner {
             debug_assert!(tx_buffer.as_ref().len() == tx_len);
             let mut frame = EthernetFrame::new_unchecked(tx_buffer);
 
-            let src_addr = self.hardware_addr.unwrap().ethernet_or_panic();
+            let src_addr = self.hardware_addr.ethernet_or_panic();
             frame.set_src_addr(src_addr);
 
             f(frame);

--- a/src/iface/interface/ieee802154.rs
+++ b/src/iface/interface/ieee802154.rs
@@ -44,7 +44,7 @@ impl InterfaceInner {
         packet: IpPacket,
         frag: &mut Fragmenter,
     ) {
-        let ll_src_a = self.hardware_addr.unwrap().ieee802154_or_panic();
+        let ll_src_a = self.hardware_addr.ieee802154_or_panic();
 
         // Create the IEEE802.15.4 header.
         let ieee_repr = Ieee802154Repr {

--- a/src/iface/interface/ipv6.rs
+++ b/src/iface/interface/ipv6.rs
@@ -192,17 +192,9 @@ impl InterfaceInner {
                         return None;
                     }
                     if flags.contains(NdiscNeighborFlags::OVERRIDE)
-                        || !self
-                            .neighbor_cache
-                            .as_mut()
-                            .unwrap()
-                            .lookup(&ip_addr, self.now)
-                            .found()
+                        || !self.neighbor_cache.lookup(&ip_addr, self.now).found()
                     {
-                        self.neighbor_cache
-                            .as_mut()
-                            .unwrap()
-                            .fill(ip_addr, lladdr, self.now)
+                        self.neighbor_cache.fill(ip_addr, lladdr, self.now)
                     }
                 }
                 None
@@ -217,11 +209,8 @@ impl InterfaceInner {
                     if !lladdr.is_unicast() || !target_addr.is_unicast() {
                         return None;
                     }
-                    self.neighbor_cache.as_mut().unwrap().fill(
-                        ip_repr.src_addr.into(),
-                        lladdr,
-                        self.now,
-                    );
+                    self.neighbor_cache
+                        .fill(ip_repr.src_addr.into(), lladdr, self.now);
                 }
 
                 if self.has_solicited_node(ip_repr.dst_addr) && self.has_ip_addr(target_addr) {
@@ -229,7 +218,7 @@ impl InterfaceInner {
                         flags: NdiscNeighborFlags::SOLICITED,
                         target_addr,
                         #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
-                        lladdr: Some(self.hardware_addr.unwrap().into()),
+                        lladdr: Some(self.hardware_addr.into()),
                     });
                     let ip_repr = Ipv6Repr {
                         src_addr: target_addr,

--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -317,7 +317,7 @@ impl<'a> Socket<'a> {
             }
         };
 
-        let Some(HardwareAddress::Ethernet(ethernet_addr)) = cx.hardware_addr() else {
+        let HardwareAddress::Ethernet(ethernet_addr) = cx.hardware_addr() else {
             panic!("using DHCPv4 socket with a non-ethernet hardware address.");
         };
 
@@ -542,7 +542,7 @@ impl<'a> Socket<'a> {
     {
         // note: Dhcpv4Socket is only usable in ethernet mediums, so the
         // unwrap can never fail.
-        let Some(HardwareAddress::Ethernet(ethernet_addr)) = cx.hardware_addr() else {
+        let HardwareAddress::Ethernet(ethernet_addr) = cx.hardware_addr() else {
             panic!("using DHCPv4 socket with a non-ethernet hardware address.");
         };
 

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -275,20 +275,32 @@ impl fmt::Display for Error {
 pub type Result<T> = core::result::Result<T, Error>;
 
 /// Representation of an hardware address, such as an Ethernet address or an IEEE802.15.4 address.
-#[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
+#[cfg(any(
+    feature = "medium-ip",
+    feature = "medium-ethernet",
+    feature = "medium-ieee802154"
+))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum HardwareAddress {
+    #[cfg(feature = "medium-ip")]
+    Ip,
     #[cfg(feature = "medium-ethernet")]
     Ethernet(EthernetAddress),
     #[cfg(feature = "medium-ieee802154")]
     Ieee802154(Ieee802154Address),
 }
 
-#[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
+#[cfg(any(
+    feature = "medium-ip",
+    feature = "medium-ethernet",
+    feature = "medium-ieee802154"
+))]
 impl HardwareAddress {
     pub const fn as_bytes(&self) -> &[u8] {
         match self {
+            #[cfg(feature = "medium-ip")]
+            HardwareAddress::Ip => unreachable!(),
             #[cfg(feature = "medium-ethernet")]
             HardwareAddress::Ethernet(addr) => addr.as_bytes(),
             #[cfg(feature = "medium-ieee802154")]
@@ -299,6 +311,8 @@ impl HardwareAddress {
     /// Query wether the address is an unicast address.
     pub fn is_unicast(&self) -> bool {
         match self {
+            #[cfg(feature = "medium-ip")]
+            HardwareAddress::Ip => unreachable!(),
             #[cfg(feature = "medium-ethernet")]
             HardwareAddress::Ethernet(addr) => addr.is_unicast(),
             #[cfg(feature = "medium-ieee802154")]
@@ -309,6 +323,8 @@ impl HardwareAddress {
     /// Query wether the address is a broadcast address.
     pub fn is_broadcast(&self) -> bool {
         match self {
+            #[cfg(feature = "medium-ip")]
+            HardwareAddress::Ip => unreachable!(),
             #[cfg(feature = "medium-ethernet")]
             HardwareAddress::Ethernet(addr) => addr.is_broadcast(),
             #[cfg(feature = "medium-ieee802154")]
@@ -333,12 +349,30 @@ impl HardwareAddress {
             _ => panic!("HardwareAddress is not Ethernet."),
         }
     }
+
+    #[inline]
+    pub(crate) fn medium(&self) -> Medium {
+        match self {
+            #[cfg(feature = "medium-ip")]
+            HardwareAddress::Ip => Medium::Ip,
+            #[cfg(feature = "medium-ethernet")]
+            HardwareAddress::Ethernet(_) => Medium::Ethernet,
+            #[cfg(feature = "medium-ieee802154")]
+            HardwareAddress::Ieee802154(_) => Medium::Ieee802154,
+        }
+    }
 }
 
-#[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
+#[cfg(any(
+    feature = "medium-ip",
+    feature = "medium-ethernet",
+    feature = "medium-ieee802154"
+))]
 impl core::fmt::Display for HardwareAddress {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
+            #[cfg(feature = "medium-ip")]
+            HardwareAddress::Ip => write!(f, "no hardware addr"),
             #[cfg(feature = "medium-ethernet")]
             HardwareAddress::Ethernet(addr) => write!(f, "{addr}"),
             #[cfg(feature = "medium-ieee802154")]

--- a/src/wire/sixlowpan.rs
+++ b/src/wire/sixlowpan.rs
@@ -700,7 +700,7 @@ pub mod iphc {
             match self.tf_field() {
                 0b00 | 0b10 => {
                     let start = self.ip_fields_start() as usize;
-                    Some(self.buffer.as_ref()[start..][0] & 0b1111_11)
+                    Some(self.buffer.as_ref()[start..][0] & 0b111111)
                 }
                 0b01 | 0b11 => None,
                 _ => unreachable!(),


### PR DESCRIPTION
Since `neighbor_cache` is now using `heapless::LinearMap` it doesn't need to be an `Option` any more. 

It's also possible to just make the `hardware_address` not `Option`.