### PR TITLE
fix(dhcpv4): panic when parsing address

### DIFF
--- a/src/wire/dhcpv4.rs
+++ b/src/wire/dhcpv4.rs
@@ -788,13 +788,18 @@ impl<'a> Repr<'a> {
                 (field::OPT_DOMAIN_NAME_SERVER, _) => {
                     let mut servers = Vec::new();
                     const IP_ADDR_BYTE_LEN: usize = 4;
-                    for chunk in data.chunks(IP_ADDR_BYTE_LEN) {
+                    let mut addrs = data.chunks_exact(IP_ADDR_BYTE_LEN);
+                    for chunk in &mut addrs {
                         // We ignore push failures because that will only happen
                         // if we attempt to push more than 4 addresses, and the only
                         // solution to that is to support more addresses.
                         servers.push(Ipv4Address::from_bytes(chunk)).ok();
                     }
                     dns_servers = Some(servers);
+
+                    if !addrs.remainder().is_empty() {
+                        net_trace!("DHCP domain name servers contained invalid address");
+                    }
                 }
                 _ => {}
             }


### PR DESCRIPTION
If the domain name server address list did not contain the correct amount of bytes, then the last `chunk` was not 4 bytes long and `Ipv4Address::from_bytes` would panic.