### PR TITLE
tcp: Perform a reset() after an abort()

### DIFF
--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -2231,6 +2231,11 @@ impl<'a> Socket<'a> {
         if self.state == State::Closed {
             // When aborting a connection, forget about it after sending a single RST packet.
             self.tuple = None;
+            #[cfg(feature = "async")]
+            {
+                // Wake tx now so that async users can wait for the RST to be sent
+                self.tx_waker.wake();
+            }
         }
 
         Ok(())


### PR DESCRIPTION
It is useful to wake wakers once the RST packet has been emitted, so async callers can wait before dropping the socket. Another option would be to just wake wakers explicitly, but a .reset() is simpler.

This is to enable https://github.com/embassy-rs/embassy/pull/1471 "embassy-net: Make TcpSocket::abort() async"