### PR TITLE
fix: check length field of NDISC redirected head

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,7 +12,7 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1", features = ["derive"] }
 getopts = "0.2"
-smoltcp = { path = "..", features = [ "medium-ethernet" ] }
+smoltcp = { path = ".." }
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/fuzz/fuzz_targets/sixlowpan_packet.rs
+++ b/fuzz/fuzz_targets/sixlowpan_packet.rs
@@ -77,6 +77,7 @@ fuzz_target!(|fuzz: SixlowpanPacketFuzzer| {
                                                 &frame,
                                                 &iphc_repr.src_addr,
                                                 &iphc_repr.dst_addr,
+                                                &Default::default(),
                                             ) {
                                                 let mut buffer = vec![
                                                     0;

--- a/src/wire/ndiscoption.rs
+++ b/src/wire/ndiscoption.rs
@@ -466,13 +466,14 @@ impl<'a> Repr<'a> {
                 if opt.data_len() < 6 {
                     Err(Error)
                 } else {
-                    let ip_packet =
-                        Ipv6Packet::new_unchecked(&opt.data()[field::REDIRECTED_RESERVED.len()..]);
+                    let redirected_packet = &opt.data()[field::REDIRECTED_RESERVED.len()..];
+
+                    let ip_packet = Ipv6Packet::new_checked(redirected_packet)?;
                     let ip_repr = Ipv6Repr::parse(&ip_packet)?;
+
                     Ok(Repr::RedirectedHeader(RedirectedHeader {
                         header: ip_repr,
-                        data: &opt.data()
-                            [field::REDIRECTED_RESERVED.len() + ip_repr.buffer_len()..],
+                        data: &redirected_packet[ip_repr.buffer_len()..][..ip_repr.payload_len],
                     }))
                 }
             }


### PR DESCRIPTION
If the length field indicates a lenght bigger than the actual data that it is carying, then the packet is just wrong. Emitting such a packet is also not allowed. We now also parse the IPv6 header in an NDISC redirected packet and check that the length is correct.