### PR TITLE
tcp: consider segments partially overlapping the window as acceptable

### DIFF
--- a/src/wire/tcp.rs
+++ b/src/wire/tcp.rs
@@ -13,6 +13,24 @@ use crate::wire::{IpAddress, IpProtocol};
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 pub struct SeqNumber(pub i32);
 
+impl SeqNumber {
+    pub fn max(self, rhs: Self) -> Self {
+        if self > rhs {
+            self
+        } else {
+            rhs
+        }
+    }
+
+    pub fn min(self, rhs: Self) -> Self {
+        if self < rhs {
+            self
+        } else {
+            rhs
+        }
+    }
+}
+
 impl fmt::Display for SeqNumber {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0 as u32)


### PR DESCRIPTION
rfc9293 says this should be an OR, not an AND:
https://www.rfc-editor.org/rfc/rfc9293.html#name-segment-acceptability-tests

Does not work yet, causes some tests to fail due to seq overflows. Needs to push only the intersection of segment+window to the buffer.