### PR TITLE
RFC: support for TCP Segmentation Offloading (TSO)

### DIFF
--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -1751,7 +1751,7 @@ impl InterfaceInner {
                     emit_ip(&ip_repr, tx_buffer);
                     Ok(())
                 })
-            },
+            }
         }
     }
 }

--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -304,7 +304,7 @@ pub struct DeviceCapabilities {
     /// TCP segmentation offload (TSO) support
     ///
     /// If the network device is able to support TCP segmentation offloading (TSO),
-    /// the stack forward the segementation to the harware to improve qthe performance.
+    /// the stack forward the segementation to the harware to improve the performance.
     pub tso: TsoCapabilities,
 }
 

--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -224,6 +224,39 @@ impl ChecksumCapabilities {
     }
 }
 
+/// Describes if the device supports TCP segment offloading (TSO).
+#[derive(Debug, Copy, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TsoCapabilities {
+    /// Supports TSO for IPv4 and IPv6
+    Both,
+    /// Supports TSO for IPv4
+    Tso4,
+    /// Supports TSO for IPv6
+    Tso6,
+    /// Doesn't support TSO
+    #[default]
+    None,
+}
+
+impl TsoCapabilities {
+    /// Returns true if TCP segment offloading is supported for IPv4
+    pub fn tso4(&self) -> bool {
+        match *self {
+            TsoCapabilities::Both | TsoCapabilities::Tso4 => true,
+            _ => false,
+        }
+    }
+
+    /// Returns true if TCP segment offloading is supported for IPv6
+    pub fn tso6(&self) -> bool {
+        match *self {
+            TsoCapabilities::Both | TsoCapabilities::Tso6 => true,
+            _ => false,
+        }
+    }
+}
+
 /// A description of device capabilities.
 ///
 /// Higher-level protocols may achieve higher throughput or lower latency if they consider
@@ -267,6 +300,12 @@ pub struct DeviceCapabilities {
     /// If the network device is capable of verifying or computing checksums for some protocols,
     /// it can request that the stack not do so in software to improve performance.
     pub checksum: ChecksumCapabilities,
+
+    /// TCP segmentation offload (TSO) support
+    ///
+    /// If the network device is able to support TCP segmentation offloading (TSO),
+    /// the stack forward the segementation to the harware to improve qthe performance.
+    pub tso: TsoCapabilities,
 }
 
 impl DeviceCapabilities {
@@ -281,6 +320,14 @@ impl DeviceCapabilities {
             #[cfg(feature = "medium-ieee802154")]
             Medium::Ieee802154 => self.max_transmission_unit, // TODO(thvdveld): what is the MTU for Medium::IEEE802
         }
+    }
+
+    pub fn tso4(&self) -> bool {
+        self.tso.tso4()
+    }
+
+    pub fn tso6(&self) -> bool {
+        self.tso.tso6()
     }
 }
 

--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -224,7 +224,7 @@ impl ChecksumCapabilities {
     }
 }
 
-/// Describes if the device supports TCP segment offloading (TSO).
+/// Describes if the device supports TCP segmentation offloading (TSO).
 #[derive(Debug, Copy, Clone, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TsoCapabilities {

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -2202,12 +2202,9 @@ impl<'a> Socket<'a> {
                 };
 
                 let size = if tso {
-                    win_limit.min(
-                        u16::MAX as usize
-                            - ETHERNET_HEADER_LEN
-                            - ip_repr.header_len()
-                            - TCP_HEADER_LEN,
-                    )
+                    // according to the Virtio I/O Device Specification the maximum size of
+                    // a TCP or UDP packet, plus the 14 byte ethernet header
+                    win_limit.min(65550)
                 } else {
                     // Maximum size we're allowed to send. This can be limited by 3 factors:
                     // 1. remote window

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -13,8 +13,8 @@ use crate::socket::{Context, PollAt};
 use crate::storage::{Assembler, RingBuffer};
 use crate::time::{Duration, Instant};
 use crate::wire::{
-    ETHERNET_HEADER_LEN, IpAddress, IpEndpoint, IpListenEndpoint, IpProtocol, IpRepr, ip::Version, TcpControl, TcpRepr,
-    TcpSeqNumber, TCP_HEADER_LEN,
+    ip::Version, IpAddress, IpEndpoint, IpListenEndpoint, IpProtocol, IpRepr, TcpControl, TcpRepr,
+    TcpSeqNumber, ETHERNET_HEADER_LEN, TCP_HEADER_LEN,
 };
 
 macro_rules! tcp_trace {
@@ -1868,7 +1868,10 @@ impl<'a> Socket<'a> {
         let assembler_was_empty = self.assembler.is_empty();
 
         // Try adding payload octets to the assembler.
-        let Ok(contig_len) = self.assembler.add_then_remove_front(payload_offset, payload_len) else {
+        let Ok(contig_len) = self
+            .assembler
+            .add_then_remove_front(payload_offset, payload_len)
+        else {
             net_debug!(
                 "assembler: too many holes to add {} octets at offset {}",
                 payload_len,
@@ -2199,7 +2202,12 @@ impl<'a> Socket<'a> {
                 };
 
                 let size = if tso {
-                    win_limit.min(u16::MAX as usize - ETHERNET_HEADER_LEN - ip_repr.header_len() - TCP_HEADER_LEN)
+                    win_limit.min(
+                        u16::MAX as usize
+                            - ETHERNET_HEADER_LEN
+                            - ip_repr.header_len()
+                            - TCP_HEADER_LEN,
+                    )
                 } else {
                     // Maximum size we're allowed to send. This can be limited by 3 factors:
                     // 1. remote window


### PR DESCRIPTION
I tried to extend a driver to support TCP segmentation offloading (TSO). In this case, smoltcp has to create one header (Ethernert+IP+TCP) followed by multiple payloads. To support TSO, I extended the `DeviceCapabilities`  with `TsoCapabilities`. `TsoCapabilities` can describe, if TSO is supported for IPv4, IPv6 or both. In case TSO is supported, smoltcp emits packets with the maximum size of the remote window to the device driver.

Maybe my solution is a little bit naive. I am not an TCP expert. My test driver is a revised driver for [Virtio](https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-1940001). Consquently, my VM uses virtio to forward messages to a tap device. Afterwards, the host forwards the packets over a 10 Gbit/s device to a server, which sends a response back. Both devices (tap and the ethernet device) supports TSO. I monitored the communication with Wireshark. It seems to work and I don't see any strange behavior.

I would appreciate comments to improve my work.