### PR TITLE
fix: make codecov informational

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,2 +1,11 @@
 github_checks:
   annotations: false
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Adding the lines makes codecov informational. This should stop making the coverage report fail CI (hopefully).