### PR TITLE
Parse full IPv6 packet before processing

### DIFF
--- a/src/iface/interface/sixlowpan.rs
+++ b/src/iface/interface/sixlowpan.rs
@@ -566,8 +566,7 @@ impl InterfaceInner {
                     checksum_caps,
                 );
             }
-            #[cfg(feature = "socket-raw")]
-            IpPayload::Raw(_raw) => todo!(),
+            IpPayload::Raw(_) => todo!(),
 
             #[allow(unreachable_patterns)]
             _ => unreachable!(),

--- a/src/iface/interface/tests/ipv4.rs
+++ b/src/iface/interface/tests/ipv4.rs
@@ -239,8 +239,8 @@ fn test_icmp_error_port_unreachable(#[case] medium: Medium) {
         iface.inner.process_udp(
             &mut sockets,
             PacketMeta::default(),
-            ip_repr,
-            udp_repr,
+            &ip_repr,
+            &udp_repr,
             false,
             &UDP_PAYLOAD,
             data
@@ -273,8 +273,8 @@ fn test_icmp_error_port_unreachable(#[case] medium: Medium) {
         iface.inner.process_udp(
             &mut sockets,
             PacketMeta::default(),
-            ip_repr,
-            udp_repr,
+            &ip_repr,
+            &udp_repr,
             false,
             &UDP_PAYLOAD,
             packet_broadcast.into_inner(),
@@ -573,7 +573,6 @@ fn test_icmpv4_socket(#[case] medium: Medium) {
         payload_len: 24,
         hop_limit: 64,
     };
-    let ip_repr = IpRepr::Ipv4(ipv4_repr);
 
     // Open a socket and ensure the packet is handled due to the listening
     // socket.
@@ -591,7 +590,9 @@ fn test_icmpv4_socket(#[case] medium: Medium) {
         ..ipv4_repr
     };
     assert_eq!(
-        iface.inner.process_icmpv4(&mut sockets, ip_repr, icmp_data),
+        iface
+            .inner
+            .process_icmpv4(&mut sockets, &ipv4_repr, icmp_data),
         Some(IpPacket::new_ipv4(
             ipv4_reply,
             IpPayload::Icmpv4(echo_reply)
@@ -957,8 +958,8 @@ fn test_icmp_reply_size(#[case] medium: Medium) {
         iface.inner.process_udp(
             &mut sockets,
             PacketMeta::default(),
-            ip_repr.into(),
-            udp_repr,
+            &IpRepr::Ipv4(ip_repr),
+            &udp_repr,
             false,
             &vec![0x2a; MAX_PAYLOAD_LEN],
             payload,

--- a/src/iface/interface/tests/ipv6.rs
+++ b/src/iface/interface/tests/ipv6.rs
@@ -721,8 +721,8 @@ fn test_icmp_reply_size(#[case] medium: Medium) {
         iface.inner.process_udp(
             &mut sockets,
             PacketMeta::default(),
-            ip_repr.into(),
-            udp_repr,
+            &IpRepr::Ipv6(ip_repr),
+            &udp_repr,
             false,
             &vec![0x2a; MAX_PAYLOAD_LEN],
             payload,

--- a/src/iface/interface/tests/mod.rs
+++ b/src/iface/interface/tests/mod.rs
@@ -129,8 +129,8 @@ fn test_handle_udp_broadcast(
         iface.inner.process_udp(
             &mut sockets,
             PacketMeta::default(),
-            ip_repr,
-            udp_repr,
+            &ip_repr,
+            &udp_repr,
             false,
             &UDP_PAYLOAD,
             packet.into_inner(),

--- a/src/iface/ip_packet.rs
+++ b/src/iface/ip_packet.rs
@@ -42,7 +42,6 @@ impl<'p> IpPacket<'p> {
     pub(crate) fn new_ipv6(ip_repr: Ipv6Repr, payload: IpPayload<'p>) -> Self {
         Self::Ipv6(Ipv6Packet {
             header: ip_repr,
-            #[cfg(feature = "proto-ipv6-hbh")]
             hop_by_hop: None,
             #[cfg(feature = "proto-ipv6-fragmentation")]
             fragment: None,
@@ -90,7 +89,6 @@ impl<'p> IpPacket<'p> {
                 &mut Icmpv6Packet::new_unchecked(payload),
                 &caps.checksum,
             ),
-            #[cfg(feature = "socket-raw")]
             IpPayload::Raw(raw_packet) => payload.copy_from_slice(raw_packet),
             #[cfg(any(feature = "socket-udp", feature = "socket-dns"))]
             IpPayload::Udp(udp_repr, inner_payload) => udp_repr.emit(
@@ -154,7 +152,6 @@ pub(crate) struct Ipv4Packet<'p> {
 #[cfg(feature = "proto-ipv6")]
 pub(crate) struct Ipv6Packet<'p> {
     pub(crate) header: Ipv6Repr,
-    #[cfg(feature = "proto-ipv6-hbh")]
     pub(crate) hop_by_hop: Option<Ipv6HopByHopRepr<'p>>,
     #[cfg(feature = "proto-ipv6-fragmentation")]
     pub(crate) fragment: Option<Ipv6FragmentRepr>,
@@ -172,7 +169,6 @@ pub(crate) enum IpPayload<'p> {
     Igmp(IgmpRepr),
     #[cfg(feature = "proto-ipv6")]
     Icmpv6(Icmpv6Repr<'p>),
-    #[cfg(feature = "socket-raw")]
     Raw(&'p [u8]),
     #[cfg(any(feature = "socket-udp", feature = "socket-dns"))]
     Udp(UdpRepr, &'p [u8]),
@@ -198,8 +194,7 @@ impl<'p> IpPayload<'p> {
             Self::Tcp(_) => SixlowpanNextHeader::Uncompressed(IpProtocol::Tcp),
             #[cfg(feature = "socket-udp")]
             Self::Udp(..) => SixlowpanNextHeader::Compressed,
-            #[cfg(feature = "socket-raw")]
-            Self::Raw(_) => todo!(),
+            Self::Raw(_) => unreachable!(),
         }
     }
 }

--- a/src/wire/ipv6hbh.rs
+++ b/src/wire/ipv6hbh.rs
@@ -66,7 +66,7 @@ pub struct Repr<'a> {
 
 impl<'a> Repr<'a> {
     /// Parse an IPv6 Hop-by-Hop Header and return a high-level representation.
-    pub fn parse<T>(header: &'a Header<&'a T>) -> Result<Repr<'a>>
+    pub fn parse<T>(header: &Header<&'a T>) -> Result<Repr<'a>>
     where
         T: AsRef<[u8]> + ?Sized,
     {

--- a/src/wire/ipv6routing.rs
+++ b/src/wire/ipv6routing.rs
@@ -223,12 +223,14 @@ impl<T: AsRef<[u8]>> Header<T> {
         let data = self.buffer.as_ref();
         data[field::PAD] >> 4
     }
+}
 
+impl<'a, T: AsRef<[u8]> + ?Sized> Header<&'a T> {
     /// Return the address vector in bytes
     ///
     /// # Panics
     /// This function may panic if this header is not the RPL Source Routing Header routing type.
-    pub fn addresses(&self) -> &[u8] {
+    pub fn addresses(&self) -> &'a [u8] {
         let data = self.buffer.as_ref();
         &data[field::ADDRESSES..]
     }
@@ -372,7 +374,7 @@ pub enum Repr<'a> {
 
 impl<'a> Repr<'a> {
     /// Parse an IPv6 Routing Header and return a high-level representation.
-    pub fn parse<T>(header: &'a Header<&'a T>) -> Result<Repr<'a>>
+    pub fn parse<T>(header: &Header<&'a T>) -> Result<Repr<'a>>
     where
         T: AsRef<[u8]> + ?Sized,
     {


### PR DESCRIPTION
With these changes, an IPv6 packet is fully parsed before being processed by other functions. I made these changes, because for RPL, IPv6 hop-by-hop headers and routing headers need to be modified after they are parsed such that packets can be forwarded/processed correctly. For example, if an hop-by-hop is present followed by a routing header, first the hop-by-hop needs to be processed before the routing header. With the implementation currently in main, it is not clear if the processing in of the headers is done in this order. It is also not easy to keep these headers around until they need to be forwarded.

With the changes, an IPv6 packet is parsed into an `Ipv6Packet` (not the one from wire). This packet contains a parsed IPv6 header, Hop-by-Hop header, Routing header, Fragmentation header and a payload, which may be TCP, UDP, ICMPv6, etc. With the changes, when a packet needs to be forwarded, the parsed IPv6 packet can now easily be modified and returned by the `process_ipv6` function, such that the packet is forwarded with the correct headers.

At first, I thought that the modifications I made will impact the binary sizes and make it way bigger, however, I was surprised to see that it's even a tiny bit smaller now.

Example server (before):
```
   text	  data	   bss	   dec	   hex	filename
1482212	 81272	   536	1564020	17dd74	server
```

Example server (after):
```
   text	  data	   bss	   dec	   hex	filename
1482060	 80800	   536	1563396	17db04	server
```

Example sixlowpan (before):
```
   text	  data	   bss	   dec	   hex	filename
1469581	 80256	   536	1550373	17a825	sixlowpan
```

Example sixlowpan (after):
```
   text	  data	   bss	   dec	   hex	filename
1469429	 79784	   536	1549749	17a5b5	sixlowpan
```