### PR TITLE
Match the behavior of peek_slice to recv_slice

### DIFF
--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1173,10 +1173,7 @@ impl<'a> Socket<'a> {
     ///
     /// This function otherwise behaves identically to [recv_slice](#method.recv_slice).
     pub fn peek_slice(&mut self, data: &mut [u8]) -> Result<usize, RecvError> {
-        let buffer = self.peek(data.len())?;
-        let data = &mut data[..buffer.len()];
-        data.copy_from_slice(buffer);
-        Ok(buffer.len())
+        Ok(self.rx_buffer.read_allocated(0, data))
     }
 
     /// Return the amount of octets queued in the transmit buffer.


### PR DESCRIPTION
Previously, ```peek_slice()``` did not match the behavior of ```recv_slice()``` when there is a buffer wrapparound. I believe that by using the ```read_allocated()``` method, this will be fixed. I created an issue for this here: https://github.com/smoltcp-rs/smoltcp/issues/833

This is my first time trying to contribute to smoltcp so I've only tested locally a few ways. One is running my program that uses ```peek_slice()``` that previously failed (it now succeeds). I also ran:
```
cargo +stable test --no-default-features --features alloc,socket-tcp,proto-ipv4,medium-ethernet
``` 
And the tests completed succesfully. Please let me know if I need to do anything else.