### PR TITLE
Ipv6 source address selection based on RFC 6724

### DIFF
--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -176,7 +176,7 @@ fn main() {
                     );
                     icmp_repr.emit(&mut icmp_packet, &device_caps.checksum);
                 }
-                IpAddress::Ipv6(_) => {
+                IpAddress::Ipv6(address) => {
                     let (icmp_repr, mut icmp_packet) = send_icmp_ping!(
                         Icmpv6Repr,
                         Icmpv6Packet,
@@ -187,7 +187,10 @@ fn main() {
                         remote_addr
                     );
                     icmp_repr.emit(
-                        &iface.ipv6_addr().unwrap().into_address(),
+                        &iface
+                            .get_source_address_ipv6(&address)
+                            .unwrap()
+                            .into_address(),
                         &remote_addr,
                         &mut icmp_packet,
                         &device_caps.checksum,
@@ -217,11 +220,14 @@ fn main() {
                         received
                     );
                 }
-                IpAddress::Ipv6(_) => {
+                IpAddress::Ipv6(address) => {
                     let icmp_packet = Icmpv6Packet::new_checked(&payload).unwrap();
                     let icmp_repr = Icmpv6Repr::parse(
                         &remote_addr,
-                        &iface.ipv6_addr().unwrap().into_address(),
+                        &iface
+                            .get_source_address_ipv6(&address)
+                            .unwrap()
+                            .into_address(),
                         &icmp_packet,
                         &device_caps.checksum,
                     )

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -928,14 +928,12 @@ impl InterfaceInner {
 
     #[allow(unused)] // unused depending on which sockets are enabled
     pub(crate) fn get_source_address(&mut self, dst_addr: IpAddress) -> Option<IpAddress> {
-        let v = dst_addr.version();
-        for cidr in self.ip_addrs.iter() {
-            let addr = cidr.address();
-            if addr.version() == v {
-                return Some(addr);
-            }
+        match dst_addr {
+            #[cfg(feature = "proto-ipv4")]
+            IpAddress::Ipv4(addr) => self.get_source_address_ipv4(addr).map(|a| a.into()),
+            #[cfg(feature = "proto-ipv6")]
+            IpAddress::Ipv6(addr) => self.get_source_address_ipv6(addr).map(|a| a.into()),
         }
-        None
     }
 
     #[cfg(feature = "proto-ipv4")]

--- a/src/iface/interface/tests/ipv6.rs
+++ b/src/iface/interface/tests/ipv6.rs
@@ -797,33 +797,62 @@ fn get_source_address() {
         Ipv6Address::new(0x2001, 0x0db9, 0x0003, 0, 0, 0, 0, 2);
 
     assert_eq!(
-        iface.inner.get_source_address_ipv6(LINK_LOCAL_ADDR),
+        iface.inner.get_source_address_ipv6(&LINK_LOCAL_ADDR),
         Some(OWN_LINK_LOCAL_ADDR)
     );
     assert_eq!(
-        iface.inner.get_source_address_ipv6(UNIQUE_LOCAL_ADDR1),
+        iface.inner.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR1),
         Some(OWN_UNIQUE_LOCAL_ADDR1)
     );
     assert_eq!(
-        iface.inner.get_source_address_ipv6(UNIQUE_LOCAL_ADDR2),
+        iface.inner.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR2),
         Some(OWN_UNIQUE_LOCAL_ADDR2)
     );
     assert_eq!(
-        iface.inner.get_source_address_ipv6(UNIQUE_LOCAL_ADDR3),
+        iface.inner.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR3),
         Some(OWN_UNIQUE_LOCAL_ADDR1)
     );
     assert_eq!(
         iface
             .inner
-            .get_source_address_ipv6(Ipv6Address::LINK_LOCAL_ALL_NODES),
+            .get_source_address_ipv6(&Ipv6Address::LINK_LOCAL_ALL_NODES),
         Some(OWN_LINK_LOCAL_ADDR)
     );
     assert_eq!(
-        iface.inner.get_source_address_ipv6(GLOBAL_UNICAST_ADDR1),
+        iface.inner.get_source_address_ipv6(&GLOBAL_UNICAST_ADDR1),
         Some(OWN_GLOBAL_UNICAST_ADDR1)
     );
     assert_eq!(
-        iface.inner.get_source_address_ipv6(GLOBAL_UNICAST_ADDR2),
+        iface.inner.get_source_address_ipv6(&GLOBAL_UNICAST_ADDR2),
+        Some(OWN_GLOBAL_UNICAST_ADDR1)
+    );
+
+    assert_eq!(
+        iface.get_source_address_ipv6(&LINK_LOCAL_ADDR),
+        Some(OWN_LINK_LOCAL_ADDR)
+    );
+    assert_eq!(
+        iface.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR1),
+        Some(OWN_UNIQUE_LOCAL_ADDR1)
+    );
+    assert_eq!(
+        iface.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR2),
+        Some(OWN_UNIQUE_LOCAL_ADDR2)
+    );
+    assert_eq!(
+        iface.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR3),
+        Some(OWN_UNIQUE_LOCAL_ADDR1)
+    );
+    assert_eq!(
+        iface.get_source_address_ipv6(&Ipv6Address::LINK_LOCAL_ALL_NODES),
+        Some(OWN_LINK_LOCAL_ADDR)
+    );
+    assert_eq!(
+        iface.get_source_address_ipv6(&GLOBAL_UNICAST_ADDR1),
+        Some(OWN_GLOBAL_UNICAST_ADDR1)
+    );
+    assert_eq!(
+        iface.get_source_address_ipv6(&GLOBAL_UNICAST_ADDR2),
         Some(OWN_GLOBAL_UNICAST_ADDR1)
     );
 }

--- a/src/iface/interface/tests/ipv6.rs
+++ b/src/iface/interface/tests/ipv6.rs
@@ -735,3 +735,95 @@ fn test_icmp_reply_size(#[case] medium: Medium) {
         ))
     );
 }
+
+#[cfg(feature = "medium-ip")]
+#[test]
+fn get_source_address() {
+    let (mut iface, _, _) = setup(Medium::Ip);
+
+    const OWN_LINK_LOCAL_ADDR: Ipv6Address = Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
+    const OWN_UNIQUE_LOCAL_ADDR1: Ipv6Address = Ipv6Address::new(0xfd00, 0, 0, 201, 1, 1, 1, 2);
+    const OWN_UNIQUE_LOCAL_ADDR2: Ipv6Address = Ipv6Address::new(0xfd01, 0, 0, 201, 1, 1, 1, 2);
+    const OWN_GLOBAL_UNICAST_ADDR1: Ipv6Address =
+        Ipv6Address::new(0x2001, 0x0db8, 0x0003, 0, 0, 0, 0, 1);
+
+    // List of addresses of the interface:
+    //   fe80::1/64
+    //   fd00::201:1:1:1:2/64
+    //   fd01::201:1:1:1:2/64
+    //   2001:db8:3::1/64
+    //   ::1/128
+    //   ::/128
+    iface.update_ip_addrs(|addrs| {
+        addrs.clear();
+
+        addrs
+            .push(IpCidr::Ipv6(Ipv6Cidr::new(OWN_LINK_LOCAL_ADDR, 64)))
+            .unwrap();
+        addrs
+            .push(IpCidr::Ipv6(Ipv6Cidr::new(OWN_UNIQUE_LOCAL_ADDR1, 64)))
+            .unwrap();
+        addrs
+            .push(IpCidr::Ipv6(Ipv6Cidr::new(OWN_UNIQUE_LOCAL_ADDR2, 64)))
+            .unwrap();
+        addrs
+            .push(IpCidr::Ipv6(Ipv6Cidr::new(OWN_GLOBAL_UNICAST_ADDR1, 64)))
+            .unwrap();
+
+        // These should never be used:
+        addrs
+            .push(IpCidr::Ipv6(Ipv6Cidr::new(Ipv6Address::LOOPBACK, 128)))
+            .unwrap();
+        addrs
+            .push(IpCidr::Ipv6(Ipv6Cidr::new(Ipv6Address::UNSPECIFIED, 128)))
+            .unwrap();
+    });
+
+    // List of addresses we test:
+    //   fe80::42          -> fe80::1
+    //   fd00::201:1:1:1:1 -> fd00::201:1:1:1:2
+    //   fd01::201:1:1:1:1 -> fd01::201:1:1:1:2
+    //   fd02::201:1:1:1:1 -> fd00::201:1:1:1:2 (because first added in the list)
+    //   ff02::1           -> fe80::1 (same scope)
+    //   2001:db8:3::2     -> 2001:db8:3::1
+    //   2001:db9:3::2     -> 2001:db8:3::1
+    const LINK_LOCAL_ADDR: Ipv6Address = Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 42);
+    const UNIQUE_LOCAL_ADDR1: Ipv6Address = Ipv6Address::new(0xfd00, 0, 0, 201, 1, 1, 1, 1);
+    const UNIQUE_LOCAL_ADDR2: Ipv6Address = Ipv6Address::new(0xfd01, 0, 0, 201, 1, 1, 1, 1);
+    const UNIQUE_LOCAL_ADDR3: Ipv6Address = Ipv6Address::new(0xfd02, 0, 0, 201, 1, 1, 1, 1);
+    const GLOBAL_UNICAST_ADDR1: Ipv6Address =
+        Ipv6Address::new(0x2001, 0x0db8, 0x0003, 0, 0, 0, 0, 2);
+    const GLOBAL_UNICAST_ADDR2: Ipv6Address =
+        Ipv6Address::new(0x2001, 0x0db9, 0x0003, 0, 0, 0, 0, 2);
+
+    assert_eq!(
+        iface.inner.get_source_address_ipv6(LINK_LOCAL_ADDR),
+        Some(OWN_LINK_LOCAL_ADDR)
+    );
+    assert_eq!(
+        iface.inner.get_source_address_ipv6(UNIQUE_LOCAL_ADDR1),
+        Some(OWN_UNIQUE_LOCAL_ADDR1)
+    );
+    assert_eq!(
+        iface.inner.get_source_address_ipv6(UNIQUE_LOCAL_ADDR2),
+        Some(OWN_UNIQUE_LOCAL_ADDR2)
+    );
+    assert_eq!(
+        iface.inner.get_source_address_ipv6(UNIQUE_LOCAL_ADDR3),
+        Some(OWN_UNIQUE_LOCAL_ADDR1)
+    );
+    assert_eq!(
+        iface
+            .inner
+            .get_source_address_ipv6(Ipv6Address::LINK_LOCAL_ALL_NODES),
+        Some(OWN_LINK_LOCAL_ADDR)
+    );
+    assert_eq!(
+        iface.inner.get_source_address_ipv6(GLOBAL_UNICAST_ADDR1),
+        Some(OWN_GLOBAL_UNICAST_ADDR1)
+    );
+    assert_eq!(
+        iface.inner.get_source_address_ipv6(GLOBAL_UNICAST_ADDR2),
+        Some(OWN_GLOBAL_UNICAST_ADDR1)
+    );
+}

--- a/src/socket/dns.rs
+++ b/src/socket/dns.rs
@@ -610,7 +610,7 @@ impl<'a> Socket<'a> {
                 };
 
                 let dst_addr = servers[pq.server_idx];
-                let src_addr = cx.get_source_address(dst_addr).unwrap(); // TODO remove unwrap
+                let src_addr = cx.get_source_address(&dst_addr).unwrap(); // TODO remove unwrap
                 let ip_repr = IpRepr::new(
                     src_addr,
                     dst_addr,

--- a/src/socket/icmp.rs
+++ b/src/socket/icmp.rs
@@ -539,7 +539,7 @@ impl<'a> Socket<'a> {
             match *remote_endpoint {
                 #[cfg(feature = "proto-ipv4")]
                 IpAddress::Ipv4(dst_addr) => {
-                    let src_addr = match cx.get_source_address_ipv4(dst_addr) {
+                    let src_addr = match cx.get_source_address_ipv4(&dst_addr) {
                         Some(addr) => addr,
                         None => {
                             net_trace!(
@@ -571,7 +571,7 @@ impl<'a> Socket<'a> {
                 }
                 #[cfg(feature = "proto-ipv6")]
                 IpAddress::Ipv6(dst_addr) => {
-                    let src_addr = match cx.get_source_address_ipv6(dst_addr) {
+                    let src_addr = match cx.get_source_address_ipv6(&dst_addr) {
                         Some(addr) => addr,
                         None => {
                             net_trace!(

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -851,7 +851,7 @@ impl<'a> Socket<'a> {
                     addr
                 }
                 None => cx
-                    .get_source_address(remote_endpoint.addr)
+                    .get_source_address(&remote_endpoint.addr)
                     .ok_or(ConnectError::Unaddressable)?,
             },
             port: local_endpoint.port,

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -519,7 +519,7 @@ impl<'a> Socket<'a> {
         let res = self.tx_buffer.dequeue_with(|packet_meta, payload_buf| {
             let src_addr = match endpoint.addr {
                 Some(addr) => addr,
-                None => match cx.get_source_address(packet_meta.endpoint.addr) {
+                None => match cx.get_source_address(&packet_meta.endpoint.addr) {
                     Some(addr) => addr,
                     None => {
                         net_trace!(

--- a/src/wire/ipv6.rs
+++ b/src/wire/ipv6.rs
@@ -25,6 +25,41 @@ pub const ADDR_SIZE: usize = 16;
 /// [RFC 8200 § 2]: https://www.rfc-editor.org/rfc/rfc4291#section-2
 pub const IPV4_MAPPED_PREFIX_SIZE: usize = ADDR_SIZE - 4; // 4 == ipv4::ADDR_SIZE , cannot DRY here because of dependency on a IPv4 module which is behind the feature
 
+/// The [scope] of an address.
+///
+/// [scope]: https://www.rfc-editor.org/rfc/rfc4291#section-2.7
+#[repr(u8)]
+pub(crate) enum Scope {
+    /// Interface Local scope
+    InterfaceLocal = 0x1,
+    /// Link local scope
+    LinkLocal = 0x2,
+    /// Administratively configured
+    AdminLocal = 0x4,
+    /// Single site scope
+    SiteLocal = 0x5,
+    /// Organization scope
+    OrganizationLocal = 0x8,
+    /// Global scope
+    Global = 0xE,
+    /// Unknown scope
+    Unknown = 0xFF,
+}
+
+impl From<u8> for Scope {
+    fn from(value: u8) -> Self {
+        match value {
+            0x1 => Self::InterfaceLocal,
+            0x2 => Self::LinkLocal,
+            0x4 => Self::AdminLocal,
+            0x5 => Self::SiteLocal,
+            0x8 => Self::OrganizationLocal,
+            0xE => Self::Global,
+            _ => Self::Unknown,
+        }
+    }
+}
+
 /// A sixteen-octet IPv6 address.
 #[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default)]
 pub struct Address(pub [u8; ADDR_SIZE]);
@@ -143,6 +178,13 @@ impl Address {
         !(self.is_multicast() || self.is_unspecified())
     }
 
+    /// Query whether the IPv6 address is a [global unicast address].
+    ///
+    /// [global unicast address]: https://datatracker.ietf.org/doc/html/rfc3587
+    pub const fn is_global_unicast(&self) -> bool {
+        (self.0[0] >> 5) == 0b001
+    }
+
     /// Query whether the IPv6 address is a [multicast address].
     ///
     /// [multicast address]: https://tools.ietf.org/html/rfc4291#section-2.7
@@ -226,6 +268,22 @@ impl Address {
             0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0xFF,
             self.0[13], self.0[14], self.0[15],
         ])
+    }
+
+    /// Return the scope of the address.
+    pub(crate) fn scope(&self) -> Scope {
+        if self.is_multicast() {
+            return Scope::from(self.as_bytes()[1] & 0b1111);
+        }
+
+        if self.is_link_local() {
+            Scope::LinkLocal
+        } else if self.is_unique_local() || self.is_global_unicast() {
+            // ULA are considered global scope
+            Scope::Global
+        } else {
+            Scope::Unknown
+        }
     }
 
     /// Convert to an `IpAddress`.
@@ -840,6 +898,7 @@ mod test {
 
     const LINK_LOCAL_ADDR: Address = Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
     const UNIQUE_LOCAL_ADDR: Address = Address::new(0xfd00, 0, 0, 201, 1, 1, 1, 1);
+    const GLOBAL_UNICAST_ADDR: Address = Address::new(0x2001, 0xdb8, 0x3, 0, 0, 0, 0, 1);
 
     #[test]
     fn test_basic_multicast() {
@@ -848,11 +907,13 @@ mod test {
         assert!(!Address::LINK_LOCAL_ALL_ROUTERS.is_link_local());
         assert!(!Address::LINK_LOCAL_ALL_ROUTERS.is_loopback());
         assert!(!Address::LINK_LOCAL_ALL_ROUTERS.is_unique_local());
+        assert!(!Address::LINK_LOCAL_ALL_ROUTERS.is_global_unicast());
         assert!(!Address::LINK_LOCAL_ALL_NODES.is_unspecified());
         assert!(Address::LINK_LOCAL_ALL_NODES.is_multicast());
         assert!(!Address::LINK_LOCAL_ALL_NODES.is_link_local());
         assert!(!Address::LINK_LOCAL_ALL_NODES.is_loopback());
         assert!(!Address::LINK_LOCAL_ALL_NODES.is_unique_local());
+        assert!(!Address::LINK_LOCAL_ALL_NODES.is_global_unicast());
     }
 
     #[test]
@@ -862,6 +923,7 @@ mod test {
         assert!(LINK_LOCAL_ADDR.is_link_local());
         assert!(!LINK_LOCAL_ADDR.is_loopback());
         assert!(!LINK_LOCAL_ADDR.is_unique_local());
+        assert!(!LINK_LOCAL_ADDR.is_global_unicast());
     }
 
     #[test]
@@ -871,6 +933,7 @@ mod test {
         assert!(!Address::LOOPBACK.is_link_local());
         assert!(Address::LOOPBACK.is_loopback());
         assert!(!Address::LOOPBACK.is_unique_local());
+        assert!(!Address::LOOPBACK.is_global_unicast());
     }
 
     #[test]
@@ -880,6 +943,17 @@ mod test {
         assert!(!UNIQUE_LOCAL_ADDR.is_link_local());
         assert!(!UNIQUE_LOCAL_ADDR.is_loopback());
         assert!(UNIQUE_LOCAL_ADDR.is_unique_local());
+        assert!(!UNIQUE_LOCAL_ADDR.is_global_unicast());
+    }
+
+    #[test]
+    fn test_global_unicast() {
+        assert!(!GLOBAL_UNICAST_ADDR.is_unspecified());
+        assert!(!GLOBAL_UNICAST_ADDR.is_multicast());
+        assert!(!GLOBAL_UNICAST_ADDR.is_link_local());
+        assert!(!GLOBAL_UNICAST_ADDR.is_loopback());
+        assert!(!GLOBAL_UNICAST_ADDR.is_unique_local());
+        assert!(GLOBAL_UNICAST_ADDR.is_global_unicast());
     }
 
     #[test]

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -191,6 +191,8 @@ pub use self::ipv4::{
 };
 
 #[cfg(feature = "proto-ipv6")]
+pub(crate) use self::ipv6::Scope as Ipv6AddressScope;
+#[cfg(feature = "proto-ipv6")]
 pub use self::ipv6::{
     Address as Ipv6Address, Cidr as Ipv6Cidr, Packet as Ipv6Packet, Repr as Ipv6Repr,
     HEADER_LEN as IPV6_HEADER_LEN, MIN_MTU as IPV6_MIN_MTU,


### PR DESCRIPTION
Instead of selecting the first address in the interface list of addresses, [RFC 6724](https://www.rfc-editor.org/rfc/rfc6724) is used for selecting the source IPv6 address based on the destination address.

The functions `get_source_address`, `get_source_address_ipv4` and `get_source_address_ipv6` had a mutable reference to self. However, this seemed not necessary. I made the reference immutable, but maybe someone knows why this was mutable?