### PR TITLE
Add comment about using static lifetime for SocketSets with owned storage

### DIFF
--- a/src/iface/socket_set.rs
+++ b/src/iface/socket_set.rs
@@ -37,7 +37,9 @@ impl fmt::Display for SocketHandle {
 
 /// An extensible set of sockets.
 ///
-/// The lifetime `'a` is used when storing a `Socket<'a>`.
+/// The lifetime `'a` is used when storing a `Socket<'a>`.  If you're using
+/// owned buffers for your sockets (passed in as `Vec`s) you can use
+/// `SocketSet<'static>`.
 #[derive(Debug)]
 pub struct SocketSet<'a> {
     sockets: ManagedSlice<'a, SocketStorage<'a>>,


### PR DESCRIPTION
It wasn't obvious to me that `'static` can/should be the lifetime to use with a `SocketSet` if you're not borrowing storage; adding a comment will hopefully save others a little time fighting with lifetime-creep and interactions with thread constraints (thread closures can only borrow `'static` data).