### PR TITLE
Better defmt for Instant, Duration and Ipv6Address

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -22,7 +22,6 @@ use core::{fmt, ops};
 /// * A value less than `0` indicates a time before the starting
 ///   point.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Instant {
     micros: i64,
 }
@@ -134,6 +133,13 @@ impl fmt::Display for Instant {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for Instant {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{}.{:03}s", self.secs(), self.millis());
+    }
+}
+
 impl ops::Add<Duration> for Instant {
     type Output = Instant;
 
@@ -172,7 +178,6 @@ impl ops::Sub<Instant> for Instant {
 
 /// A relative amount of time.
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Duration {
     micros: u64,
 }
@@ -227,6 +232,13 @@ impl Duration {
 impl fmt::Display for Duration {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}.{:03}s", self.secs(), self.millis())
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Duration {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{}.{:03}s", self.secs(), self.millis());
     }
 }
 

--- a/src/wire/ieee802154.rs
+++ b/src/wire/ieee802154.rs
@@ -82,11 +82,32 @@ impl Pan {
 
 /// A IEEE 802.15.4 address.
 #[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Address {
     Absent,
     Short([u8; 2]),
     Extended([u8; 8]),
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Address {
+    fn format(&self, f: defmt::Formatter) {
+        match self {
+            Self::Absent => defmt::write!(f, "not-present"),
+            Self::Short(bytes) => defmt::write!(f, "{:02x}:{:02x}", bytes[0], bytes[1]),
+            Self::Extended(bytes) => defmt::write!(
+                f,
+                "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+                bytes[0],
+                bytes[1],
+                bytes[2],
+                bytes[3],
+                bytes[4],
+                bytes[5],
+                bytes[6],
+                bytes[7]
+            ),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -171,10 +192,10 @@ impl fmt::Display for Address {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Absent => write!(f, "not-present"),
-            Self::Short(bytes) => write!(f, "{:02x}-{:02x}", bytes[0], bytes[1]),
+            Self::Short(bytes) => write!(f, "{:02x}:{:02x}", bytes[0], bytes[1]),
             Self::Extended(bytes) => write!(
                 f,
-                "{:02x}-{:02x}-{:02x}-{:02x}-{:02x}-{:02x}-{:02x}-{:02x}",
+                "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
                 bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7]
             ),
         }

--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -274,7 +274,7 @@ impl fmt::Display for Cidr {
 #[cfg(feature = "defmt")]
 impl defmt::Format for Cidr {
     fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{:?}/{=u8}", self.address, self.prefix_len);
+        defmt::write!(f, "{}/{=u8}", self.address, self.prefix_len);
     }
 }
 

--- a/src/wire/ipv6.rs
+++ b/src/wire/ipv6.rs
@@ -379,7 +379,6 @@ impl From<ipv4::Address> for Address {
 /// A specification of an IPv6 CIDR block, containing an address and a variable-length
 /// subnet masking prefix length.
 #[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Cidr {
     address: Address,
     prefix_len: u8,
@@ -441,6 +440,13 @@ impl fmt::Display for Cidr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // https://tools.ietf.org/html/rfc4291#section-2.3
         write!(f, "{}/{}", self.address, self.prefix_len)
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Cidr {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{}/{=u8}", self.address, self.prefix_len);
     }
 }
 


### PR DESCRIPTION
This changes the defmt formatting of Instant, Duration and Ipv6Address. They now have the same display as fmt::Display.