### PR TITLE
fix(pcap): IEEE802.15.4 without FCS pcap link type

### DIFF
--- a/src/phy/pcap_writer.rs
+++ b/src/phy/pcap_writer.rs
@@ -14,8 +14,8 @@ enum_with_unknown! {
         Ethernet =   1,
         /// IPv4 or IPv6 packets (depending on the version field)
         Ip       = 101,
-        /// IEEE 802.15.4 packets with FCS included.
-        Ieee802154WithFcs = 195,
+        /// IEEE 802.15.4 packets without FCS.
+        Ieee802154WithoutFcs = 230,
     }
 }
 
@@ -135,7 +135,7 @@ impl<D: Device, S: PcapSink> PcapWriter<D, S> {
             #[cfg(feature = "medium-ethernet")]
             Medium::Ethernet => PcapLinkType::Ethernet,
             #[cfg(feature = "medium-ieee802154")]
-            Medium::Ieee802154 => PcapLinkType::Ieee802154WithFcs,
+            Medium::Ieee802154 => PcapLinkType::Ieee802154WithoutFcs,
         };
         sink.global_header(link_type);
         PcapWriter {


### PR DESCRIPTION
Since smoltcp does not generate the FCS, the pcap link type should be set to IEEE802.15.4 without FCS.