### PR TITLE
RFC: listen on all ports

### DIFF
--- a/examples/multicast.rs
+++ b/examples/multicast.rs
@@ -111,7 +111,7 @@ fn main() {
         }
 
         let socket = sockets.get_mut::<udp::Socket>(udp_handle);
-        if !socket.is_open() {
+        if !socket.is_bound() {
             socket.bind(MDNS_PORT).unwrap()
         }
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -96,7 +96,7 @@ fn main() {
 
         // udp:6969: respond "hello"
         let socket = sockets.get_mut::<udp::Socket>(udp_handle);
-        if !socket.is_open() {
+        if !socket.is_bound() {
             socket.bind(6969).unwrap()
         }
 

--- a/examples/sixlowpan.rs
+++ b/examples/sixlowpan.rs
@@ -113,7 +113,7 @@ fn main() {
 
         // udp:6969: respond "hello"
         let socket = sockets.get_mut::<udp::Socket>(udp_handle);
-        if !socket.is_open() {
+        if !socket.is_bound() {
             socket.bind(6969).unwrap()
         }
 

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1345,7 +1345,9 @@ impl<'a> Socket<'a> {
                 Some(addr) => ip_repr.dst_addr() == addr,
                 None => true,
             };
-            addr_ok && repr.dst_port != 0 && (self.listen_endpoint.port == 0 || repr.dst_port == self.listen_endpoint.port)
+            addr_ok
+                && repr.dst_port != 0
+                && (self.listen_endpoint.port == 0 || repr.dst_port == self.listen_endpoint.port)
         }
     }
 
@@ -1864,7 +1866,10 @@ impl<'a> Socket<'a> {
         let assembler_was_empty = self.assembler.is_empty();
 
         // Try adding payload octets to the assembler.
-        let Ok(contig_len) = self.assembler.add_then_remove_front(payload_offset, payload_len) else {
+        let Ok(contig_len) = self
+            .assembler
+            .add_then_remove_front(payload_offset, payload_len)
+        else {
             net_debug!(
                 "assembler: too many holes to add {} octets at offset {}",
                 payload_len,

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -745,16 +745,12 @@ impl<'a> Socket<'a> {
     /// Start listening on the given endpoint.
     ///
     /// This function returns `Err(Error::Illegal)` if the socket was already open
-    /// (see [is_open](#method.is_open)), and `Err(Error::Unaddressable)`
-    /// if the port in the given endpoint is zero.
+    /// (see [is_open](#method.is_open)).
     pub fn listen<T>(&mut self, local_endpoint: T) -> Result<(), ListenError>
     where
         T: Into<IpListenEndpoint>,
     {
         let local_endpoint = local_endpoint.into();
-        if local_endpoint.port == 0 {
-            return Err(ListenError::Unaddressable);
-        }
 
         if self.is_open() {
             return Err(ListenError::InvalidState);
@@ -1349,7 +1345,7 @@ impl<'a> Socket<'a> {
                 Some(addr) => ip_repr.dst_addr() == addr,
                 None => true,
             };
-            addr_ok && repr.dst_port != 0 && repr.dst_port == self.listen_endpoint.port
+            addr_ok && repr.dst_port != 0 && (self.listen_endpoint.port == 0 || repr.dst_port == self.listen_endpoint.port)
         }
     }
 
@@ -2895,9 +2891,9 @@ mod test {
     }
 
     #[test]
-    fn test_listen_validation() {
+    fn test_listen_any_port() {
         let mut s = socket();
-        assert_eq!(s.listen(0), Err(ListenError::Unaddressable));
+        assert_eq!(s.listen(0), Ok(()));
     }
 
     #[test]


### PR DESCRIPTION
This would close #809. It can also allow rebinding the UDP socket port, but that isn't implemented (granted, it's a single-line change)

I've still to create examples, tests and documentation, I'm publishing it in this state to get some feedback