### PR TITLE
6LoWPAN Routing Header compression

### DIFF
--- a/src/iface/interface/ipv6.rs
+++ b/src/iface/interface/ipv6.rs
@@ -268,7 +268,7 @@ impl InterfaceInner {
         self.process_nxt_hdr(
             sockets,
             ipv6_repr,
-            hbh_repr.next_header,
+            hbh_repr.next_header.unwrap(),
             handled_by_raw_socket,
             &ip_payload[hbh_repr.buffer_len()..],
         )

--- a/src/wire/sixlowpan.rs
+++ b/src/wire/sixlowpan.rs
@@ -1570,6 +1570,13 @@ pub mod nhc {
         }
     }
 
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    pub enum ExtHdrNextHeader {
+        Inline,
+        Elided,
+    }
+
     /// A read/write wrapper around a 6LoWPAN NHC Extension header.
     #[derive(Debug, Clone)]
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]


### PR DESCRIPTION
Based on changes I made in #765.

This adds the compressed format of the IPv6 Routing header used for 6LoWPAN.