### PR TITLE
iface: rename IpPacket to Packet

### DIFF
--- a/src/iface/interface/ieee802154.rs
+++ b/src/iface/interface/ieee802154.rs
@@ -10,7 +10,7 @@ impl InterfaceInner {
         meta: PacketMeta,
         sixlowpan_payload: &'payload [u8],
         _fragments: &'output mut FragmentsBuffer,
-    ) -> Option<IpPacket<'output>> {
+    ) -> Option<Packet<'output>> {
         let ieee802154_frame = check!(Ieee802154Frame::new_checked(sixlowpan_payload));
         let ieee802154_repr = check!(Ieee802154Repr::parse(&ieee802154_frame));
 
@@ -45,7 +45,7 @@ impl InterfaceInner {
         ll_dst_a: Ieee802154Address,
         tx_token: Tx,
         meta: PacketMeta,
-        packet: IpPacket,
+        packet: Packet,
         frag: &mut Fragmenter,
     ) {
         let ll_src_a = self.hardware_addr.ieee802154_or_panic();

--- a/src/iface/interface/igmp.rs
+++ b/src/iface/interface/igmp.rs
@@ -1,4 +1,5 @@
-use super::{check, IgmpReportState, Interface, InterfaceInner, IpPacket};
+use super::*;
+
 use crate::phy::{Device, PacketMeta};
 use crate::time::{Duration, Instant};
 use crate::wire::*;
@@ -231,7 +232,7 @@ impl InterfaceInner {
         &mut self,
         ipv4_repr: Ipv4Repr,
         ip_payload: &'frame [u8],
-    ) -> Option<IpPacket<'frame>> {
+    ) -> Option<Packet<'frame>> {
         let igmp_packet = check!(IgmpPacket::new_checked(ip_payload));
         let igmp_repr = check!(IgmpRepr::parse(&igmp_packet));
 

--- a/src/iface/interface/tests/ipv6.rs
+++ b/src/iface/interface/tests/ipv6.rs
@@ -1,7 +1,7 @@
 use super::*;
 
-fn parse_ipv6(data: &[u8]) -> crate::wire::Result<IpPacket<'_>> {
-    let ipv6_header = Ipv6PacketWire::new_checked(data)?;
+fn parse_ipv6(data: &[u8]) -> crate::wire::Result<Packet<'_>> {
+    let ipv6_header = Ipv6Packet::new_checked(data)?;
     let ipv6 = Ipv6Repr::parse(&ipv6_header)?;
 
     match ipv6.next_header {
@@ -21,7 +21,7 @@ fn parse_ipv6(data: &[u8]) -> crate::wire::Result<IpPacket<'_>> {
                 &Icmpv6Packet::new_checked(ipv6_header.payload())?,
                 &Default::default(),
             )?;
-            Ok(IpPacket::new_ipv6(ipv6, IpPayload::Icmpv6(icmp)))
+            Ok(Packet::new_ipv6(ipv6, IpPayload::Icmpv6(icmp)))
         }
         IpProtocol::Ipv6NoNxt => todo!(),
         IpProtocol::Ipv6Opts => todo!(),
@@ -51,7 +51,7 @@ fn multicast_source_address(#[case] medium: Medium) {
         iface.inner.process_ipv6(
             &mut sockets,
             PacketMeta::default(),
-            &Ipv6PacketWire::new_checked(&data[..]).unwrap()
+            &Ipv6Packet::new_checked(&data[..]).unwrap()
         ),
         response
     );
@@ -78,7 +78,7 @@ fn hop_by_hop_skip_with_icmp(#[case] medium: Medium) {
         0x0, 0x2a, 0x1, 0xa4, 0x4c, 0x6f, 0x72, 0x65, 0x6d, 0x20, 0x49, 0x70, 0x73, 0x75, 0x6d,
     ];
 
-    let response = Some(IpPacket::new_ipv6(
+    let response = Some(Packet::new_ipv6(
         Ipv6Repr {
             src_addr: Ipv6Address::from_parts(&[0xfdbe, 0, 0, 0, 0, 0, 0, 0x0001]),
             dst_addr: Ipv6Address::from_parts(&[0xfdbe, 0, 0, 0, 0, 0, 0, 0x0002]),
@@ -99,7 +99,7 @@ fn hop_by_hop_skip_with_icmp(#[case] medium: Medium) {
         iface.inner.process_ipv6(
             &mut sockets,
             PacketMeta::default(),
-            &Ipv6PacketWire::new_checked(&data[..]).unwrap()
+            &Ipv6Packet::new_checked(&data[..]).unwrap()
         ),
         response
     );
@@ -134,7 +134,7 @@ fn hop_by_hop_discard_with_icmp(#[case] medium: Medium) {
         iface.inner.process_ipv6(
             &mut sockets,
             PacketMeta::default(),
-            &Ipv6PacketWire::new_checked(&data[..]).unwrap()
+            &Ipv6Packet::new_checked(&data[..]).unwrap()
         ),
         response
     );
@@ -156,7 +156,7 @@ fn imcp_empty_echo_request(#[case] medium: Medium) {
 
     assert_eq!(
         parse_ipv6(&data),
-        Ok(IpPacket::new_ipv6(
+        Ok(Packet::new_ipv6(
             Ipv6Repr {
                 src_addr: Ipv6Address::from_parts(&[0xfdbe, 0, 0, 0, 0, 0, 0, 0x0002]),
                 dst_addr: Ipv6Address::from_parts(&[0xfdbe, 0, 0, 0, 0, 0, 0, 0x0001]),
@@ -172,7 +172,7 @@ fn imcp_empty_echo_request(#[case] medium: Medium) {
         ))
     );
 
-    let response = Some(IpPacket::new_ipv6(
+    let response = Some(Packet::new_ipv6(
         Ipv6Repr {
             src_addr: Ipv6Address::from_parts(&[0xfdbe, 0, 0, 0, 0, 0, 0, 0x0001]),
             dst_addr: Ipv6Address::from_parts(&[0xfdbe, 0, 0, 0, 0, 0, 0, 0x0002]),
@@ -193,7 +193,7 @@ fn imcp_empty_echo_request(#[case] medium: Medium) {
         iface.inner.process_ipv6(
             &mut sockets,
             PacketMeta::default(),
-            &Ipv6PacketWire::new_checked(&data[..]).unwrap()
+            &Ipv6Packet::new_checked(&data[..]).unwrap()
         ),
         response
     );
@@ -216,7 +216,7 @@ fn icmp_echo_request(#[case] medium: Medium) {
 
     assert_eq!(
         parse_ipv6(&data),
-        Ok(IpPacket::new_ipv6(
+        Ok(Packet::new_ipv6(
             Ipv6Repr {
                 src_addr: Ipv6Address::from_parts(&[0xfdbe, 0, 0, 0, 0, 0, 0, 0x0002]),
                 dst_addr: Ipv6Address::from_parts(&[0xfdbe, 0, 0, 0, 0, 0, 0, 0x0001]),
@@ -232,7 +232,7 @@ fn icmp_echo_request(#[case] medium: Medium) {
         ))
     );
 
-    let response = Some(IpPacket::new_ipv6(
+    let response = Some(Packet::new_ipv6(
         Ipv6Repr {
             src_addr: Ipv6Address::from_parts(&[0xfdbe, 0, 0, 0, 0, 0, 0, 0x0001]),
             dst_addr: Ipv6Address::from_parts(&[0xfdbe, 0, 0, 0, 0, 0, 0, 0x0002]),
@@ -253,7 +253,7 @@ fn icmp_echo_request(#[case] medium: Medium) {
         iface.inner.process_ipv6(
             &mut sockets,
             PacketMeta::default(),
-            &Ipv6PacketWire::new_checked(&data[..]).unwrap()
+            &Ipv6Packet::new_checked(&data[..]).unwrap()
         ),
         response
     );
@@ -276,7 +276,7 @@ fn icmp_echo_reply_as_input(#[case] medium: Medium) {
 
     assert_eq!(
         parse_ipv6(&data),
-        Ok(IpPacket::new_ipv6(
+        Ok(Packet::new_ipv6(
             Ipv6Repr {
                 src_addr: Ipv6Address::from_parts(&[0xfdbe, 0, 0, 0, 0, 0, 0, 0x0002]),
                 dst_addr: Ipv6Address::from_parts(&[0xfdbe, 0, 0, 0, 0, 0, 0, 0x0001]),
@@ -300,7 +300,7 @@ fn icmp_echo_reply_as_input(#[case] medium: Medium) {
         iface.inner.process_ipv6(
             &mut sockets,
             PacketMeta::default(),
-            &Ipv6PacketWire::new_checked(&data[..]).unwrap()
+            &Ipv6Packet::new_checked(&data[..]).unwrap()
         ),
         response
     );
@@ -329,7 +329,7 @@ fn unknown_proto_with_multicast_dst_address(#[case] medium: Medium) {
         iface.inner.process_ipv6(
             &mut sockets,
             PacketMeta::default(),
-            &Ipv6PacketWire::new_checked(&data[..]).unwrap()
+            &Ipv6Packet::new_checked(&data[..]).unwrap()
         ),
         response
     );
@@ -350,7 +350,7 @@ fn unknown_proto(#[case] medium: Medium) {
         0x0, 0x0, 0x0, 0x0, 0x1,
     ];
 
-    let response = Some(IpPacket::new_ipv6(
+    let response = Some(Packet::new_ipv6(
         Ipv6Repr {
             src_addr: Ipv6Address::from_parts(&[0xfdbe, 0, 0, 0, 0, 0, 0, 0x0001]),
             dst_addr: Ipv6Address::from_parts(&[0xfdbe, 0, 0, 0, 0, 0, 0, 0x0002]),
@@ -378,7 +378,7 @@ fn unknown_proto(#[case] medium: Medium) {
         iface.inner.process_ipv6(
             &mut sockets,
             PacketMeta::default(),
-            &Ipv6PacketWire::new_checked(&data[..]).unwrap()
+            &Ipv6Packet::new_checked(&data[..]).unwrap()
         ),
         response
     );
@@ -398,7 +398,7 @@ fn ndsic_neighbor_advertisement_ethernet(#[case] medium: Medium) {
 
     assert_eq!(
         parse_ipv6(&data),
-        Ok(IpPacket::new_ipv6(
+        Ok(Packet::new_ipv6(
             Ipv6Repr {
                 src_addr: Ipv6Address::from_parts(&[0xfdbe, 0, 0, 0, 0, 0, 0, 0x0002]),
                 dst_addr: Ipv6Address::from_parts(&[0xfdbe, 0, 0, 0, 0, 0, 0, 0x0001]),
@@ -422,7 +422,7 @@ fn ndsic_neighbor_advertisement_ethernet(#[case] medium: Medium) {
         iface.inner.process_ipv6(
             &mut sockets,
             PacketMeta::default(),
-            &Ipv6PacketWire::new_checked(&data[..]).unwrap()
+            &Ipv6Packet::new_checked(&data[..]).unwrap()
         ),
         response
     );
@@ -452,7 +452,7 @@ fn ndsic_neighbor_advertisement_ethernet_multicast_addr(#[case] medium: Medium) 
 
     assert_eq!(
         parse_ipv6(&data),
-        Ok(IpPacket::new_ipv6(
+        Ok(Packet::new_ipv6(
             Ipv6Repr {
                 src_addr: Ipv6Address::from_parts(&[0xfdbe, 0, 0, 0, 0, 0, 0, 0x0002]),
                 dst_addr: Ipv6Address::from_parts(&[0xfdbe, 0, 0, 0, 0, 0, 0, 0x0001]),
@@ -478,7 +478,7 @@ fn ndsic_neighbor_advertisement_ethernet_multicast_addr(#[case] medium: Medium) 
         iface.inner.process_ipv6(
             &mut sockets,
             PacketMeta::default(),
-            &Ipv6PacketWire::new_checked(&data[..]).unwrap()
+            &Ipv6Packet::new_checked(&data[..]).unwrap()
         ),
         response
     );
@@ -506,7 +506,7 @@ fn ndsic_neighbor_advertisement_ieee802154(#[case] medium: Medium) {
 
     assert_eq!(
         parse_ipv6(&data),
-        Ok(IpPacket::new_ipv6(
+        Ok(Packet::new_ipv6(
             Ipv6Repr {
                 src_addr: Ipv6Address::from_parts(&[0xfdbe, 0, 0, 0, 0, 0, 0, 0x0002]),
                 dst_addr: Ipv6Address::from_parts(&[0xfdbe, 0, 0, 0, 0, 0, 0, 0x0001]),
@@ -530,7 +530,7 @@ fn ndsic_neighbor_advertisement_ieee802154(#[case] medium: Medium) {
         iface.inner.process_ipv6(
             &mut sockets,
             PacketMeta::default(),
-            &Ipv6PacketWire::new_checked(&data[..]).unwrap()
+            &Ipv6Packet::new_checked(&data[..]).unwrap()
         ),
         response
     );
@@ -605,7 +605,7 @@ fn test_handle_valid_ndisc_request(#[case] medium: Medium) {
             frame.into_inner(),
             &mut iface.fragments
         ),
-        Some(EthernetPacket::Ip(IpPacket::new_ipv6(
+        Some(EthernetPacket::Ip(Packet::new_ipv6(
             ipv6_expected,
             IpPayload::Icmpv6(icmpv6_expected)
         )))
@@ -729,7 +729,7 @@ fn test_icmp_reply_size(#[case] medium: Medium) {
             &vec![0x2a; MAX_PAYLOAD_LEN],
             payload,
         ),
-        Some(IpPacket::new_ipv6(
+        Some(Packet::new_ipv6(
             expected_ip_repr,
             IpPayload::Icmpv6(expected_icmp_repr)
         ))

--- a/src/iface/interface/tests/mod.rs
+++ b/src/iface/interface/tests/mod.rs
@@ -151,8 +151,6 @@ fn test_handle_udp_broadcast(
 #[test]
 #[cfg(all(feature = "medium-ip", feature = "socket-tcp", feature = "proto-ipv6"))]
 pub fn tcp_not_accepted() {
-    use crate::iface::ip_packet::{IpPacket, IpPayload, Ipv6Packet};
-
     let (mut iface, mut sockets, _) = setup(Medium::Ip);
     let tcp = TcpRepr {
         src_port: 4242,
@@ -189,23 +187,15 @@ pub fn tcp_not_accepted() {
             }),
             &tcp_bytes,
         ),
-        Some(IpPacket::Ipv6(Ipv6Packet {
-            header: Ipv6Repr {
+        Some(Packet::new_ipv6(
+            Ipv6Repr {
                 src_addr: Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 1),
                 dst_addr: Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 2),
                 next_header: IpProtocol::Tcp,
                 payload_len: tcp.buffer_len(),
                 hop_limit: 64,
             },
-
-            #[cfg(feature = "proto-ipv6-hbh")]
-            hop_by_hop: None,
-            #[cfg(feature = "proto-ipv6-fragmentation")]
-            fragment: None,
-            #[cfg(feature = "proto-ipv6-routing")]
-            routing: None,
-
-            payload: IpPayload::Tcp(TcpRepr {
+            IpPayload::Tcp(TcpRepr {
                 src_port: 4243,
                 dst_port: 4242,
                 control: TcpControl::Rst,
@@ -218,7 +208,7 @@ pub fn tcp_not_accepted() {
                 sack_ranges: [None, None, None],
                 payload: &[],
             })
-        })),
+        ))
     );
     // Unspecified destination address.
     tcp.emit(

--- a/src/iface/interface/tests/sixlowpan.rs
+++ b/src/iface/interface/tests/sixlowpan.rs
@@ -38,7 +38,7 @@ fn icmp_echo_request(#[case] medium: Medium) {
         0x37,
     ];
 
-    let response = Some(IpPacket::new_ipv6(
+    let response = Some(Packet::new_ipv6(
         Ipv6Repr {
             src_addr: Ipv6Address::from_parts(&[0xfe80, 0, 0, 0, 0x180b, 0x4242, 0x4242, 0x4242]),
             dst_addr: Ipv6Address::from_parts(&[0xfe80, 0, 0, 0, 0x241c, 0x2957, 0x34a6, 0x3a62]),
@@ -190,7 +190,7 @@ fn test_echo_request_sixlowpan_128_bytes() {
 
     assert_eq!(
         result,
-        Some(IpPacket::new_ipv6(
+        Some(Packet::new_ipv6(
             Ipv6Repr {
                 src_addr: Ipv6Address([
                     0xfe, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x92, 0xfc, 0x48, 0xc2, 0xa4, 0x41,
@@ -362,7 +362,7 @@ In at rhoncus tortor. Cras blandit tellus diam, varius vestibulum nibh commodo n
         Ieee802154Address::default(),
         tx_token,
         PacketMeta::default(),
-        IpPacket::new_ipv6(
+        Packet::new_ipv6(
             Ipv6Repr {
                 src_addr: Ipv6Address::default(),
                 dst_addr: Ipv6Address::default(),

--- a/src/iface/mod.rs
+++ b/src/iface/mod.rs
@@ -15,7 +15,7 @@ mod rpl;
 mod socket_meta;
 mod socket_set;
 
-mod ip_packet;
+mod packet;
 
 #[cfg(feature = "proto-igmp")]
 pub use self::interface::MulticastError;

--- a/src/iface/packet.rs
+++ b/src/iface/packet.rs
@@ -8,19 +8,19 @@ use crate::wire::*;
 pub(crate) enum EthernetPacket<'a> {
     #[cfg(feature = "proto-ipv4")]
     Arp(ArpRepr),
-    Ip(IpPacket<'a>),
+    Ip(Packet<'a>),
 }
 
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub(crate) enum IpPacket<'p> {
+pub(crate) enum Packet<'p> {
     #[cfg(feature = "proto-ipv4")]
-    Ipv4(Ipv4Packet<'p>),
+    Ipv4(PacketV4<'p>),
     #[cfg(feature = "proto-ipv6")]
-    Ipv6(Ipv6Packet<'p>),
+    Ipv6(PacketV6<'p>),
 }
 
-impl<'p> IpPacket<'p> {
+impl<'p> Packet<'p> {
     pub(crate) fn new(ip_repr: IpRepr, payload: IpPayload<'p>) -> Self {
         match ip_repr {
             #[cfg(feature = "proto-ipv4")]
@@ -32,7 +32,7 @@ impl<'p> IpPacket<'p> {
 
     #[cfg(feature = "proto-ipv4")]
     pub(crate) fn new_ipv4(ip_repr: Ipv4Repr, payload: IpPayload<'p>) -> Self {
-        Self::Ipv4(Ipv4Packet {
+        Self::Ipv4(PacketV4 {
             header: ip_repr,
             payload,
         })
@@ -40,7 +40,7 @@ impl<'p> IpPacket<'p> {
 
     #[cfg(feature = "proto-ipv6")]
     pub(crate) fn new_ipv6(ip_repr: Ipv6Repr, payload: IpPayload<'p>) -> Self {
-        Self::Ipv6(Ipv6Packet {
+        Self::Ipv6(PacketV6 {
             header: ip_repr,
             #[cfg(feature = "proto-ipv6-hbh")]
             hop_by_hop: None,
@@ -55,18 +55,18 @@ impl<'p> IpPacket<'p> {
     pub(crate) fn ip_repr(&self) -> IpRepr {
         match self {
             #[cfg(feature = "proto-ipv4")]
-            IpPacket::Ipv4(p) => IpRepr::Ipv4(p.header),
+            Packet::Ipv4(p) => IpRepr::Ipv4(p.header),
             #[cfg(feature = "proto-ipv6")]
-            IpPacket::Ipv6(p) => IpRepr::Ipv6(p.header),
+            Packet::Ipv6(p) => IpRepr::Ipv6(p.header),
         }
     }
 
     pub(crate) fn payload(&self) -> &IpPayload<'p> {
         match self {
             #[cfg(feature = "proto-ipv4")]
-            IpPacket::Ipv4(p) => &p.payload,
+            Packet::Ipv4(p) => &p.payload,
             #[cfg(feature = "proto-ipv6")]
-            IpPacket::Ipv6(p) => &p.payload,
+            Packet::Ipv6(p) => &p.payload,
         }
     }
 
@@ -144,7 +144,7 @@ impl<'p> IpPacket<'p> {
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg(feature = "proto-ipv4")]
-pub(crate) struct Ipv4Packet<'p> {
+pub(crate) struct PacketV4<'p> {
     header: Ipv4Repr,
     payload: IpPayload<'p>,
 }
@@ -152,7 +152,7 @@ pub(crate) struct Ipv4Packet<'p> {
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg(feature = "proto-ipv6")]
-pub(crate) struct Ipv6Packet<'p> {
+pub(crate) struct PacketV6<'p> {
     pub(crate) header: Ipv6Repr,
     #[cfg(feature = "proto-ipv6-hbh")]
     pub(crate) hop_by_hop: Option<Ipv6HopByHopRepr<'p>>,


### PR DESCRIPTION
`IpPacket`/`Ipv6Packet`/`Ipv4Packet` were already defined in `src/wire/*`. It is confusing to use them together with the version in `src/iface/`. In some cases the compiler or clippy complained about ambiguity.