### PR TITLE
neigh: add fill_with_expiration method

### DIFF
--- a/src/iface/neighbor.rs
+++ b/src/iface/neighbor.rs
@@ -72,8 +72,21 @@ impl Cache {
         debug_assert!(protocol_addr.is_unicast());
         debug_assert!(hardware_addr.is_unicast());
 
+        let expires_at = timestamp + Self::ENTRY_LIFETIME;
+        self.fill_with_expiration(protocol_addr, hardware_addr, expires_at);
+    }
+
+    pub fn fill_with_expiration(
+        &mut self,
+        protocol_addr: IpAddress,
+        hardware_addr: HardwareAddress,
+        expires_at: Instant,
+    ) {
+        debug_assert!(protocol_addr.is_unicast());
+        debug_assert!(hardware_addr.is_unicast());
+
         let neighbor = Neighbor {
-            expires_at: timestamp + Self::ENTRY_LIFETIME,
+            expires_at,
             hardware_addr,
         };
         match self.storage.insert(protocol_addr, neighbor) {


### PR DESCRIPTION
This method is useful when we want to fill the cache with an entry that has a specific expiration time. In RPL, an expiration of 60 seconds is way too fast. 