### PR TITLE
iface: fix outdated docs on `Interface::new`

### DIFF
--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -451,16 +451,6 @@ enum IgmpReportState {
 
 impl Interface {
     /// Create a network interface using the previously provided configuration.
-    ///
-    /// # Panics
-    /// If a required option is not provided, this function will panic. Required
-    /// options are:
-    ///
-    /// - [ethernet_addr]
-    /// - [neighbor_cache]
-    ///
-    /// [ethernet_addr]: #method.ethernet_addr
-    /// [neighbor_cache]: #method.neighbor_cache
     pub fn new<D>(config: Config, device: &mut D, now: Instant) -> Self
     where
         D: Device + ?Sized,

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -451,12 +451,15 @@ enum IgmpReportState {
 
 impl Interface {
     /// Create a network interface using the previously provided configuration.
+    ///
+    /// # Panics
+    /// This function panics if the [`Config::hardware_address`] does not match
+    /// the medium of the device.
     pub fn new<D>(config: Config, device: &mut D, now: Instant) -> Self
     where
         D: Device + ?Sized,
     {
         let caps = device.capabilities();
-
         assert_eq!(
             config.hardware_addr.medium(),
             caps.medium,


### PR DESCRIPTION
The methods linked in the docs don't exist anymore.
Also I believe with #745 `neighbor_cache` and `hardware_address` are not optional anymore and thus a panic can not happen?