### PR TITLE
return RecvError::Truncated when calling recv_slice with a small buffer

### DIFF
--- a/src/socket/raw.rs
+++ b/src/socket/raw.rs
@@ -57,12 +57,14 @@ impl std::error::Error for SendError {}
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum RecvError {
     Exhausted,
+    Truncated,
 }
 
 impl core::fmt::Display for RecvError {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             RecvError::Exhausted => write!(f, "exhausted"),
+            RecvError::Truncated => write!(f, "truncated"),
         }
     }
 }
@@ -273,9 +275,16 @@ impl<'a> Socket<'a> {
 
     /// Dequeue a packet, and copy the payload into the given slice.
     ///
+    /// **Note**: when the size of the provided buffer is smaller than the size of the payload,
+    /// the packet is dropped and a `RecvError::Truncated` error is returned.
+    ///
     /// See also [recv](#method.recv).
     pub fn recv_slice(&mut self, data: &mut [u8]) -> Result<usize, RecvError> {
         let buffer = self.recv()?;
+        if data.len() < buffer.len() {
+            return Err(RecvError::Truncated);
+        }
+
         let length = min(data.len(), buffer.len());
         data[..length].copy_from_slice(&buffer[..length]);
         Ok(length)
@@ -303,9 +312,16 @@ impl<'a> Socket<'a> {
     /// and return the amount of octets copied without removing the packet from the receive buffer.
     /// This function otherwise behaves identically to [recv_slice](#method.recv_slice).
     ///
+    /// **Note**: when the size of the provided buffer is smaller than the size of the payload,
+    /// no data is copied into the provided buffer and a `RecvError::Truncated` error is returned.
+    ///
     /// See also [peek](#method.peek).
     pub fn peek_slice(&mut self, data: &mut [u8]) -> Result<usize, RecvError> {
         let buffer = self.peek()?;
+        if data.len() < buffer.len() {
+            return Err(RecvError::Truncated);
+        }
+
         let length = min(data.len(), buffer.len());
         data[..length].copy_from_slice(&buffer[..length]);
         Ok(length)
@@ -602,8 +618,7 @@ mod test {
                     socket.process(&mut cx, &$hdr, &$payload);
 
                     let mut slice = [0; 4];
-                    assert_eq!(socket.recv_slice(&mut slice[..]), Ok(4));
-                    assert_eq!(&slice, &$packet[..slice.len()]);
+                    assert_eq!(socket.recv_slice(&mut slice[..]), Err(RecvError::Truncated));
                 }
 
                 #[rstest]
@@ -641,10 +656,8 @@ mod test {
                     socket.process(&mut cx, &$hdr, &$payload);
 
                     let mut slice = [0; 4];
-                    assert_eq!(socket.peek_slice(&mut slice[..]), Ok(4));
-                    assert_eq!(&slice, &$packet[..slice.len()]);
-                    assert_eq!(socket.recv_slice(&mut slice[..]), Ok(4));
-                    assert_eq!(&slice, &$packet[..slice.len()]);
+                    assert_eq!(socket.peek_slice(&mut slice[..]), Err(RecvError::Truncated));
+                    assert_eq!(socket.recv_slice(&mut slice[..]), Err(RecvError::Truncated));
                     assert_eq!(socket.peek_slice(&mut slice[..]), Err(RecvError::Exhausted));
                 }
             }

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1331,7 +1331,7 @@ impl<'a> Socket<'a> {
         // Rate-limit to 1 per second max.
         self.challenge_ack_timer = cx.now() + Duration::from_secs(1);
 
-        return Some(self.ack_reply(ip_repr, repr));
+        Some(self.ack_reply(ip_repr, repr))
     }
 
     pub(crate) fn accepts(&self, _cx: &mut Context, ip_repr: &IpRepr, repr: &TcpRepr) -> bool {


### PR DESCRIPTION
When calling `recv_slice`/`peek_slice` in the udp, icmp and raw sockets, data is lost when the provided buffer is smaller than the payload to be copied (not the case for `peek_slice` because it is not dequeued).

With this commit, an `RecvError::Truncated` error is returned. In case of UDP, the endpoint is also returned in the error. In case of ICMP, the IP address is also returned in the error.

I implemented it the way @whitequark proposes it in #330. Data is still lost, but at least the caller knows that the data was truncated to the size of the provided buffer. As @whitequark says, it is preferred to call `recv` instead of `recv_slice` as there would be no truncation. If this is expected behaviour for `recv_slice`, we could close #330.