### PR TITLE
Check IPv6 address after processing HBH

### DIFF
--- a/src/iface/interface/igmp.rs
+++ b/src/iface/interface/igmp.rs
@@ -208,21 +208,6 @@ impl Interface {
 }
 
 impl InterfaceInner {
-    /// Check whether the interface listens to given destination multicast IP address.
-    ///
-    /// If built without feature `proto-igmp` this function will
-    /// always return `false`.
-    pub fn has_multicast_group<T: Into<IpAddress>>(&self, addr: T) -> bool {
-        match addr.into() {
-            IpAddress::Ipv4(key) => {
-                key == Ipv4Address::MULTICAST_ALL_SYSTEMS
-                    || self.ipv4_multicast_groups.get(&key).is_some()
-            }
-            #[allow(unreachable_patterns)]
-            _ => false,
-        }
-    }
-
     /// Host duties of the **IGMPv2** protocol.
     ///
     /// Sets up `igmp_report_state` for responding to IGMP general/specific membership queries.

--- a/src/iface/interface/ipv6.rs
+++ b/src/iface/interface/ipv6.rs
@@ -49,7 +49,10 @@ impl InterfaceInner {
             (ipv6_repr.next_header, ipv6_packet.payload())
         };
 
-        if !self.has_ip_addr(ipv6_repr.dst_addr) && !self.has_multicast_group(ipv6_repr.dst_addr) {
+        if !self.has_ip_addr(ipv6_repr.dst_addr)
+            && !self.has_multicast_group(ipv6_repr.dst_addr)
+            && !ipv6_repr.dst_addr.is_loopback()
+        {
             net_trace!("packet IP address not for this interface");
             return None;
         }

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -1023,11 +1023,7 @@ impl InterfaceInner {
             #[cfg(feature = "proto-rpl")]
             IpAddress::Ipv6(Ipv6Address::LINK_LOCAL_ALL_RPL_NODES) => true,
             #[cfg(feature = "proto-ipv6")]
-            IpAddress::Ipv6(addr) => self.ip_addrs.iter().any(|a| match a.address() {
-                IpAddress::Ipv6(a) => a.solicited_node() == addr,
-                #[allow(unreachable_patterns)]
-                _ => false,
-            }),
+            IpAddress::Ipv6(addr) => self.has_solicited_node(addr),
             #[allow(unreachable_patterns)]
             _ => false,
         }

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -1007,9 +1007,30 @@ impl InterfaceInner {
         })
     }
 
-    #[cfg(not(feature = "proto-igmp"))]
+    /// Check whether the interface listens to given destination multicast IP address.
+    ///
+    /// If built without feature `proto-igmp` this function will
+    /// always return `false` when using IPv4.
     fn has_multicast_group<T: Into<IpAddress>>(&self, addr: T) -> bool {
-        false
+        match addr.into() {
+            #[cfg(feature = "proto-igmp")]
+            IpAddress::Ipv4(key) => {
+                key == Ipv4Address::MULTICAST_ALL_SYSTEMS
+                    || self.ipv4_multicast_groups.get(&key).is_some()
+            }
+            #[cfg(feature = "proto-ipv6")]
+            IpAddress::Ipv6(Ipv6Address::LINK_LOCAL_ALL_NODES) => true,
+            #[cfg(feature = "proto-rpl")]
+            IpAddress::Ipv6(Ipv6Address::LINK_LOCAL_ALL_RPL_NODES) => true,
+            #[cfg(feature = "proto-ipv6")]
+            IpAddress::Ipv6(addr) => self.ip_addrs.iter().any(|a| match a.address() {
+                IpAddress::Ipv6(a) => a.solicited_node() == addr,
+                #[allow(unreachable_patterns)]
+                _ => false,
+            }),
+            #[allow(unreachable_patterns)]
+            _ => false,
+        }
     }
 
     #[cfg(feature = "medium-ip")]

--- a/src/iface/interface/tests/sixlowpan.rs
+++ b/src/iface/interface/tests/sixlowpan.rs
@@ -59,6 +59,13 @@ fn icmp_echo_request(#[case] medium: Medium) {
     ));
 
     let (mut iface, mut sockets, _device) = setup(medium);
+    iface.update_ip_addrs(|ips| {
+        ips.push(IpCidr::Ipv6(Ipv6Cidr::new(
+            Ipv6Address::from_parts(&[0xfe80, 0, 0, 0, 0x180b, 0x4242, 0x4242, 0x4242]),
+            10,
+        )))
+        .unwrap();
+    });
 
     assert_eq!(
         iface.inner.process_ieee802154(
@@ -77,6 +84,13 @@ fn test_echo_request_sixlowpan_128_bytes() {
     use crate::phy::Checksum;
 
     let (mut iface, mut sockets, mut device) = setup(Medium::Ieee802154);
+    iface.update_ip_addrs(|ips| {
+        ips.push(IpCidr::Ipv6(Ipv6Cidr::new(
+            Ipv6Address::new(0xfe80, 0x0, 0x0, 0x0, 0x92fc, 0x48c2, 0xa441, 0xfc76),
+            10,
+        )))
+        .unwrap();
+    });
     // TODO: modify the example, such that we can also test if the checksum is correctly
     // computed.
     iface.inner.caps.checksum.icmpv6 = Checksum::None;
@@ -283,6 +297,13 @@ fn test_sixlowpan_udp_with_fragmentation() {
     };
 
     let (mut iface, mut sockets, mut device) = setup(Medium::Ieee802154);
+    iface.update_ip_addrs(|ips| {
+        ips.push(IpCidr::Ipv6(Ipv6Cidr::new(
+            Ipv6Address::new(0xfe80, 0x0, 0x0, 0x0, 0x92fc, 0x48c2, 0xa441, 0xfc76),
+            10,
+        )))
+        .unwrap();
+    });
     iface.inner.caps.checksum.udp = Checksum::None;
 
     let udp_rx_buffer = udp::PacketBuffer::new(vec![udp::PacketMetadata::EMPTY], vec![0; 1024 * 4]);

--- a/src/wire/ipv6.rs
+++ b/src/wire/ipv6.rs
@@ -87,6 +87,14 @@ impl Address {
         0x02,
     ]);
 
+    /// The link-local [all RPL nodes multicast address].
+    ///
+    /// [all RPL nodes multicast address]: https://www.rfc-editor.org/rfc/rfc6550.html#section-20.19
+    pub const LINK_LOCAL_ALL_RPL_NODES: Address = Address([
+        0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x1a,
+    ]);
+
     /// The [loopback address].
     ///
     /// [loopback address]: https://tools.ietf.org/html/rfc4291#section-2.5.3


### PR DESCRIPTION
Now, the destination address of the IP packet is checked if it is part of the interface addresses or the multicast addresses, only after processing the hop-by-hop header, as this header must be processed by every node. 

1. I modified the `has_multicast_group` function to also check IPv6 multicast addresses, such as the ALL_NODES, ALL_RPL_NODES (only when using RPL) and the IPv6 solicited address.
2. For some HBH options, an ICMPv6 parameter problem must be transmitted [RFC2460 Section 4.2](https://datatracker.ietf.org/doc/html/rfc2460#section-4.2). In some cases even when the destination address is a multicast address. Therefore also did point (3).
3. ICMPv6 messages were not transmitted when the destination address was a multicast address. I am not sure why we did it like that. When the destination address is multicast, I use the first IPv6 address from the interface. The selection of the correct IPv6 source address is something that still needs work in smoltcp.

[RFC8200 Section 4](https://datatracker.ietf.org/doc/html/rfc8200#section-4) says the following about hop-by-hop headers:

>  Extension headers (except for the Hop-by-Hop Options header) are not
   processed, inserted, or deleted by any node along a packet's delivery
   path, until the packet reaches the node (or each of the set of nodes,
   in the case of multicast) identified in the Destination Address field
   of the IPv6 header.

Therefore, when an hop-by-hop extension is present, we should process it. Then we check if the packet reached its destination. If not, we discard the packet if we are not using a routing protocol. In case of RPL, we route the packet to the correct next node.