### PR TITLE
Better impls defmt for some structs

### DIFF
--- a/src/wire/ieee802154.rs
+++ b/src/wire/ieee802154.rs
@@ -66,7 +66,6 @@ impl fmt::Display for AddressingMode {
 
 /// A IEEE 802.15.4 PAN.
 #[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Pan(pub u16);
 
 impl Pan {
@@ -77,6 +76,19 @@ impl Pan {
         let mut pan = [0u8; 2];
         LittleEndian::write_u16(&mut pan, self.0);
         pan
+    }
+}
+
+impl fmt::Display for Pan {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:0x}", self.0)
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Pan {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "{:02x}", self.0)
     }
 }
 
@@ -759,16 +771,56 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Frame<T> {
 
 impl<T: AsRef<[u8]>> fmt::Display for Frame<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "IEEE802.15.4 frame type={} seq={:2x?} dst_pan={:x?} dest={:x?} src_pan={:?} src={:x?}",
-            self.frame_type(),
-            self.sequence_number(),
-            self.dst_pan_id(),
-            self.dst_addr(),
-            self.src_pan_id(),
-            self.src_addr(),
-        )
+        write!(f, "IEEE802.15.4 frame type={}", self.frame_type())?;
+
+        if let Some(seq) = self.sequence_number() {
+            write!(f, " seq={:02x}", seq)?;
+        }
+
+        if let Some(pan) = self.dst_pan_id() {
+            write!(f, " dst-pan={}", pan)?;
+        }
+
+        if let Some(pan) = self.src_pan_id() {
+            write!(f, " src-pan={}", pan)?;
+        }
+
+        if let Some(addr) = self.dst_addr() {
+            write!(f, " dst={}", addr)?;
+        }
+
+        if let Some(addr) = self.src_addr() {
+            write!(f, " src={}", addr)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl<T: AsRef<[u8]>> defmt::Format for Frame<T> {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "IEEE802.15.4 frame type={}", self.frame_type());
+
+        if let Some(seq) = self.sequence_number() {
+            defmt::write!(f, " seq={:02x}", seq);
+        }
+
+        if let Some(pan) = self.dst_pan_id() {
+            defmt::write!(f, " dst-pan={}", pan);
+        }
+
+        if let Some(pan) = self.src_pan_id() {
+            defmt::write!(f, " src-pan={}", pan);
+        }
+
+        if let Some(addr) = self.dst_addr() {
+            defmt::write!(f, " dst={}", addr);
+        }
+
+        if let Some(addr) = self.src_addr() {
+            defmt::write!(f, " src={}", addr);
+        }
     }
 }
 

--- a/src/wire/ipv6.rs
+++ b/src/wire/ipv6.rs
@@ -721,7 +721,6 @@ impl<T: AsRef<[u8]>> AsRef<[u8]> for Packet<T> {
 
 /// A high-level representation of an Internet Protocol version 6 packet header.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Repr {
     /// IPv6 address of the source node.
     pub src_addr: Address,
@@ -779,6 +778,20 @@ impl fmt::Display for Repr {
             f,
             "IPv6 src={} dst={} nxt_hdr={} hop_limit={}",
             self.src_addr, self.dst_addr, self.next_header, self.hop_limit
+        )
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Repr {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(
+            fmt,
+            "IPv6 src={} dst={} nxt_hdr={} hop_limit={}",
+            self.src_addr,
+            self.dst_addr,
+            self.next_header,
+            self.hop_limit
         )
     }
 }

--- a/src/wire/sixlowpan.rs
+++ b/src/wire/sixlowpan.rs
@@ -405,10 +405,36 @@ pub mod frag {
 
     /// A high-level representation of a 6LoWPAN Fragment header.
     #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub enum Repr {
         FirstFragment { size: u16, tag: u16 },
         Fragment { size: u16, tag: u16, offset: u8 },
+    }
+
+    impl core::fmt::Display for Repr {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            match self {
+                Repr::FirstFragment { size, tag } => {
+                    write!(f, "FirstFrag size={size} tag={tag}")
+                }
+                Repr::Fragment { size, tag, offset } => {
+                    write!(f, "NthFrag size={size} tag={tag} offset={offset}")
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "defmt")]
+    impl defmt::Format for Repr {
+        fn format(&self, fmt: defmt::Formatter) {
+            match self {
+                Repr::FirstFragment { size, tag } => {
+                    defmt::write!(fmt, "FirstFrag size={} tag={}", size, tag);
+                }
+                Repr::Fragment { size, tag, offset } => {
+                    defmt::write!(fmt, "NthFrag size={} tag={} offset={}", size, tag, offset);
+                }
+            }
+        }
     }
 
     impl Repr {
@@ -456,10 +482,28 @@ pub mod frag {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum NextHeader {
     Compressed,
     Uncompressed(IpProtocol),
+}
+
+impl core::fmt::Display for NextHeader {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            NextHeader::Compressed => write!(f, "compressed"),
+            NextHeader::Uncompressed(protocol) => write!(f, "{protocol}"),
+        }
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for NextHeader {
+    fn format(&self, fmt: defmt::Formatter) {
+        match self {
+            NextHeader::Compressed => defmt::write!(fmt, "compressed"),
+            NextHeader::Uncompressed(protocol) => defmt::write!(fmt, "{}", protocol),
+        }
+    }
 }
 
 pub mod iphc {
@@ -1145,7 +1189,6 @@ pub mod iphc {
 
     /// A high-level representation of a 6LoWPAN IPHC header.
     #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct Repr {
         pub src_addr: ipv6::Address,
         pub ll_src_addr: Option<LlAddress>,
@@ -1157,6 +1200,30 @@ pub mod iphc {
         pub ecn: Option<u8>,
         pub dscp: Option<u8>,
         pub flow_label: Option<u16>,
+    }
+
+    impl core::fmt::Display for Repr {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            write!(
+                f,
+                "IPHC src={} dst={} nxt-hdr={} hop-limit={}",
+                self.src_addr, self.dst_addr, self.next_header, self.hop_limit
+            )
+        }
+    }
+
+    #[cfg(feature = "defmt")]
+    impl defmt::Format for Repr {
+        fn format(&self, fmt: defmt::Formatter) {
+            defmt::write!(
+                fmt,
+                "IPHC src={} dst={} nxt-hdr={} hop-limit={}",
+                self.src_addr,
+                self.dst_addr,
+                self.next_header,
+                self.hop_limit
+            );
+        }
     }
 
     impl Repr {

--- a/src/wire/udp.rs
+++ b/src/wire/udp.rs
@@ -8,7 +8,6 @@ use crate::wire::{IpAddress, IpProtocol};
 
 /// A read/write wrapper around an User Datagram Protocol packet buffer.
 #[derive(Debug, PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Packet<T: AsRef<[u8]>> {
     buffer: T,
 }
@@ -208,7 +207,6 @@ impl<T: AsRef<[u8]>> AsRef<[u8]> for Packet<T> {
 
 /// A high-level representation of an User Datagram Protocol packet.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Repr {
     pub src_port: u16,
     pub dst_port: u16,
@@ -305,9 +303,30 @@ impl<'a, T: AsRef<[u8]> + ?Sized> fmt::Display for Packet<&'a T> {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl<'a, T: AsRef<[u8]> + ?Sized> defmt::Format for Packet<&'a T> {
+    fn format(&self, fmt: defmt::Formatter) {
+        // Cannot use Repr::parse because we don't have the IP addresses.
+        defmt::write!(
+            fmt,
+            "UDP src={} dst={} len={}",
+            self.src_port(),
+            self.dst_port(),
+            self.payload().len()
+        );
+    }
+}
+
 impl fmt::Display for Repr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "UDP src={} dst={}", self.src_port, self.dst_port)
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Repr {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "UDP src={} dst={}", self.src_port, self.dst_port);
     }
 }
 


### PR DESCRIPTION
Sometimes, the defmt implementation was not readable when debugging. I changed it such that the defmt implementation matches the Display implementation (which was more readable).