### PR TITLE
fix(tcp): add missing feature to test

### DIFF
--- a/src/iface/interface/tests/mod.rs
+++ b/src/iface/interface/tests/mod.rs
@@ -149,7 +149,7 @@ fn test_handle_udp_broadcast(
 }
 
 #[test]
-#[cfg(all(feature = "socket-tcp", feature = "proto-ipv6"))]
+#[cfg(all(feature = "medium-ip", feature = "socket-tcp", feature = "proto-ipv6"))]
 pub fn tcp_not_accepted() {
     use crate::iface::ip_packet::{IpPacket, IpPayload, Ipv6Packet};
 


### PR DESCRIPTION
#867 was merged with failing tests. Somehow, github allowed this. I thought the merge queue was going to prevent that.