### PR TITLE
IPv6 Extension Headers rewrite

### DIFF
--- a/src/iface/interface/ipv6.rs
+++ b/src/iface/interface/ipv6.rs
@@ -244,9 +244,11 @@ impl InterfaceInner {
         handled_by_raw_socket: bool,
         ip_payload: &'frame [u8],
     ) -> Option<IpPacket<'frame>> {
-        let hbh_pkt = check!(Ipv6HopByHopHeader::new_checked(ip_payload));
-        let hbh_repr = check!(Ipv6HopByHopRepr::parse(&hbh_pkt));
-        for opt_repr in hbh_repr.options() {
+        let hbh_hdr = check!(Ipv6HopByHopHeader::new_checked(ip_payload));
+        let hbh_repr = check!(Ipv6HopByHopRepr::parse(&hbh_hdr));
+
+        let hbh_options = Ipv6OptionsIterator::new(hbh_repr.data);
+        for opt_repr in hbh_options {
             let opt_repr = check!(opt_repr);
             match opt_repr {
                 Ipv6OptionRepr::Pad1 | Ipv6OptionRepr::PadN(_) => (),
@@ -273,7 +275,7 @@ impl InterfaceInner {
             ipv6_repr,
             hbh_repr.next_header,
             handled_by_raw_socket,
-            &ip_payload[hbh_repr.buffer_len()..],
+            &ip_payload[hbh_repr.header_len() + hbh_repr.data.len()..],
         )
     }
 

--- a/src/iface/interface/tests.rs
+++ b/src/iface/interface/tests.rs
@@ -1063,11 +1063,11 @@ fn test_icmpv6_nxthdr_unknown() {
             hbh_pkt.set_header_len(0);
             offset += 8;
             {
-                let mut pad_pkt = Ipv6Option::new_unchecked(&mut *hbh_pkt.options_mut());
+                let mut pad_pkt = Ipv6Option::new_unchecked(&mut hbh_pkt.payload_mut()[..]);
                 Ipv6OptionRepr::PadN(3).emit(&mut pad_pkt);
             }
             {
-                let mut pad_pkt = Ipv6Option::new_unchecked(&mut hbh_pkt.options_mut()[5..]);
+                let mut pad_pkt = Ipv6Option::new_unchecked(&mut hbh_pkt.payload_mut()[5..]);
                 Ipv6OptionRepr::Pad1.emit(&mut pad_pkt);
             }
         }

--- a/src/wire/ipv6option.rs
+++ b/src/wire/ipv6option.rs
@@ -322,12 +322,8 @@ impl<'a> Ipv6OptionsIterator<'a> {
     /// Create a new `Ipv6OptionsIterator`, used to iterate over the
     /// options contained in a IPv6 Extension Header (e.g. the Hop-by-Hop
     /// header).
-    ///
-    /// # Panics
-    /// This function panics if the `length` provided is larger than the
-    /// length of the `data` buffer.
-    pub fn new(data: &'a [u8], length: usize) -> Ipv6OptionsIterator<'a> {
-        assert!(length <= data.len());
+    pub fn new(data: &'a [u8]) -> Ipv6OptionsIterator<'a> {
+        let length = data.len();
         Ipv6OptionsIterator {
             pos: 0,
             hit_error: false,
@@ -591,10 +587,7 @@ mod test {
             0x08, 0x00,
         ];
 
-        let mut iterator = Ipv6OptionsIterator::new(&options, 0);
-        assert_eq!(iterator.next(), None);
-
-        iterator = Ipv6OptionsIterator::new(&options, 16);
+        let iterator = Ipv6OptionsIterator::new(&options);
         for (i, opt) in iterator.enumerate() {
             match (i, opt) {
                 (0, Ok(Repr::Pad1)) => continue,
@@ -614,12 +607,5 @@ mod test {
                 (i, res) => panic!("Unexpected option `{res:?}` at index {i}"),
             }
         }
-    }
-
-    #[test]
-    #[should_panic(expected = "length <= data.len()")]
-    fn test_options_iter_truncated() {
-        let options = [0x01, 0x02, 0x00, 0x00];
-        let _ = Ipv6OptionsIterator::new(&options, 5);
     }
 }

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -101,9 +101,9 @@ mod ipv4;
 #[cfg(feature = "proto-ipv6")]
 mod ipv6;
 #[cfg(feature = "proto-ipv6")]
-mod ipv6fragment;
+mod ipv6ext_header;
 #[cfg(feature = "proto-ipv6")]
-mod ipv6hopbyhop;
+mod ipv6fragment;
 #[cfg(feature = "proto-ipv6")]
 mod ipv6option;
 #[cfg(feature = "proto-ipv6")]
@@ -190,12 +190,19 @@ pub use self::ipv6::{
 
 #[cfg(feature = "proto-ipv6")]
 pub use self::ipv6option::{
-    FailureType as Ipv6OptionFailureType, Ipv6Option, Repr as Ipv6OptionRepr,
+    FailureType as Ipv6OptionFailureType, Ipv6Option, Ipv6OptionsIterator, Repr as Ipv6OptionRepr,
     Type as Ipv6OptionType,
 };
 
 #[cfg(feature = "proto-ipv6")]
-pub use self::ipv6hopbyhop::{Header as Ipv6HopByHopHeader, Repr as Ipv6HopByHopRepr};
+pub use self::ipv6ext_header::{Header as Ipv6ExtHeader, Repr as Ipv6ExtHeaderRepr};
+
+#[cfg(feature = "proto-ipv6")]
+/// A read/write wrapper around an IPv6 Hop-By-Hop header.
+pub type Ipv6HopByHopHeader<T> = Ipv6ExtHeader<T>;
+#[cfg(feature = "proto-ipv6")]
+/// A high-level representation of an IPv6 Hop-By-Hop heade.
+pub type Ipv6HopByHopRepr<'a> = Ipv6ExtHeaderRepr<'a>;
 
 #[cfg(feature = "proto-ipv6")]
 pub use self::ipv6fragment::{Header as Ipv6FragmentHeader, Repr as Ipv6FragmentRepr};


### PR DESCRIPTION
I rewrote the IPv6 Extension Headers. All those headers have the `Next Header` and `Header Length` fields in common. These are now accessible using `Ipv6ExtHeader`. I removed the IPv6HopByHopOption, because this header only contains options, which can be accessed using the `Ipv6OptionsIterator`.

I also added tests for 6LoWPAN extension headers, routing header and hop-by-hop header), replacing #765 and #770 .