### PR TITLE
Add function to explicitly set the flag given the u16 value.

### DIFF
--- a/src/wire/tcp.rs
+++ b/src/wire/tcp.rs
@@ -432,11 +432,7 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Packet<T> {
     pub fn set_flag(&self, flag:u16) -> bool {
         let data = self.buffer.as_ref();
         let raw = NetworkEndian::read_u16(&data[field::FLAGS]);
-        let raw = if value {
-            raw | flag
-        } else {
-            raw & !flag
-        };
+        let raw = raw & flags != 0
         NetworkEndian::write_u16(&mut data[field::FLAGS], raw)
     }
 

--- a/src/wire/tcp.rs
+++ b/src/wire/tcp.rs
@@ -427,6 +427,19 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Packet<T> {
         NetworkEndian::write_u16(&mut data[field::FLAGS], raw)
     }
 
+    // Set a flag given a u16 value.
+     #[inline]
+    pub fn set_flag(&self, flag:u16) -> bool {
+        let data = self.buffer.as_ref();
+        let raw = NetworkEndian::read_u16(&data[field::FLAGS]);
+        let raw = if value {
+            raw | flag
+        } else {
+            raw & !flag
+        };
+        NetworkEndian::write_u16(&mut data[field::FLAGS], raw)
+    }
+
     /// Set the FIN flag.
     #[inline]
     pub fn set_fin(&mut self, value: bool) {

--- a/src/wire/tcp.rs
+++ b/src/wire/tcp.rs
@@ -429,10 +429,10 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Packet<T> {
 
     // Set a flag given a u16 value.
      #[inline]
-    pub fn set_flag(&self, flag:u16) -> bool {
+    pub fn set_flag(&self, flag:u16) {
         let data = self.buffer.as_ref();
         let raw = NetworkEndian::read_u16(&data[field::FLAGS]);
-        let raw = raw & flags != 0
+        let raw = raw & flags != 0;
         NetworkEndian::write_u16(&mut data[field::FLAGS], raw)
     }
 


### PR DESCRIPTION
Hi, 

I have a current use case to explicitly utilize the u16 values of the flag types of a TCP header rather than using the Boolean setter as this will speed up the current implementation of the logic I am writing.

This PR adds explicit functionality to allowing a flag to be set given a u16 value.