### PR TITLE
DHCP: Add an upper bound to the renew/rebind timeout in `RetryConfig`

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -184,6 +184,8 @@ pub struct Duration {
 
 impl Duration {
     pub const ZERO: Duration = Duration::from_micros(0);
+    /// The longest possible duration we can encode.
+    pub const MAX: Duration = Duration::from_micros(u64::MAX);
     /// Create a new `Duration` from a number of microseconds.
     pub const fn from_micros(micros: u64) -> Duration {
         Duration { micros }


### PR DESCRIPTION
# Description

This lets the user set an upper bound on the duration between times smoltcp sends a renew or rebind by setting a `max_renew_timeout` field to DHCP `RetryConfig` struct, which defaults to not imposing a cap unless the user explicitly sets one.

### Design questions

Use of this feature doesn't follow the official DHCP spec, but the `RetryConfig` struct already has a `min_renew_timeout` field which breaks the same spec by allowing the user to change the lower-bound imposed, so I think this is reasonable to add. Feel free to close this PR if you disagree.

I also added `#[non_exhaustive]` to the `RetryConfig` struct because this addition will necessarily be backwards incompatible and ineligible for inclusion until `v0.11.0`, but marking it as `#[non_exhaustive]` will allow anyone else in the future who wants more configuration options to add them without breaking backwards-compatibility. I can remove this attribute and let any future additions also require a major change instead.

I also didn't put any checks for the user putting `max_renew_duration` smaller than the existing `min_renew_duration`. If they do, then they'll silently get `max_renew_duration` as the chosen value every time. I think this is a reasonable response to an unlikely scenario, but I can do something else instead if you prefer.

# Validation

The existing unit tests cover logic in the case where no upper bound is set. I added a new unit test that covers the user setting a custom upper- and lower- bound to ensure that this behavior acts correctly.

I also have a firmware setup which uses this DHCP client that I switched to using this branch and set the maximum, and observed it capping at the maximum like expected.