### PR TITLE
6LoWPAN Hop-by-Hop Header compression

### DIFF
--- a/src/iface/interface/ipv6.rs
+++ b/src/iface/interface/ipv6.rs
@@ -268,7 +268,7 @@ impl InterfaceInner {
         self.process_nxt_hdr(
             sockets,
             ipv6_repr,
-            hbh_repr.next_header,
+            hbh_repr.next_header.unwrap(),
             handled_by_raw_socket,
             &ip_payload[hbh_repr.buffer_len()..],
         )

--- a/src/wire/sixlowpan.rs
+++ b/src/wire/sixlowpan.rs
@@ -1570,6 +1570,13 @@ pub mod nhc {
         }
     }
 
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    pub enum ExtHdrNextHeader {
+        Inline,
+        Elided,
+    }
+
     /// A read/write wrapper around a 6LoWPAN NHC Extension header.
     #[derive(Debug, Clone)]
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]


### PR DESCRIPTION
This changes the wire representation for IPv6 Hop-by-hop Headers, such that they can be used together with 6LoWPAN (and later with RPL).

6LoWPAN has the same Extension Headers as IPv6, however, the next header field can sometimes be elided, and the length field does not have the same semantics as the definition in the IPv6 standard.

More information can be found here: https://datatracker.ietf.org/doc/html/rfc6282#section-4.2

I added an enum `PacketFormat` that is added to the `Header` struct. When the `proto-sixlowpan` feature flag is not used, then there is only one variant of the `PacketFormat`, so I think the compiler should be able to optimize this away. 