### PR TITLE
iface: add support for sending to subnet-local broadcast addrs (like 192.168.1.255).

### DIFF
--- a/src/iface/interface/tests.rs
+++ b/src/iface/interface/tests.rs
@@ -268,46 +268,56 @@ fn test_local_subnet_broadcasts() {
 
     assert!(iface
         .inner
-        .is_subnet_broadcast(Ipv4Address([192, 168, 1, 255])),);
+        .is_broadcast_v4(Ipv4Address([255, 255, 255, 255])));
     assert!(!iface
         .inner
-        .is_subnet_broadcast(Ipv4Address([192, 168, 1, 254])),);
+        .is_broadcast_v4(Ipv4Address([255, 255, 255, 254])));
+    assert!(iface.inner.is_broadcast_v4(Ipv4Address([192, 168, 1, 255])));
+    assert!(!iface.inner.is_broadcast_v4(Ipv4Address([192, 168, 1, 254])));
 
     iface.update_ip_addrs(|addrs| {
         addrs.iter_mut().next().map(|addr| {
             *addr = IpCidr::Ipv4(Ipv4Cidr::new(Ipv4Address([192, 168, 23, 24]), 16));
         });
     });
-    assert!(!iface
-        .inner
-        .is_subnet_broadcast(Ipv4Address([192, 168, 23, 255])),);
-    assert!(!iface
-        .inner
-        .is_subnet_broadcast(Ipv4Address([192, 168, 23, 254])),);
-    assert!(!iface
-        .inner
-        .is_subnet_broadcast(Ipv4Address([192, 168, 255, 254])),);
     assert!(iface
         .inner
-        .is_subnet_broadcast(Ipv4Address([192, 168, 255, 255])),);
+        .is_broadcast_v4(Ipv4Address([255, 255, 255, 255])));
+    assert!(!iface
+        .inner
+        .is_broadcast_v4(Ipv4Address([255, 255, 255, 254])));
+    assert!(!iface
+        .inner
+        .is_broadcast_v4(Ipv4Address([192, 168, 23, 255])));
+    assert!(!iface
+        .inner
+        .is_broadcast_v4(Ipv4Address([192, 168, 23, 254])));
+    assert!(!iface
+        .inner
+        .is_broadcast_v4(Ipv4Address([192, 168, 255, 254])));
+    assert!(iface
+        .inner
+        .is_broadcast_v4(Ipv4Address([192, 168, 255, 255])));
 
     iface.update_ip_addrs(|addrs| {
         addrs.iter_mut().next().map(|addr| {
             *addr = IpCidr::Ipv4(Ipv4Cidr::new(Ipv4Address([192, 168, 23, 24]), 8));
         });
     });
-    assert!(!iface
-        .inner
-        .is_subnet_broadcast(Ipv4Address([192, 23, 1, 255])),);
-    assert!(!iface
-        .inner
-        .is_subnet_broadcast(Ipv4Address([192, 23, 1, 254])),);
-    assert!(!iface
-        .inner
-        .is_subnet_broadcast(Ipv4Address([192, 255, 255, 254])),);
     assert!(iface
         .inner
-        .is_subnet_broadcast(Ipv4Address([192, 255, 255, 255])),);
+        .is_broadcast_v4(Ipv4Address([255, 255, 255, 255])));
+    assert!(!iface
+        .inner
+        .is_broadcast_v4(Ipv4Address([255, 255, 255, 254])));
+    assert!(!iface.inner.is_broadcast_v4(Ipv4Address([192, 23, 1, 255])));
+    assert!(!iface.inner.is_broadcast_v4(Ipv4Address([192, 23, 1, 254])));
+    assert!(!iface
+        .inner
+        .is_broadcast_v4(Ipv4Address([192, 255, 255, 254])));
+    assert!(iface
+        .inner
+        .is_broadcast_v4(Ipv4Address([192, 255, 255, 255])));
 }
 
 #[test]

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -405,13 +405,13 @@ impl<'a> Socket<'a> {
         Ok((length, endpoint))
     }
 
-    pub(crate) fn accepts(&self, _cx: &mut Context, ip_repr: &IpRepr, repr: &UdpRepr) -> bool {
+    pub(crate) fn accepts(&self, cx: &mut Context, ip_repr: &IpRepr, repr: &UdpRepr) -> bool {
         if self.endpoint.port != repr.dst_port {
             return false;
         }
         if self.endpoint.addr.is_some()
             && self.endpoint.addr != Some(ip_repr.dst_addr())
-            && !ip_repr.dst_addr().is_broadcast()
+            && !cx.is_broadcast(&ip_repr.dst_addr())
             && !ip_repr.dst_addr().is_multicast()
         {
             return false;


### PR DESCRIPTION
#377 added support for subnet-local broadcast addrs for ingress, but it was missing for egress.