### PR TITLE
Remove generic in parse and emit functions

### DIFF
--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -208,7 +208,7 @@ fn main() {
 
             match remote_addr {
                 IpAddress::Ipv4(_) => {
-                    let icmp_packet = Icmpv4Packet::new_checked(&payload).unwrap();
+                    let icmp_packet = Icmpv4Packet::new_checked(payload).unwrap();
                     let icmp_repr = Icmpv4Repr::parse(&icmp_packet, &device_caps.checksum).unwrap();
                     get_icmp_pong!(
                         Icmpv4Repr,
@@ -221,7 +221,7 @@ fn main() {
                     );
                 }
                 IpAddress::Ipv6(address) => {
-                    let icmp_packet = Icmpv6Packet::new_checked(&payload).unwrap();
+                    let icmp_packet = Icmpv6Packet::new_checked(payload).unwrap();
                     let icmp_repr = Icmpv6Repr::parse(
                         &remote_addr,
                         &iface

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -1517,8 +1517,8 @@ impl InterfaceInner {
         };
 
         // Emit function for the IP header and payload.
-        let emit_ip = |repr: &IpRepr, mut tx_buffer: &mut [u8]| {
-            repr.emit(&mut tx_buffer, &self.caps.checksum);
+        let emit_ip = |repr: &IpRepr, tx_buffer: &mut [u8]| {
+            repr.emit(tx_buffer, &self.caps.checksum);
 
             let payload = &mut tx_buffer[repr.header_len()..];
             packet.emit_payload(repr, payload, &caps)

--- a/src/iface/interface/sixlowpan.rs
+++ b/src/iface/interface/sixlowpan.rs
@@ -421,7 +421,7 @@ impl InterfaceInner {
                     tx_buf = &mut tx_buf[ieee_len..];
 
                     // Add the first fragment header
-                    let mut frag1_packet = SixlowpanFragPacket::new_unchecked(&mut tx_buf);
+                    let mut frag1_packet = SixlowpanFragPacket::new_unchecked(&mut tx_buf[..]);
                     frag1.emit(&mut frag1_packet);
                     tx_buf = &mut tx_buf[frag1.buffer_len()..];
 
@@ -752,7 +752,7 @@ mod tests {
             0xfd, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
         ])];
 
-        let ieee_frame = Ieee802154Frame::new_checked(&SIXLOWPAN_COMPRESSED_RPL_DAO).unwrap();
+        let ieee_frame = Ieee802154Frame::new_checked(&SIXLOWPAN_COMPRESSED_RPL_DAO[..]).unwrap();
         let ieee_repr = Ieee802154Repr::parse(&ieee_frame).unwrap();
 
         let mut buffer = [0u8; 256];

--- a/src/iface/interface/tests/ipv4.rs
+++ b/src/iface/interface/tests/ipv4.rs
@@ -181,8 +181,8 @@ fn test_icmp_error_port_unreachable(#[case] medium: Medium) {
 
     let mut udp_bytes_unicast = vec![0u8; 20];
     let mut udp_bytes_broadcast = vec![0u8; 20];
-    let mut packet_unicast = UdpPacket::new_unchecked(&mut udp_bytes_unicast);
-    let mut packet_broadcast = UdpPacket::new_unchecked(&mut udp_bytes_broadcast);
+    let mut packet_unicast = UdpPacket::new_unchecked(&mut udp_bytes_unicast[..]);
+    let mut packet_broadcast = UdpPacket::new_unchecked(&mut udp_bytes_broadcast[..]);
 
     let udp_repr = UdpRepr {
         src_port: 67,

--- a/src/iface/interface/tests/mod.rs
+++ b/src/iface/interface/tests/mod.rs
@@ -78,7 +78,7 @@ fn test_handle_udp_broadcast(
     let udp_socket = udp::Socket::new(rx_buffer, tx_buffer);
 
     let mut udp_bytes = vec![0u8; 13];
-    let mut packet = UdpPacket::new_unchecked(&mut udp_bytes);
+    let mut packet = UdpPacket::new_unchecked(&mut udp_bytes[..]);
 
     let socket_handle = sockets.add(udp_socket);
 

--- a/src/socket/icmp.rs
+++ b/src/socket/icmp.rs
@@ -722,7 +722,7 @@ mod test_ipv4 {
         assert!(socket.can_send());
 
         let mut bytes = [0xff; 24];
-        let mut packet = Icmpv4Packet::new_unchecked(&mut bytes);
+        let mut packet = Icmpv4Packet::new_unchecked(&mut bytes[..]);
         ECHOV4_REPR.emit(&mut packet, &checksum);
 
         assert_eq!(
@@ -769,7 +769,7 @@ mod test_ipv4 {
         let checksum = ChecksumCapabilities::default();
 
         let mut bytes = [0xff; 24];
-        let mut packet = Icmpv4Packet::new_unchecked(&mut bytes);
+        let mut packet = Icmpv4Packet::new_unchecked(&mut bytes[..]);
         ECHOV4_REPR.emit(&mut packet, &checksum);
 
         s.set_hop_limit(Some(0x2a));
@@ -839,7 +839,7 @@ mod test_ipv4 {
 
         let checksum = ChecksumCapabilities::default();
         let mut bytes = [0xff; 20];
-        let mut packet = Icmpv4Packet::new_unchecked(&mut bytes);
+        let mut packet = Icmpv4Packet::new_unchecked(&mut bytes[..]);
         let icmp_repr = Icmpv4Repr::EchoRequest {
             ident: 0x4321,
             seq_no: 0x5678,
@@ -865,7 +865,7 @@ mod test_ipv4 {
         let checksum = ChecksumCapabilities::default();
 
         let mut bytes = [0xff; 18];
-        let mut packet = UdpPacket::new_unchecked(&mut bytes);
+        let mut packet = UdpPacket::new_unchecked(&mut bytes[..]);
         UDP_REPR.emit(
             &mut packet,
             &REMOTE_IPV4.into(),
@@ -985,7 +985,7 @@ mod test_ipv6 {
         assert!(socket.can_send());
 
         let mut bytes = vec![0xff; 24];
-        let mut packet = Icmpv6Packet::new_unchecked(&mut bytes);
+        let mut packet = Icmpv6Packet::new_unchecked(&mut bytes[..]);
         ECHOV6_REPR.emit(
             &LOCAL_IPV6.into(),
             &REMOTE_IPV6.into(),
@@ -1037,7 +1037,7 @@ mod test_ipv6 {
         let checksum = ChecksumCapabilities::default();
 
         let mut bytes = vec![0xff; 24];
-        let mut packet = Icmpv6Packet::new_unchecked(&mut bytes);
+        let mut packet = Icmpv6Packet::new_unchecked(&mut bytes[..]);
         ECHOV6_REPR.emit(
             &LOCAL_IPV6.into(),
             &REMOTE_IPV6.into(),
@@ -1153,7 +1153,7 @@ mod test_ipv6 {
 
         let checksum = ChecksumCapabilities::default();
         let mut bytes = [0xff; 20];
-        let mut packet = Icmpv6Packet::new_unchecked(&mut bytes);
+        let mut packet = Icmpv6Packet::new_unchecked(&mut bytes[..]);
         let icmp_repr = Icmpv6Repr::EchoRequest {
             ident: 0x4321,
             seq_no: 0x5678,
@@ -1184,7 +1184,7 @@ mod test_ipv6 {
         let checksum = ChecksumCapabilities::default();
 
         let mut bytes = [0xff; 18];
-        let mut packet = UdpPacket::new_unchecked(&mut bytes);
+        let mut packet = UdpPacket::new_unchecked(&mut bytes[..]);
         UDP_REPR.emit(
             &mut packet,
             &REMOTE_IPV6.into(),

--- a/src/wire/arp.rs
+++ b/src/wire/arp.rs
@@ -270,7 +270,7 @@ pub enum Repr {
 impl Repr {
     /// Parse an Address Resolution Protocol packet and return a high-level representation,
     /// or return `Err(Error)` if the packet is not recognized.
-    pub fn parse<T: AsRef<[u8]>>(packet: &Packet<T>) -> Result<Repr> {
+    pub fn parse(packet: &Packet<&[u8]>) -> Result<Repr> {
         packet.check_len()?;
 
         match (
@@ -298,7 +298,7 @@ impl Repr {
     }
 
     /// Emit a high-level representation into an Address Resolution Protocol packet.
-    pub fn emit<T: AsRef<[u8]> + AsMut<[u8]>>(&self, packet: &mut Packet<T>) {
+    pub fn emit(&self, packet: &mut Packet<&mut [u8]>) {
         match *self {
             Repr::EthernetIpv4 {
                 operation,
@@ -321,7 +321,7 @@ impl Repr {
     }
 }
 
-impl<T: AsRef<[u8]>> fmt::Display for Packet<T> {
+impl fmt::Display for Packet<&[u8]> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match Repr::parse(self) {
             Ok(repr) => write!(f, "{repr}"),
@@ -377,7 +377,7 @@ impl<T: AsRef<[u8]>> PrettyPrint for Packet<T> {
         f: &mut fmt::Formatter,
         indent: &mut PrettyIndent,
     ) -> fmt::Result {
-        match Packet::new_checked(buffer) {
+        match Packet::new_checked(buffer.as_ref()) {
             Err(err) => write!(f, "{indent}({err})"),
             Ok(packet) => write!(f, "{indent}{packet}"),
         }
@@ -453,7 +453,7 @@ mod test {
     #[test]
     fn test_emit() {
         let mut bytes = vec![0xa5; 28];
-        let mut packet = Packet::new_unchecked(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes[..]);
         packet_repr().emit(&mut packet);
         assert_eq!(&*packet.into_inner(), &PACKET_BYTES[..]);
     }

--- a/src/wire/dhcpv4.rs
+++ b/src/wire/dhcpv4.rs
@@ -703,11 +703,9 @@ impl<'a> Repr<'a> {
     }
 
     /// Parse a DHCP packet and return a high-level representation.
-    pub fn parse<T>(packet: &'a Packet<&'a T>) -> Result<Self>
-    where
-        T: AsRef<[u8]> + ?Sized,
-    {
+    pub fn parse(packet: &'a Packet<&'a [u8]>) -> Result<Self> {
         packet.check_len()?;
+
         let transaction_id = packet.transaction_id();
         let client_hardware_address = packet.client_hardware_address();
         let client_ip = packet.client_ip();
@@ -835,10 +833,7 @@ impl<'a> Repr<'a> {
 
     /// Emit a high-level representation into a Dynamic Host
     /// Configuration Protocol packet.
-    pub fn emit<T>(&self, packet: &mut Packet<&mut T>) -> Result<()>
-    where
-        T: AsRef<[u8]> + AsMut<[u8]> + ?Sized,
-    {
+    pub fn emit(&self, packet: &mut Packet<&mut [u8]>) -> Result<()> {
         packet.set_sname_and_boot_file_to_zero();
         packet.set_opcode(self.message_type.opcode());
         packet.set_hardware_type(Hardware::Ethernet);
@@ -1212,7 +1207,7 @@ mod test {
     fn test_emit_discover() {
         let repr = discover_repr();
         let mut bytes = vec![0xa5; repr.buffer_len()];
-        let mut packet = Packet::new_unchecked(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes[..]);
         repr.emit(&mut packet).unwrap();
         let packet = &*packet.into_inner();
         let packet_len = packet.len();
@@ -1226,7 +1221,7 @@ mod test {
     fn test_emit_offer() {
         let repr = offer_repr();
         let mut bytes = vec![0xa5; repr.buffer_len()];
-        let mut packet = Packet::new_unchecked(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes[..]);
         repr.emit(&mut packet).unwrap();
     }
 
@@ -1245,10 +1240,10 @@ mod test {
             repr
         };
         let mut bytes = vec![0xa5; repr.buffer_len()];
-        let mut packet = Packet::new_unchecked(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes[..]);
         repr.emit(&mut packet).unwrap();
 
-        let packet = Packet::new_unchecked(&bytes);
+        let packet = Packet::new_unchecked(&bytes[..]);
         let repr_parsed = Repr::parse(&packet).unwrap();
 
         assert_eq!(

--- a/src/wire/dns.rs
+++ b/src/wire/dns.rs
@@ -417,10 +417,7 @@ impl<'a> Repr<'a> {
     }
 
     /// Emit a high-level representation into a DNS packet.
-    pub fn emit<T: ?Sized>(&self, packet: &mut Packet<&mut T>)
-    where
-        T: AsRef<[u8]> + AsMut<[u8]>,
-    {
+    pub fn emit(&self, packet: &mut Packet<&mut [u8]>) {
         packet.set_transaction_id(self.transaction_id);
         packet.set_flags(self.flags);
         packet.set_opcode(self.opcode);

--- a/src/wire/ethernet.rs
+++ b/src/wire/ethernet.rs
@@ -267,7 +267,7 @@ pub struct Repr {
 
 impl Repr {
     /// Parse an Ethernet II frame and return a high-level representation.
-    pub fn parse<T: AsRef<[u8]> + ?Sized>(frame: &Frame<&T>) -> Result<Repr> {
+    pub fn parse(frame: &Frame<&[u8]>) -> Result<Repr> {
         frame.check_len()?;
         Ok(Repr {
             src_addr: frame.src_addr(),
@@ -282,8 +282,7 @@ impl Repr {
     }
 
     /// Emit a high-level representation into an Ethernet II frame.
-    pub fn emit<T: AsRef<[u8]> + AsMut<[u8]>>(&self, frame: &mut Frame<T>) {
-        assert!(frame.buffer.as_ref().len() >= self.buffer_len());
+    pub fn emit(&self, frame: &mut Frame<&mut [u8]>) {
         frame.set_src_addr(self.src_addr);
         frame.set_dst_addr(self.dst_addr);
         frame.set_ethertype(self.ethertype);

--- a/src/wire/ieee802154.rs
+++ b/src/wire/ieee802154.rs
@@ -940,7 +940,7 @@ pub struct Repr {
 
 impl Repr {
     /// Parse an IEEE 802.15.4 frame and return a high-level representation.
-    pub fn parse<T: AsRef<[u8]> + ?Sized>(packet: &Frame<&T>) -> Result<Repr> {
+    pub fn parse(packet: &Frame<&[u8]>) -> Result<Repr> {
         // Ensure the basic accessors will work.
         packet.check_len()?;
 
@@ -977,7 +977,7 @@ impl Repr {
     }
 
     /// Emit a high-level representation into an IEEE802.15.4 frame.
-    pub fn emit<T: AsRef<[u8]> + AsMut<[u8]>>(&self, frame: &mut Frame<T>) {
+    pub fn emit(&self, frame: &mut Frame<&mut [u8]>) {
         frame.set_frame_type(self.frame_type);
         frame.set_security_enabled(self.security_enabled);
         frame.set_frame_pending(self.frame_pending);

--- a/src/wire/igmp.rs
+++ b/src/wire/igmp.rs
@@ -201,10 +201,7 @@ pub enum IgmpVersion {
 impl Repr {
     /// Parse an Internet Group Management Protocol v1/v2 packet and return
     /// a high-level representation.
-    pub fn parse<T>(packet: &Packet<&T>) -> Result<Repr>
-    where
-        T: AsRef<[u8]> + ?Sized,
-    {
+    pub fn parse(packet: &Packet<&[u8]>) -> Result<Repr> {
         packet.check_len()?;
 
         // Check if the address is 0.0.0.0 or multicast
@@ -254,10 +251,7 @@ impl Repr {
     }
 
     /// Emit a high-level representation into an Internet Group Management Protocol v2 packet.
-    pub fn emit<T>(&self, packet: &mut Packet<&mut T>)
-    where
-        T: AsRef<[u8]> + AsMut<[u8]> + ?Sized,
-    {
+    pub fn emit(&self, packet: &mut Packet<&mut [u8]>) {
         match *self {
             Repr::MembershipQuery {
                 max_resp_time,
@@ -323,7 +317,7 @@ const fn duration_to_max_resp_code(duration: Duration) -> u8 {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> fmt::Display for Packet<&'a T> {
+impl fmt::Display for Packet<&[u8]> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match Repr::parse(self) {
             Ok(repr) => write!(f, "{repr}"),
@@ -365,7 +359,7 @@ impl<T: AsRef<[u8]>> PrettyPrint for Packet<T> {
         f: &mut fmt::Formatter,
         indent: &mut PrettyIndent,
     ) -> fmt::Result {
-        match Packet::new_checked(buffer) {
+        match Packet::new_checked(buffer.as_ref()) {
             Err(err) => writeln!(f, "{indent}({err})"),
             Ok(packet) => writeln!(f, "{indent}{packet}"),
         }

--- a/src/wire/ip.rs
+++ b/src/wire/ip.rs
@@ -680,11 +680,7 @@ impl Repr {
     }
 
     /// Emit this high-level representation into a buffer.
-    pub fn emit<T: AsRef<[u8]> + AsMut<[u8]>>(
-        &self,
-        buffer: T,
-        _checksum_caps: &ChecksumCapabilities,
-    ) {
+    pub fn emit(&self, buffer: &mut [u8], _checksum_caps: &ChecksumCapabilities) {
         match *self {
             #[cfg(feature = "proto-ipv4")]
             Repr::Ipv4(repr) => repr.emit(&mut Ipv4Packet::new_unchecked(buffer), _checksum_caps),

--- a/src/wire/ipsec_ah.rs
+++ b/src/wire/ipsec_ah.rs
@@ -173,8 +173,9 @@ pub struct Repr<'a> {
 
 impl<'a> Repr<'a> {
     /// Parse an IPSec Authentication Header packet and return a high-level representation.
-    pub fn parse<T: AsRef<[u8]> + ?Sized>(packet: &Packet<&'a T>) -> Result<Repr<'a>> {
+    pub fn parse(packet: &Packet<&'a [u8]>) -> Result<Repr<'a>> {
         packet.check_len()?;
+
         Ok(Repr {
             next_header: packet.next_header(),
             security_parameters_index: packet.security_parameters_index(),
@@ -189,7 +190,7 @@ impl<'a> Repr<'a> {
     }
 
     /// Emit a high-level representation into an IPSec Authentication Header.
-    pub fn emit<T: AsRef<[u8]> + AsMut<[u8]> + ?Sized>(&self, packet: &mut Packet<&'a mut T>) {
+    pub fn emit(&self, packet: &mut Packet<&'a mut [u8]>) {
         packet.set_next_header(self.next_header);
 
         let payload_len = ((field::SEQUENCE_NUMBER.end + self.integrity_check_value.len()) / 4) - 2;
@@ -273,7 +274,7 @@ mod test {
     #[test]
     fn test_emit() {
         let mut bytes = vec![0x17; 24];
-        let mut packet = Packet::new_unchecked(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes[..]);
         packet_repr().emit(&mut packet);
         assert_eq!(bytes, PACKET_BYTES2);
     }

--- a/src/wire/ipsec_esp.rs
+++ b/src/wire/ipsec_esp.rs
@@ -90,8 +90,9 @@ pub struct Repr {
 
 impl Repr {
     /// Parse an IPSec Encapsulating Security Payload packet and return a high-level representation.
-    pub fn parse<T: AsRef<[u8]>>(packet: &Packet<T>) -> Result<Repr> {
+    pub fn parse(packet: &Packet<&'_ [u8]>) -> Result<Repr> {
         packet.check_len()?;
+
         Ok(Repr {
             security_parameters_index: packet.security_parameters_index(),
             sequence_number: packet.sequence_number(),
@@ -104,7 +105,7 @@ impl Repr {
     }
 
     /// Emit a high-level representation into an IPSec Encapsulating Security Payload.
-    pub fn emit<T: AsRef<[u8]> + AsMut<[u8]>>(&self, packet: &mut Packet<T>) {
+    pub fn emit(&self, packet: &mut Packet<&'_ mut [u8]>) {
         packet.set_security_parameters_index(self.security_parameters_index);
         packet.set_sequence_number(self.sequence_number);
     }
@@ -164,7 +165,7 @@ mod test {
     #[test]
     fn test_emit() {
         let mut bytes = vec![0x17; 8];
-        let mut packet = Packet::new_unchecked(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes[..]);
         packet_repr().emit(&mut packet);
         assert_eq!(&bytes, &PACKET_BYTES[..8]);
     }

--- a/src/wire/ipv6ext_header.rs
+++ b/src/wire/ipv6ext_header.rs
@@ -131,10 +131,7 @@ pub struct Repr<'a> {
 
 impl<'a> Repr<'a> {
     /// Parse an IPv6 Extension Header Header and return a high-level representation.
-    pub fn parse<T>(header: &Header<&'a T>) -> Result<Self>
-    where
-        T: AsRef<[u8]> + ?Sized,
-    {
+    pub fn parse(header: &Header<&'a [u8]>) -> Result<Self> {
         header.check_len()?;
         Ok(Self {
             next_header: header.next_header(),
@@ -150,7 +147,7 @@ impl<'a> Repr<'a> {
     }
 
     /// Emit a high-level representation into an IPv6 Extension Header.
-    pub fn emit<T: AsRef<[u8]> + AsMut<[u8]> + ?Sized>(&self, header: &mut Header<&mut T>) {
+    pub fn emit(&self, header: &mut Header<&mut [u8]>) {
         header.set_next_header(self.next_header);
         header.set_header_len(self.length);
     }
@@ -258,7 +255,7 @@ mod test {
 
     #[test]
     fn test_repr_parse_valid() {
-        let header = Header::new_unchecked(&REPR_PACKET_PAD4);
+        let header = Header::new_unchecked(&REPR_PACKET_PAD4[..]);
         let repr = Repr::parse(&header).unwrap();
         assert_eq!(
             repr,
@@ -269,7 +266,7 @@ mod test {
             }
         );
 
-        let header = Header::new_unchecked(&REPR_PACKET_PAD12);
+        let header = Header::new_unchecked(&REPR_PACKET_PAD12[..]);
         let repr = Repr::parse(&header).unwrap();
         assert_eq!(
             repr,
@@ -289,7 +286,7 @@ mod test {
             data: &REPR_PACKET_PAD4[2..],
         };
         let mut bytes = [0u8; 2];
-        let mut header = Header::new_unchecked(&mut bytes);
+        let mut header = Header::new_unchecked(&mut bytes[..]);
         repr.emit(&mut header);
         assert_eq!(header.into_inner(), &REPR_PACKET_PAD4[..2]);
 
@@ -299,7 +296,7 @@ mod test {
             data: &REPR_PACKET_PAD12[2..],
         };
         let mut bytes = [0u8; 2];
-        let mut header = Header::new_unchecked(&mut bytes);
+        let mut header = Header::new_unchecked(&mut bytes[..]);
         repr.emit(&mut header);
         assert_eq!(header.into_inner(), &REPR_PACKET_PAD12[..2]);
     }

--- a/src/wire/ipv6routing.rs
+++ b/src/wire/ipv6routing.rs
@@ -332,7 +332,7 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Header<T> {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> fmt::Display for Header<&'a T> {
+impl<'a> fmt::Display for Header<&'a [u8]> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match Repr::parse(self) {
             Ok(repr) => write!(f, "{repr}"),
@@ -372,10 +372,7 @@ pub enum Repr<'a> {
 
 impl<'a> Repr<'a> {
     /// Parse an IPv6 Routing Header and return a high-level representation.
-    pub fn parse<T>(header: &'a Header<&'a T>) -> Result<Repr<'a>>
-    where
-        T: AsRef<[u8]> + ?Sized,
-    {
+    pub fn parse(header: &'a Header<&'a [u8]>) -> Result<Repr<'a>> {
         header.check_len()?;
         match header.routing_type() {
             Type::Type2 => Ok(Repr::Type2 {
@@ -405,7 +402,7 @@ impl<'a> Repr<'a> {
     }
 
     /// Emit a high-level representation into an IPv6 Routing Header.
-    pub fn emit<T: AsRef<[u8]> + AsMut<[u8]> + ?Sized>(&self, header: &mut Header<&mut T>) {
+    pub fn emit(&self, header: &mut Header<&mut [u8]>) {
         match *self {
             Repr::Type2 {
                 segments_left,

--- a/src/wire/mld.rs
+++ b/src/wire/mld.rs
@@ -315,10 +315,7 @@ pub enum Repr<'a> {
 
 impl<'a> Repr<'a> {
     /// Parse an MLDv2 packet and return a high-level representation.
-    pub fn parse<T>(packet: &Packet<&'a T>) -> Result<Repr<'a>>
-    where
-        T: AsRef<[u8]> + ?Sized,
-    {
+    pub fn parse(packet: &Packet<&'a [u8]>) -> Result<Repr<'a>> {
         packet.check_len()?;
         match packet.msg_type() {
             Message::MldQuery => Ok(Repr::Query {
@@ -347,10 +344,7 @@ impl<'a> Repr<'a> {
     }
 
     /// Emit a high-level representation into an MLDv2 packet.
-    pub fn emit<T>(&self, packet: &mut Packet<&mut T>)
-    where
-        T: AsRef<[u8]> + AsMut<[u8]> + ?Sized,
-    {
+    pub fn emit(&self, packet: &mut Packet<&mut [u8]>) {
         match self {
             Repr::Query {
                 max_resp_code,

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -56,11 +56,11 @@ let repr = Ipv4Repr {
 };
 let mut buffer = vec![0; repr.buffer_len() + repr.payload_len];
 { // emission
-    let mut packet = Ipv4Packet::new_unchecked(&mut buffer);
+    let mut packet = Ipv4Packet::new_unchecked(&mut buffer[..]);
     repr.emit(&mut packet, &ChecksumCapabilities::default());
 }
 { // parsing
-    let packet = Ipv4Packet::new_checked(&buffer)
+    let packet = Ipv4Packet::new_checked(&buffer[..])
                             .expect("truncated packet");
     let parsed = Ipv4Repr::parse(&packet, &ChecksumCapabilities::default())
                           .expect("malformed packet");

--- a/src/wire/ndisc.rs
+++ b/src/wire/ndisc.rs
@@ -226,10 +226,7 @@ impl<'a> Repr<'a> {
     /// Parse an NDISC packet and return a high-level representation of the
     /// packet.
     #[allow(clippy::single_match)]
-    pub fn parse<T>(packet: &Packet<&'a T>) -> Result<Repr<'a>>
-    where
-        T: AsRef<[u8]> + ?Sized,
-    {
+    pub fn parse(packet: &Packet<&'a [u8]>) -> Result<Repr<'a>> {
         packet.check_len()?;
 
         let (mut src_ll_addr, mut mtu, mut prefix_info, mut target_ll_addr, mut redirected_hdr) =
@@ -343,10 +340,7 @@ impl<'a> Repr<'a> {
         }
     }
 
-    pub fn emit<T>(&self, packet: &mut Packet<&mut T>)
-    where
-        T: AsRef<[u8]> + AsMut<[u8]> + ?Sized,
-    {
+    pub fn emit(&self, packet: &mut Packet<&mut [u8]>) {
         match *self {
             Repr::RouterSolicit { lladdr } => {
                 packet.set_msg_type(Message::RouterSolicit);

--- a/src/wire/sixlowpan/frag.rs
+++ b/src/wire/sixlowpan/frag.rs
@@ -233,7 +233,7 @@ impl defmt::Format for Repr {
 
 impl Repr {
     /// Parse a 6LoWPAN Fragment header.
-    pub fn parse<T: AsRef<[u8]>>(packet: &Packet<T>) -> Result<Self> {
+    pub fn parse(packet: &Packet<&[u8]>) -> Result<Self> {
         packet.check_len()?;
         let size = packet.datagram_size();
         let tag = packet.datagram_tag();
@@ -258,7 +258,7 @@ impl Repr {
     }
 
     /// Emit a high-level representation into a 6LoWPAN Fragment header.
-    pub fn emit<T: AsRef<[u8]> + AsMut<[u8]>>(&self, packet: &mut Packet<T>) {
+    pub fn emit(&self, packet: &mut Packet<&mut [u8]>) {
         match self {
             Self::FirstFragment { size, tag } => {
                 packet.set_dispatch_field(DISPATCH_FIRST_FRAGMENT_HEADER);

--- a/src/wire/sixlowpan/iphc.rs
+++ b/src/wire/sixlowpan/iphc.rs
@@ -721,8 +721,8 @@ impl Repr {
     ///
     /// The `ll_src_addr` and `ll_dst_addr` are the link-local addresses used for resolving the
     /// IPv6 packets.
-    pub fn parse<T: AsRef<[u8]> + ?Sized>(
-        packet: &Packet<&T>,
+    pub fn parse(
+        packet: &Packet<&[u8]>,
         ll_src_addr: Option<LlAddress>,
         ll_dst_addr: Option<LlAddress>,
         addr_context: &[AddressContext],
@@ -849,7 +849,7 @@ impl Repr {
     }
 
     /// Emit a high-level representation into a 6LoWPAN IPHC header.
-    pub fn emit<T: AsRef<[u8]> + AsMut<[u8]>>(&self, packet: &mut Packet<T>) {
+    pub fn emit(&self, packet: &mut Packet<&mut [u8]>) {
         let idx = 2;
 
         packet.set_dispatch_field();

--- a/src/wire/sixlowpan/mod.rs
+++ b/src/wire/sixlowpan/mod.rs
@@ -240,8 +240,8 @@ mod test {
             size: 0xff,
             tag: 0xabcd,
         };
-        let buffer = [0u8; 4];
-        let mut packet = frag::Packet::new_unchecked(buffer);
+        let mut buffer = [0u8; 4];
+        let mut packet = frag::Packet::new_unchecked(&mut buffer[..]);
 
         assert_eq!(repr.buffer_len(), 4);
         repr.emit(&mut packet);
@@ -255,8 +255,8 @@ mod test {
             tag: 0xabcd,
             offset: 0xcc,
         };
-        let buffer = [0u8; 5];
-        let mut packet = frag::Packet::new_unchecked(buffer);
+        let mut buffer = [0u8; 5];
+        let mut packet = frag::Packet::new_unchecked(&mut buffer[..]);
 
         assert_eq!(repr.buffer_len(), 5);
         repr.emit(&mut packet);

--- a/src/wire/sixlowpan/nhc.rs
+++ b/src/wire/sixlowpan/nhc.rs
@@ -280,7 +280,7 @@ pub struct ExtHeaderRepr {
 
 impl ExtHeaderRepr {
     /// Parse a 6LoWPAN NHC Extension Header packet and return a high-level representation.
-    pub fn parse<T: AsRef<[u8]> + ?Sized>(packet: &ExtHeaderPacket<&T>) -> Result<Self> {
+    pub fn parse(packet: &ExtHeaderPacket<&[u8]>) -> Result<Self> {
         // Ensure basic accessors will work.
         packet.check_len()?;
 
@@ -309,7 +309,7 @@ impl ExtHeaderRepr {
     }
 
     /// Emit a high-level representation into a 6LoWPAN NHC Extension Header packet.
-    pub fn emit<T: AsRef<[u8]> + AsMut<[u8]>>(&self, packet: &mut ExtHeaderPacket<T>) {
+    pub fn emit(&self, packet: &mut ExtHeaderPacket<&mut [u8]>) {
         packet.set_dispatch_field();
         packet.set_extension_header_id(self.ext_header_id);
         packet.set_next_header(self.next_header);
@@ -693,8 +693,8 @@ pub struct UdpNhcRepr(pub UdpRepr);
 
 impl<'a> UdpNhcRepr {
     /// Parse a 6LoWPAN NHC UDP packet and return a high-level representation.
-    pub fn parse<T: AsRef<[u8]> + ?Sized>(
-        packet: &UdpNhcPacket<&'a T>,
+    pub fn parse(
+        packet: &UdpNhcPacket<&'a [u8]>,
         src_addr: &ipv6::Address,
         dst_addr: &ipv6::Address,
         checksum_caps: &ChecksumCapabilities,
@@ -748,9 +748,9 @@ impl<'a> UdpNhcRepr {
     }
 
     /// Emit a high-level representation into a LOWPAN_NHC UDP header.
-    pub fn emit<T: AsRef<[u8]> + AsMut<[u8]>>(
+    pub fn emit(
         &self,
-        packet: &mut UdpNhcPacket<T>,
+        packet: &mut UdpNhcPacket<&mut [u8]>,
         src_addr: &Address,
         dst_addr: &Address,
         payload_len: usize,

--- a/src/wire/tcp.rs
+++ b/src/wire/tcp.rs
@@ -811,17 +811,13 @@ pub struct Repr<'a> {
 
 impl<'a> Repr<'a> {
     /// Parse a Transmission Control Protocol packet and return a high-level representation.
-    pub fn parse<T>(
-        packet: &Packet<&'a T>,
+    pub fn parse(
+        packet: &Packet<&'a [u8]>,
         src_addr: &IpAddress,
         dst_addr: &IpAddress,
         checksum_caps: &ChecksumCapabilities,
-    ) -> Result<Repr<'a>>
-    where
-        T: AsRef<[u8]> + ?Sized,
-    {
+    ) -> Result<Repr<'a>> {
         packet.check_len()?;
-
         // Source and destination ports must be present.
         if packet.src_port() == 0 {
             return Err(Error);
@@ -937,15 +933,13 @@ impl<'a> Repr<'a> {
     }
 
     /// Emit a high-level representation into a Transmission Control Protocol packet.
-    pub fn emit<T>(
+    pub fn emit(
         &self,
-        packet: &mut Packet<&mut T>,
+        packet: &mut Packet<&mut [u8]>,
         src_addr: &IpAddress,
         dst_addr: &IpAddress,
         checksum_caps: &ChecksumCapabilities,
-    ) where
-        T: AsRef<[u8]> + AsMut<[u8]> + ?Sized,
-    {
+    ) {
         packet.set_src_port(self.src_port);
         packet.set_dst_port(self.dst_port);
         packet.set_seq_number(self.seq_number);
@@ -1256,7 +1250,7 @@ mod test {
     fn test_emit() {
         let repr = packet_repr();
         let mut bytes = vec![0xa5; repr.buffer_len()];
-        let mut packet = Packet::new_unchecked(&mut bytes);
+        let mut packet = Packet::new_unchecked(&mut bytes[..]);
         repr.emit(
             &mut packet,
             &SRC_ADDR.into(),


### PR DESCRIPTION
I was using `cargo bloat` and I saw duplicate functions in wire. After this PR, the duplicates were gone. Removing the generics in the parse and emit functions prevents monomorphization of these functions. Preventing monomorphization reduces the binary size of the library.

`cargo bloat --release --example server --filter smoltcp`:
On main:        216.3KiB
On this branch: 202.5KiB

`cargo bloat --release --example sixlowpan --filter smoltcp`:
On main:        213.9KiB
On this branch: 199.0KiB

I know that this is for an example of `std`. However, the impact of code size will be smaller for embedded I suppose. The negative impact on user experience seems low since I didn't had to change much in the examples (only the ping example) and in the tests. 