### PR TITLE
Bump minor version of heapless

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ libc = { version = "0.2.18", optional = true }
 bitflags = { version = "1.0", default-features = false }
 defmt = { version = "0.3", optional = true }
 cfg-if = "1.0.0"
-heapless = "0.7.8"
+heapless = "0.7.15"
 
 [dev-dependencies]
 env_logger = "0.10"


### PR DESCRIPTION
Smoltcp uses `heapless::Vec::remove`, which was added in [version 0.7.15](https://github.com/japaric/heapless/blob/HEAD/CHANGELOG.md#v0715---2022-07-05)

There is also a newer version, [0.7.16](https://github.com/japaric/heapless/blob/HEAD/CHANGELOG.md#v0716---2022-08-09), but I don't know if smoltcp requires it