### PR TITLE
Change `phy::RawSocket` to open the underlying socket with `O_NONBLOCK`

### DIFF
--- a/src/phy/sys/bpf.rs
+++ b/src/phy/sys/bpf.rs
@@ -57,7 +57,10 @@ fn open_device() -> io::Result<libc::c_int> {
     unsafe {
         for i in 0..256 {
             let dev = format!("/dev/bpf{}\0", i);
-            match libc::open(dev.as_ptr() as *const libc::c_char, libc::O_RDWR) {
+            match libc::open(
+                dev.as_ptr() as *const libc::c_char,
+                libc::O_RDWR | libc::O_NONBLOCK,
+            ) {
                 -1 => continue,
                 fd => return Ok(fd),
             };


### PR DESCRIPTION
`phy::RawSocket` is written in a way assuming that the underlying socket is nonblocking (e.g `receive` checks for `io::ErrorKind::WouldBlock` [here](https://github.com/smoltcp-rs/smoltcp/blob/f9b064a4a81e72d3e1fe574ddbd57ec0e86f96c2/src/phy/raw_socket.rs#L84)). However, the socket was not being opened in a nonblocking mode.

I found this by trying to use `phy::RawSocket` to test some larger chunk of `smoltcp`-using code on macOS -- the first call to `iface.poll(...)` blocked indefinitely.

