### PR TITLE
Fix fuzzer

### DIFF
--- a/fuzz/fuzz_targets/sixlowpan_packet.rs
+++ b/fuzz/fuzz_targets/sixlowpan_packet.rs
@@ -94,6 +94,7 @@ fuzz_target!(|fuzz: SixlowpanPacketFuzzer| {
                                                     &iphc_repr.dst_addr,
                                                     frame.payload().len(),
                                                     |b| b.copy_from_slice(frame.payload()),
+                                                    &ChecksumCapabilities::ignored(),
                                                 );
                                             }
                                         }
@@ -181,7 +182,7 @@ fuzz_target!(|fuzz: SixlowpanPacketFuzzer| {
                                 if let Ok(frame) = Ipv6RoutingHeader::new_checked(payload) {
                                     if let Ok(repr) = Ipv6RoutingRepr::parse(&frame) {
                                         let mut buffer = vec![0; repr.buffer_len()];
-                                        let mut packet = Ipv6RoutingHeader::new(&mut buffer[..]);
+                                        let mut packet = Ipv6RoutingHeader::new_unchecked(&mut buffer[..]);
                                         repr.emit(&mut packet);
                                     }
                                 }

--- a/src/wire/ipv6routing.rs
+++ b/src/wire/ipv6routing.rs
@@ -269,8 +269,8 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Header<T> {
             Type::Rpl => {
                 // Retain the higher order 4 bits of the padding field
                 data[field::PAD] &= 0xF0;
-                data[6] = 0;
-                data[7] = 0;
+                data[4] = 0;
+                data[5] = 0;
             }
 
             _ => panic!("Unrecognized routing type when clearing reserved fields."),


### PR DESCRIPTION
Updates the `sixlowpan_packet` fuzzer. Running the fuzzer found 2 issues: IPv6Route packet wrote OOB and 6LoWPAN Extension Header did not parse inlined next headers correctly. This PR fixes these issues and added a test.