### PR TITLE
Add opcode and flag enums to dns export

### DIFF
--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -251,7 +251,7 @@ pub use self::dhcpv4::{
 };
 
 #[cfg(feature = "proto-dns")]
-pub use self::dns::{Packet as DnsPacket, Repr as DnsRepr, Type as DnsQueryType};
+pub use self::dns::{Packet as DnsPacket, Repr as DnsRepr, Type as DnsQueryType, Opcode as DnsOpCode, Flags as DnsFlags};
 
 /// Parsing a packet failed.
 ///

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -251,7 +251,10 @@ pub use self::dhcpv4::{
 };
 
 #[cfg(feature = "proto-dns")]
-pub use self::dns::{Packet as DnsPacket, Repr as DnsRepr, Type as DnsQueryType, Opcode as DnsOpCode, Flags as DnsFlags};
+pub use self::dns::{
+        Flags as DnsFlags, Opcode as DnsOpCode, Packet as DnsPacket, Repr as DnsRepr,
+        Type as DnsQueryType
+    };
 
 /// Parsing a packet failed.
 ///

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -253,7 +253,7 @@ pub use self::dhcpv4::{
 #[cfg(feature = "proto-dns")]
 pub use self::dns::{
     Flags as DnsFlags, Opcode as DnsOpCode, Packet as DnsPacket, Repr as DnsRepr,
-    Type as DnsQueryType
+    Type as DnsQueryType,
 };
 
 /// Parsing a packet failed.

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -252,7 +252,7 @@ pub use self::dhcpv4::{
 
 #[cfg(feature = "proto-dns")]
 pub use self::dns::{
-    Flags as DnsFlags, Opcode as DnsOpCode, Packet as DnsPacket, Repr as DnsRepr,
+    Flags as DnsFlags, Opcode as DnsOpcode, Packet as DnsPacket, Repr as DnsRepr,
     Type as DnsQueryType,
 };
 

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -252,9 +252,9 @@ pub use self::dhcpv4::{
 
 #[cfg(feature = "proto-dns")]
 pub use self::dns::{
-        Flags as DnsFlags, Opcode as DnsOpCode, Packet as DnsPacket, Repr as DnsRepr,
-        Type as DnsQueryType
-    };
+    Flags as DnsFlags, Opcode as DnsOpCode, Packet as DnsPacket, Repr as DnsRepr,
+    Type as DnsQueryType
+};
 
 /// Parsing a packet failed.
 ///


### PR DESCRIPTION
Added opcode and flag enums to dns export. As it currently stands, user is not able to access the enums which are parameters to DnsPacket's "set_opcode" and "set_flags" functions. This change will allow the user to import and use those enums to set the packet contents. If there is a more elegant way to include them in DnsPacket instead of being their own imports, please suggest what changes can be made. Refer to [issue 762](https://github.com/smoltcp-rs/smoltcp/issues/762)

Edit: Sorry for commit spam, rustfmt not working locally for some reason.