### PR TITLE
IPv4: Don't discard from unspecified src addresses

### DIFF
--- a/src/iface/interface/ipv4.rs
+++ b/src/iface/interface/ipv4.rs
@@ -18,9 +18,9 @@ impl InterfaceInner {
         frag: &'a mut FragmentsBuffer,
     ) -> Option<IpPacket<'a>> {
         let ipv4_repr = check!(Ipv4Repr::parse(ipv4_packet, &self.caps.checksum));
-        if !self.is_unicast_v4(ipv4_repr.src_addr) {
-            // Discard packets with non-unicast source addresses.
-            net_debug!("non-unicast source address");
+        if !self.is_unicast_v4(ipv4_repr.src_addr) && !ipv4_repr.src_addr.is_unspecified() {
+            // Discard packets with non-unicast source addresses but allow unspecified
+            net_debug!("non-unicast or unspecified source address");
             return None;
         }
 


### PR DESCRIPTION
IPv4 packets from `0.0.0.0` get discarded early. This makes it impossible to create a DHCP server.

Not sure if this is the right location or even the right approach for this fix.

Maybe there is also a way to make this work without modifying the code?
