### PR TITLE
Pass the now time when creating the iface

### DIFF
--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -97,7 +97,7 @@ fn main() {
     };
     config.random_seed = rand::random();
 
-    let mut iface = Interface::new(config, &mut device);
+    let mut iface = Interface::new(config, &mut device, Instant::now());
     iface.update_ip_addrs(|ip_addrs| {
         ip_addrs
             .push(IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24))

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -38,7 +38,7 @@ fn main() {
     };
     config.random_seed = rand::random();
 
-    let mut iface = Interface::new(config, &mut device);
+    let mut iface = Interface::new(config, &mut device, Instant::now());
     iface.update_ip_addrs(|ip_addrs| {
         ip_addrs
             .push(IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24))

--- a/examples/dhcp_client.rs
+++ b/examples/dhcp_client.rs
@@ -36,7 +36,7 @@ fn main() {
         Medium::Ieee802154 => todo!(),
     };
     config.random_seed = rand::random();
-    let mut iface = Interface::new(config, &mut device);
+    let mut iface = Interface::new(config, &mut device, Instant::now());
 
     // Create sockets
     let mut dhcp_socket = dhcpv4::Socket::new();

--- a/examples/dns.rs
+++ b/examples/dns.rs
@@ -33,7 +33,7 @@ fn main() {
     };
     config.random_seed = rand::random();
 
-    let mut iface = Interface::new(config, &mut device);
+    let mut iface = Interface::new(config, &mut device, Instant::now());
     iface.update_ip_addrs(|ip_addrs| {
         ip_addrs
             .push(IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24))

--- a/examples/httpclient.rs
+++ b/examples/httpclient.rs
@@ -38,7 +38,7 @@ fn main() {
     };
     config.random_seed = rand::random();
 
-    let mut iface = Interface::new(config, &mut device);
+    let mut iface = Interface::new(config, &mut device, Instant::now());
     iface.update_ip_addrs(|ip_addrs| {
         ip_addrs
             .push(IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24))

--- a/examples/loopback.rs
+++ b/examples/loopback.rs
@@ -91,7 +91,7 @@ fn main() {
         Medium::Ieee802154 => todo!(),
     };
 
-    let mut iface = Interface::new(config, &mut device);
+    let mut iface = Interface::new(config, &mut device, Instant::now());
     iface.update_ip_addrs(|ip_addrs| {
         ip_addrs
             .push(IpCidr::new(IpAddress::v4(127, 0, 0, 1), 8))

--- a/examples/multicast.rs
+++ b/examples/multicast.rs
@@ -37,7 +37,7 @@ fn main() {
     };
     config.random_seed = rand::random();
 
-    let mut iface = Interface::new(config, &mut device);
+    let mut iface = Interface::new(config, &mut device, Instant::now());
     iface.update_ip_addrs(|ip_addrs| {
         ip_addrs
             .push(IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24))

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -114,7 +114,7 @@ fn main() {
     };
     config.random_seed = rand::random();
 
-    let mut iface = Interface::new(config, &mut device);
+    let mut iface = Interface::new(config, &mut device, Instant::now());
     iface.update_ip_addrs(|ip_addrs| {
         ip_addrs
             .push(IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24))

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -34,7 +34,7 @@ fn main() {
 
     config.random_seed = rand::random();
 
-    let mut iface = Interface::new(config, &mut device);
+    let mut iface = Interface::new(config, &mut device, Instant::now());
     iface.update_ip_addrs(|ip_addrs| {
         ip_addrs
             .push(IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24))

--- a/examples/sixlowpan.rs
+++ b/examples/sixlowpan.rs
@@ -79,7 +79,7 @@ fn main() {
     config.random_seed = rand::random();
     config.pan_id = Some(Ieee802154Pan(0xbeef));
 
-    let mut iface = Interface::new(config, &mut device);
+    let mut iface = Interface::new(config, &mut device, Instant::now());
     iface.update_ip_addrs(|ip_addrs| {
         ip_addrs
             .push(IpCidr::new(

--- a/examples/sixlowpan_benchmark.rs
+++ b/examples/sixlowpan_benchmark.rs
@@ -159,7 +159,7 @@ fn main() {
     config.random_seed = rand::random();
     config.pan_id = Some(Ieee802154Pan(0xbeef));
 
-    let mut iface = Interface::new(config, &mut device);
+    let mut iface = Interface::new(config, &mut device, Instant::now());
     iface.update_ip_addrs(|ip_addrs| {
         ip_addrs
             .push(IpCidr::new(

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -461,7 +461,7 @@ impl Interface {
     ///
     /// [ethernet_addr]: #method.ethernet_addr
     /// [neighbor_cache]: #method.neighbor_cache
-    pub fn new<D>(config: Config, device: &mut D) -> Self
+    pub fn new<D>(config: Config, device: &mut D, now: Instant) -> Self
     where
         D: Device + ?Sized,
     {
@@ -519,7 +519,7 @@ impl Interface {
             },
             fragmenter: Fragmenter::new(),
             inner: InterfaceInner {
-                now: Instant::from_secs(0),
+                now,
                 caps,
                 hardware_addr: config.hardware_addr,
                 ip_addrs: Vec::new(),

--- a/src/iface/interface/tests.rs
+++ b/src/iface/interface/tests.rs
@@ -40,7 +40,7 @@ fn create_ip<'a>() -> (Interface, SocketSet<'a>, Loopback) {
     let mut device = Loopback::new(Medium::Ip);
 
     let config = Config::new(HardwareAddress::Ip);
-    let mut iface = Interface::new(config, &mut device);
+    let mut iface = Interface::new(config, &mut device, Instant::ZERO);
     iface.update_ip_addrs(|ip_addrs| {
         #[cfg(feature = "proto-ipv4")]
         ip_addrs
@@ -65,7 +65,7 @@ fn create_ethernet<'a>() -> (Interface, SocketSet<'a>, Loopback) {
     let mut device = Loopback::new(Medium::Ethernet);
 
     let config = Config::new(HardwareAddress::Ethernet(EthernetAddress::default()));
-    let mut iface = Interface::new(config, &mut device);
+    let mut iface = Interface::new(config, &mut device, Instant::ZERO);
     iface.update_ip_addrs(|ip_addrs| {
         #[cfg(feature = "proto-ipv4")]
         ip_addrs
@@ -90,7 +90,7 @@ fn create_ieee802154<'a>() -> (Interface, SocketSet<'a>, Loopback) {
     let mut device = Loopback::new(Medium::Ieee802154);
 
     let config = Config::new(HardwareAddress::Ieee802154(Ieee802154Address::default()));
-    let mut iface = Interface::new(config, &mut device);
+    let mut iface = Interface::new(config, &mut device, Instant::ZERO);
     iface.update_ip_addrs(|ip_addrs| {
         #[cfg(feature = "proto-ipv6")]
         ip_addrs
@@ -136,7 +136,7 @@ impl TxToken for MockTxToken {
 fn test_new_panic() {
     let mut device = Loopback::new(Medium::Ethernet);
     let config = Config::new(HardwareAddress::Ip);
-    Interface::new(config, &mut device);
+    Interface::new(config, &mut device, Instant::ZERO);
 }
 
 #[test]


### PR DESCRIPTION
I think that the now time should be passed to the interface when creating it. For RPL for example, some timers need to be created (Trickle timer for DIO's or a timer for DIS). Passing the now time makes this very easy. Having an interface with `Instant::ZERO` is also not really _correct_.

For the tests, the now time is ZERO, because we don't have a source when not using `std`.