### PR TITLE
fix: don't handle empty packets

### DIFF
--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -684,6 +684,10 @@ impl Interface {
         while let Some((rx_token, tx_token)) = device.receive(self.inner.now) {
             let rx_meta = rx_token.meta();
             rx_token.consume(|frame| {
+                if frame.is_empty() {
+                    return;
+                }
+
                 match self.inner.caps.medium {
                     #[cfg(feature = "medium-ethernet")]
                     Medium::Ethernet => {


### PR DESCRIPTION
Smoltcp should not handle empty packets.