### PR TITLE
fix(tcp): don't send TCP RST with unsp. src addr

### DIFF
--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -1337,8 +1337,12 @@ impl InterfaceInner {
             }
         }
 
-        if tcp_repr.control == TcpControl::Rst {
-            // Never reply to a TCP RST packet with another TCP RST packet.
+        if tcp_repr.control == TcpControl::Rst
+            || ip_repr.dst_addr().is_unspecified()
+            || ip_repr.src_addr().is_unspecified()
+        {
+            // Never reply to a TCP RST packet with another TCP RST packet. We also never want to
+            // send a TCP RST packet with unspecified addresses.
             None
         } else {
             // The packet wasn't handled by a socket, send a TCP RST packet.


### PR DESCRIPTION
When the destination address of the TCP packet was unspecified and the packet was not handled by any socket, smoltcp would transmit a TCP RST packet back. We should never transmit a packet with a source address unspecified.