### PR TITLE
chore(wire): add check_len to all parse methods

### DIFF
--- a/src/wire/arp.rs
+++ b/src/wire/arp.rs
@@ -271,6 +271,8 @@ impl Repr {
     /// Parse an Address Resolution Protocol packet and return a high-level representation,
     /// or return `Err(Error)` if the packet is not recognized.
     pub fn parse<T: AsRef<[u8]>>(packet: &Packet<T>) -> Result<Repr> {
+        packet.check_len()?;
+
         match (
             packet.hardware_type(),
             packet.protocol_type(),

--- a/src/wire/dhcpv4.rs
+++ b/src/wire/dhcpv4.rs
@@ -707,6 +707,7 @@ impl<'a> Repr<'a> {
     where
         T: AsRef<[u8]> + ?Sized,
     {
+        packet.check_len()?;
         let transaction_id = packet.transaction_id();
         let client_hardware_address = packet.client_hardware_address();
         let client_ip = packet.client_ip();

--- a/src/wire/ethernet.rs
+++ b/src/wire/ethernet.rs
@@ -283,6 +283,7 @@ impl Repr {
 
     /// Emit a high-level representation into an Ethernet II frame.
     pub fn emit<T: AsRef<[u8]> + AsMut<[u8]>>(&self, frame: &mut Frame<T>) {
+        assert!(frame.buffer.as_ref().len() >= self.buffer_len());
         frame.set_src_addr(self.src_addr);
         frame.set_dst_addr(self.dst_addr);
         frame.set_ethertype(self.ethertype);

--- a/src/wire/icmpv4.rs
+++ b/src/wire/icmpv4.rs
@@ -399,6 +399,8 @@ impl<'a> Repr<'a> {
     where
         T: AsRef<[u8]> + ?Sized,
     {
+        packet.check_len()?;
+
         // Valid checksum is expected.
         if checksum_caps.icmpv4.rx() && !packet.verify_checksum() {
             return Err(Error);

--- a/src/wire/icmpv6.rs
+++ b/src/wire/icmpv6.rs
@@ -617,6 +617,8 @@ impl<'a> Repr<'a> {
     where
         T: AsRef<[u8]> + ?Sized,
     {
+        packet.check_len()?;
+
         fn create_packet_from_payload<'a, T>(packet: &Packet<&'a T>) -> Result<(&'a [u8], Ipv6Repr)>
         where
             T: AsRef<[u8]> + ?Sized,

--- a/src/wire/igmp.rs
+++ b/src/wire/igmp.rs
@@ -205,6 +205,8 @@ impl Repr {
     where
         T: AsRef<[u8]> + ?Sized,
     {
+        packet.check_len()?;
+
         // Check if the address is 0.0.0.0 or multicast
         let addr = packet.group_addr();
         if !addr.is_unspecified() && !addr.is_multicast() {

--- a/src/wire/ipsec_ah.rs
+++ b/src/wire/ipsec_ah.rs
@@ -174,6 +174,7 @@ pub struct Repr<'a> {
 impl<'a> Repr<'a> {
     /// Parse an IPSec Authentication Header packet and return a high-level representation.
     pub fn parse<T: AsRef<[u8]> + ?Sized>(packet: &Packet<&'a T>) -> Result<Repr<'a>> {
+        packet.check_len()?;
         Ok(Repr {
             next_header: packet.next_header(),
             security_parameters_index: packet.security_parameters_index(),

--- a/src/wire/ipsec_esp.rs
+++ b/src/wire/ipsec_esp.rs
@@ -91,6 +91,7 @@ pub struct Repr {
 impl Repr {
     /// Parse an IPSec Encapsulating Security Payload packet and return a high-level representation.
     pub fn parse<T: AsRef<[u8]>>(packet: &Packet<T>) -> Result<Repr> {
+        packet.check_len()?;
         Ok(Repr {
             security_parameters_index: packet.security_parameters_index(),
             sequence_number: packet.sequence_number(),

--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -633,6 +633,7 @@ impl Repr {
         packet: &Packet<&T>,
         checksum_caps: &ChecksumCapabilities,
     ) -> Result<Repr> {
+        packet.check_len()?;
         // Version 4 is expected.
         if packet.version() != 4 {
             return Err(Error);

--- a/src/wire/ipv6ext_header.rs
+++ b/src/wire/ipv6ext_header.rs
@@ -135,6 +135,7 @@ impl<'a> Repr<'a> {
     where
         T: AsRef<[u8]> + ?Sized,
     {
+        header.check_len()?;
         Ok(Self {
             next_header: header.next_header(),
             length: header.header_len(),

--- a/src/wire/ipv6fragment.rs
+++ b/src/wire/ipv6fragment.rs
@@ -157,6 +157,7 @@ impl Repr {
     where
         T: AsRef<[u8]> + ?Sized,
     {
+        header.check_len()?;
         Ok(Repr {
             frag_offset: header.frag_offset(),
             more_frags: header.more_frags(),

--- a/src/wire/ipv6hbh.rs
+++ b/src/wire/ipv6hbh.rs
@@ -70,6 +70,8 @@ impl<'a> Repr<'a> {
     where
         T: AsRef<[u8]> + ?Sized,
     {
+        header.check_len()?;
+
         let mut options = Vec::new();
 
         let iter = Ipv6OptionsIterator::new(header.options());

--- a/src/wire/ipv6option.rs
+++ b/src/wire/ipv6option.rs
@@ -241,6 +241,7 @@ impl<'a> Repr<'a> {
     where
         T: AsRef<[u8]> + ?Sized,
     {
+        opt.check_len()?;
         match opt.option_type() {
             Type::Pad1 => Ok(Repr::Pad1),
             Type::PadN => Ok(Repr::PadN(opt.data_len())),

--- a/src/wire/ipv6routing.rs
+++ b/src/wire/ipv6routing.rs
@@ -376,6 +376,7 @@ impl<'a> Repr<'a> {
     where
         T: AsRef<[u8]> + ?Sized,
     {
+        header.check_len()?;
         match header.routing_type() {
             Type::Type2 => Ok(Repr::Type2 {
                 segments_left: header.segments_left(),

--- a/src/wire/mld.rs
+++ b/src/wire/mld.rs
@@ -319,6 +319,7 @@ impl<'a> Repr<'a> {
     where
         T: AsRef<[u8]> + ?Sized,
     {
+        packet.check_len()?;
         match packet.msg_type() {
             Message::MldQuery => Ok(Repr::Query {
                 max_resp_code: packet.max_resp_code(),

--- a/src/wire/ndisc.rs
+++ b/src/wire/ndisc.rs
@@ -230,6 +230,8 @@ impl<'a> Repr<'a> {
     where
         T: AsRef<[u8]> + ?Sized,
     {
+        packet.check_len()?;
+
         let (mut src_ll_addr, mut mtu, mut prefix_info, mut target_ll_addr, mut redirected_hdr) =
             (None, None, None, None, None);
 

--- a/src/wire/ndiscoption.rs
+++ b/src/wire/ndiscoption.rs
@@ -431,6 +431,8 @@ impl<'a> Repr<'a> {
     where
         T: AsRef<[u8]> + ?Sized,
     {
+        opt.check_len()?;
+
         match opt.option_type() {
             Type::SourceLinkLayerAddr => {
                 if opt.data_len() >= 1 {

--- a/src/wire/rpl.rs
+++ b/src/wire/rpl.rs
@@ -717,6 +717,8 @@ impl<'p> Repr<'p> {
     }
 
     pub fn parse<T: AsRef<[u8]> + ?Sized>(packet: &Packet<&'p T>) -> Result<Self> {
+        packet.check_len()?;
+
         let options = packet.options()?;
         match RplControlMessage::from(packet.msg_code()) {
             RplControlMessage::DodagInformationSolicitation => {

--- a/src/wire/sixlowpan/frag.rs
+++ b/src/wire/sixlowpan/frag.rs
@@ -234,6 +234,7 @@ impl defmt::Format for Repr {
 impl Repr {
     /// Parse a 6LoWPAN Fragment header.
     pub fn parse<T: AsRef<[u8]>>(packet: &Packet<T>) -> Result<Self> {
+        packet.check_len()?;
         let size = packet.datagram_size();
         let tag = packet.datagram_tag();
 

--- a/src/wire/tcp.rs
+++ b/src/wire/tcp.rs
@@ -820,6 +820,8 @@ impl<'a> Repr<'a> {
     where
         T: AsRef<[u8]> + ?Sized,
     {
+        packet.check_len()?;
+
         // Source and destination ports must be present.
         if packet.src_port() == 0 {
             return Err(Error);

--- a/src/wire/udp.rs
+++ b/src/wire/udp.rs
@@ -223,6 +223,8 @@ impl Repr {
     where
         T: AsRef<[u8]> + ?Sized,
     {
+        packet.check_len()?;
+
         // Destination port cannot be omitted (but source port can be).
         if packet.dst_port() == 0 {
             return Err(Error);


### PR DESCRIPTION
This commit adds a call to `check_len` to all parse methods in the `wire` module. This ensures that no accessor methods are invalid, helping the compiler optimise.

server:    199.4KiB -> 197.3KiB 
client:    200.2KiB -> 198.0KiB
sixlowpan: 196.8KiB -> 194.7KiB

It's a small gain, but it's worth it.

Edit: valid -> invalid