### PR TITLE
Support TUNSETIFF on MIPS, PPC and SPARC

### DIFF
--- a/src/phy/sys/linux.rs
+++ b/src/phy/sys/linux.rs
@@ -5,7 +5,22 @@ pub const SIOCGIFINDEX: libc::c_ulong = 0x8933;
 pub const ETH_P_ALL: libc::c_short = 0x0003;
 pub const ETH_P_IEEE802154: libc::c_short = 0x00F6;
 
-pub const TUNSETIFF: libc::c_ulong = 0x400454CA;
+// Constant definition as per
+// https://github.com/golang/sys/blob/master/unix/zerrors_linux_<arch>.go
+pub const TUNSETIFF: libc::c_ulong = if cfg!(any(
+    target_arch = "mips",
+    target_arch = "mips64",
+    target_arch = "mips64el",
+    target_arch = "mipsel",
+    target_arch = "powerpc",
+    target_arch = "powerpc64",
+    target_arch = "powerpc64le",
+    target_arch = "sparc64"
+)) {
+    0x800454CA
+} else {
+    0x400454CA
+};
 pub const IFF_TUN: libc::c_int = 0x0001;
 pub const IFF_TAP: libc::c_int = 0x0002;
 pub const IFF_NO_PI: libc::c_int = 0x1000;


### PR DESCRIPTION
This commit adds support for the TUNSETIFF constant on MIPS, PPC and
SPARC. The TUNSETIFF constant defined in the Linux kernel headers uses
architecture-specific macros. For this commit, the architecture-specific
definitions of the constant in the Golang source code were consulted.