### PR TITLE
iface: remove generic `T: [u8]` in functions

### DIFF
--- a/src/iface/interface/ethernet.rs
+++ b/src/iface/interface/ethernet.rs
@@ -11,11 +11,11 @@ use crate::wire::*;
 
 impl InterfaceInner {
     #[cfg(feature = "medium-ethernet")]
-    pub(super) fn process_ethernet<'frame, T: AsRef<[u8]>>(
+    pub(super) fn process_ethernet<'frame>(
         &mut self,
         sockets: &mut SocketSet,
         meta: crate::phy::PacketMeta,
-        frame: &'frame T,
+        frame: &'frame [u8],
         fragments: &'frame mut FragmentsBuffer,
     ) -> Option<EthernetPacket<'frame>> {
         let eth_frame = check!(EthernetFrame::new_checked(frame));

--- a/src/iface/interface/ieee802154.rs
+++ b/src/iface/interface/ieee802154.rs
@@ -4,11 +4,11 @@ use crate::phy::TxToken;
 use crate::wire::*;
 
 impl InterfaceInner {
-    pub(super) fn process_ieee802154<'output, 'payload: 'output, T: AsRef<[u8]> + ?Sized>(
+    pub(super) fn process_ieee802154<'output, 'payload: 'output>(
         &mut self,
         sockets: &mut SocketSet,
         meta: PacketMeta,
-        sixlowpan_payload: &'payload T,
+        sixlowpan_payload: &'payload [u8],
         _fragments: &'output mut FragmentsBuffer,
     ) -> Option<IpPacket<'output>> {
         let ieee802154_frame = check!(Ieee802154Frame::new_checked(sixlowpan_payload));

--- a/src/iface/interface/ipv4.rs
+++ b/src/iface/interface/ipv4.rs
@@ -11,11 +11,11 @@ use crate::time::Instant;
 use crate::wire::{Ipv4Packet as Ipv4PacketWire, *};
 
 impl InterfaceInner {
-    pub(super) fn process_ipv4<'a, T: AsRef<[u8]> + ?Sized>(
+    pub(super) fn process_ipv4<'a>(
         &mut self,
         sockets: &mut SocketSet,
         meta: PacketMeta,
-        ipv4_packet: &Ipv4PacketWire<&'a T>,
+        ipv4_packet: &Ipv4PacketWire<&'a [u8]>,
         frag: &'a mut FragmentsBuffer,
     ) -> Option<IpPacket<'a>> {
         let ipv4_repr = check!(Ipv4Repr::parse(ipv4_packet, &self.caps.checksum));
@@ -168,10 +168,10 @@ impl InterfaceInner {
     }
 
     #[cfg(feature = "medium-ethernet")]
-    pub(super) fn process_arp<'frame, T: AsRef<[u8]>>(
+    pub(super) fn process_arp<'frame>(
         &mut self,
         timestamp: Instant,
-        eth_frame: &EthernetFrame<&'frame T>,
+        eth_frame: &EthernetFrame<&'frame [u8]>,
     ) -> Option<EthernetPacket<'frame>> {
         let arp_packet = check!(ArpPacket::new_checked(eth_frame.payload()));
         let arp_repr = check!(ArpRepr::parse(&arp_packet));

--- a/src/iface/interface/ipv6.rs
+++ b/src/iface/interface/ipv6.rs
@@ -13,11 +13,11 @@ use crate::wire::*;
 
 impl InterfaceInner {
     #[cfg(feature = "proto-ipv6")]
-    pub(super) fn process_ipv6<'frame, T: AsRef<[u8]> + ?Sized>(
+    pub(super) fn process_ipv6<'frame>(
         &mut self,
         sockets: &mut SocketSet,
         meta: PacketMeta,
-        ipv6_packet: &Ipv6Packet<&'frame T>,
+        ipv6_packet: &Ipv6Packet<&'frame [u8]>,
     ) -> Option<IpPacket<'frame>> {
         let ipv6_repr = check!(Ipv6Repr::parse(ipv6_packet));
 

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -669,7 +669,7 @@ impl Interface {
                         if let Some(packet) = self.inner.process_ethernet(
                             sockets,
                             rx_meta,
-                            &frame,
+                            frame,
                             &mut self.fragments,
                         ) {
                             if let Err(err) =
@@ -683,7 +683,7 @@ impl Interface {
                     Medium::Ip => {
                         if let Some(packet) =
                             self.inner
-                                .process_ip(sockets, rx_meta, &frame, &mut self.fragments)
+                                .process_ip(sockets, rx_meta, frame, &mut self.fragments)
                         {
                             if let Err(err) = self.inner.dispatch_ip(
                                 tx_token,
@@ -700,7 +700,7 @@ impl Interface {
                         if let Some(packet) = self.inner.process_ieee802154(
                             sockets,
                             rx_meta,
-                            &frame,
+                            frame,
                             &mut self.fragments,
                         ) {
                             if let Err(err) = self.inner.dispatch_ip(
@@ -1152,14 +1152,14 @@ impl InterfaceInner {
     }
 
     #[cfg(feature = "medium-ip")]
-    fn process_ip<'frame, T: AsRef<[u8]>>(
+    fn process_ip<'frame>(
         &mut self,
         sockets: &mut SocketSet,
         meta: PacketMeta,
-        ip_payload: &'frame T,
+        ip_payload: &'frame [u8],
         frag: &'frame mut FragmentsBuffer,
     ) -> Option<IpPacket<'frame>> {
-        match IpVersion::of_packet(ip_payload.as_ref()) {
+        match IpVersion::of_packet(ip_payload) {
             #[cfg(feature = "proto-ipv4")]
             Ok(IpVersion::Ipv4) => {
                 let ipv4_packet = check!(Ipv4PacketWire::new_checked(ip_payload));

--- a/src/iface/interface/sixlowpan.rs
+++ b/src/iface/interface/sixlowpan.rs
@@ -8,12 +8,12 @@ use crate::wire::{Ipv6Packet as Ipv6PacketWire, *};
 pub(crate) const MAX_DECOMPRESSED_LEN: usize = 1500;
 
 impl InterfaceInner {
-    pub(super) fn process_sixlowpan<'output, 'payload: 'output, T: AsRef<[u8]> + ?Sized>(
+    pub(super) fn process_sixlowpan<'output, 'payload: 'output>(
         &mut self,
         sockets: &mut SocketSet,
         meta: PacketMeta,
         ieee802154_repr: &Ieee802154Repr,
-        payload: &'payload T,
+        payload: &'payload [u8],
         f: &'output mut FragmentsBuffer,
     ) -> Option<IpPacket<'output>> {
         let payload = match check!(SixlowpanPacket::dispatch(payload)) {
@@ -52,10 +52,10 @@ impl InterfaceInner {
     }
 
     #[cfg(feature = "proto-sixlowpan-fragmentation")]
-    fn process_sixlowpan_fragment<'output, 'payload: 'output, T: AsRef<[u8]> + ?Sized>(
+    fn process_sixlowpan_fragment<'output, 'payload: 'output>(
         &mut self,
         ieee802154_repr: &Ieee802154Repr,
-        payload: &'payload T,
+        payload: &'payload [u8],
         f: &'output mut FragmentsBuffer,
     ) -> Option<&'output [u8]> {
         use crate::iface::fragmentation::{AssemblerError, AssemblerFullError};

--- a/src/iface/interface/tests/ipv4.rs
+++ b/src/iface/interface/tests/ipv4.rs
@@ -23,7 +23,7 @@ fn test_no_icmp_no_unicast(#[case] medium: Medium) {
 
     let mut bytes = vec![0u8; 54];
     repr.emit(&mut bytes, &ChecksumCapabilities::default());
-    let frame = Ipv4PacketWire::new_unchecked(&bytes);
+    let frame = Ipv4PacketWire::new_unchecked(&bytes[..]);
 
     // Ensure that the unknown protocol frame does not trigger an
     // ICMP error response when the destination address is a
@@ -60,7 +60,7 @@ fn test_icmp_error_no_payload(#[case] medium: Medium) {
 
     let mut bytes = vec![0u8; 34];
     repr.emit(&mut bytes, &ChecksumCapabilities::default());
-    let frame = Ipv4PacketWire::new_unchecked(&bytes);
+    let frame = Ipv4PacketWire::new_unchecked(&bytes[..]);
 
     // The expected Destination Unreachable response due to the
     // unknown protocol
@@ -317,14 +317,14 @@ fn test_handle_ipv4_broadcast(#[case] medium: Medium) {
     let mut bytes = vec![0u8; ipv4_repr.buffer_len() + icmpv4_repr.buffer_len()];
     let frame = {
         ipv4_repr.emit(
-            &mut Ipv4PacketWire::new_unchecked(&mut bytes),
+            &mut Ipv4PacketWire::new_unchecked(&mut bytes[..]),
             &ChecksumCapabilities::default(),
         );
         icmpv4_repr.emit(
             &mut Icmpv4Packet::new_unchecked(&mut bytes[ipv4_repr.buffer_len()..]),
             &ChecksumCapabilities::default(),
         );
-        Ipv4PacketWire::new_unchecked(&bytes)
+        Ipv4PacketWire::new_unchecked(&bytes[..])
     };
 
     // Expected ICMPv4 echo reply
@@ -770,7 +770,7 @@ fn test_raw_socket_no_reply(#[case] medium: Medium) {
             |buf| fill_slice(buf, 0x2a),
             &ChecksumCapabilities::default(),
         );
-        Ipv4PacketWire::new_unchecked(&bytes)
+        Ipv4PacketWire::new_unchecked(&bytes[..])
     };
 
     assert_eq!(
@@ -866,7 +866,7 @@ fn test_raw_socket_with_udp_socket(#[case] medium: Medium) {
             |buf| buf.copy_from_slice(&UDP_PAYLOAD),
             &ChecksumCapabilities::default(),
         );
-        Ipv4PacketWire::new_unchecked(&bytes)
+        Ipv4PacketWire::new_unchecked(&bytes[..])
     };
 
     assert_eq!(

--- a/src/iface/interface/tests/ipv6.rs
+++ b/src/iface/interface/tests/ipv6.rs
@@ -49,7 +49,7 @@ fn multicast_source_address(#[case] medium: Medium) {
         iface.inner.process_ipv6(
             &mut sockets,
             PacketMeta::default(),
-            &Ipv6PacketWire::new_checked(&data).unwrap()
+            &Ipv6PacketWire::new_checked(&data[..]).unwrap()
         ),
         response
     );
@@ -97,7 +97,7 @@ fn hop_by_hop_skip_with_icmp(#[case] medium: Medium) {
         iface.inner.process_ipv6(
             &mut sockets,
             PacketMeta::default(),
-            &Ipv6PacketWire::new_checked(&data).unwrap()
+            &Ipv6PacketWire::new_checked(&data[..]).unwrap()
         ),
         response
     );
@@ -132,7 +132,7 @@ fn hop_by_hop_discard_with_icmp(#[case] medium: Medium) {
         iface.inner.process_ipv6(
             &mut sockets,
             PacketMeta::default(),
-            &Ipv6PacketWire::new_checked(&data).unwrap()
+            &Ipv6PacketWire::new_checked(&data[..]).unwrap()
         ),
         response
     );
@@ -191,7 +191,7 @@ fn imcp_empty_echo_request(#[case] medium: Medium) {
         iface.inner.process_ipv6(
             &mut sockets,
             PacketMeta::default(),
-            &Ipv6PacketWire::new_checked(&data).unwrap()
+            &Ipv6PacketWire::new_checked(&data[..]).unwrap()
         ),
         response
     );
@@ -251,7 +251,7 @@ fn icmp_echo_request(#[case] medium: Medium) {
         iface.inner.process_ipv6(
             &mut sockets,
             PacketMeta::default(),
-            &Ipv6PacketWire::new_checked(&data).unwrap()
+            &Ipv6PacketWire::new_checked(&data[..]).unwrap()
         ),
         response
     );
@@ -298,7 +298,7 @@ fn icmp_echo_reply_as_input(#[case] medium: Medium) {
         iface.inner.process_ipv6(
             &mut sockets,
             PacketMeta::default(),
-            &Ipv6PacketWire::new_checked(&data).unwrap()
+            &Ipv6PacketWire::new_checked(&data[..]).unwrap()
         ),
         response
     );
@@ -327,7 +327,7 @@ fn unknown_proto_with_multicast_dst_address(#[case] medium: Medium) {
         iface.inner.process_ipv6(
             &mut sockets,
             PacketMeta::default(),
-            &Ipv6PacketWire::new_checked(&data).unwrap()
+            &Ipv6PacketWire::new_checked(&data[..]).unwrap()
         ),
         response
     );
@@ -376,7 +376,7 @@ fn unknown_proto(#[case] medium: Medium) {
         iface.inner.process_ipv6(
             &mut sockets,
             PacketMeta::default(),
-            &Ipv6PacketWire::new_checked(&data).unwrap()
+            &Ipv6PacketWire::new_checked(&data[..]).unwrap()
         ),
         response
     );
@@ -420,7 +420,7 @@ fn ndsic_neighbor_advertisement_ethernet(#[case] medium: Medium) {
         iface.inner.process_ipv6(
             &mut sockets,
             PacketMeta::default(),
-            &Ipv6PacketWire::new_checked(&data).unwrap()
+            &Ipv6PacketWire::new_checked(&data[..]).unwrap()
         ),
         response
     );
@@ -476,7 +476,7 @@ fn ndsic_neighbor_advertisement_ethernet_multicast_addr(#[case] medium: Medium) 
         iface.inner.process_ipv6(
             &mut sockets,
             PacketMeta::default(),
-            &Ipv6PacketWire::new_checked(&data).unwrap()
+            &Ipv6PacketWire::new_checked(&data[..]).unwrap()
         ),
         response
     );
@@ -528,7 +528,7 @@ fn ndsic_neighbor_advertisement_ieee802154(#[case] medium: Medium) {
         iface.inner.process_ipv6(
             &mut sockets,
             PacketMeta::default(),
-            &Ipv6PacketWire::new_checked(&data).unwrap()
+            &Ipv6PacketWire::new_checked(&data[..]).unwrap()
         ),
         response
     );

--- a/src/iface/interface/tests/sixlowpan.rs
+++ b/src/iface/interface/tests/sixlowpan.rs
@@ -159,7 +159,7 @@ fn test_echo_request_sixlowpan_128_bytes() {
             &mut sockets,
             PacketMeta::default(),
             &ieee802154_repr,
-            &request_first_part_packet.into_inner(),
+            &request_first_part_packet.into_inner()[..],
             &mut iface.fragments
         ),
         None


### PR DESCRIPTION
Removing the generic reduces the code size and I don't think we actually need it in the interface.