### PR TITLE
change(udp): parse udp header in process_udp

### DIFF
--- a/src/iface/interface/ipv4.rs
+++ b/src/iface/interface/ipv4.rs
@@ -129,23 +129,7 @@ impl InterfaceInner {
 
             #[cfg(any(feature = "socket-udp", feature = "socket-dns"))]
             IpProtocol::Udp => {
-                let udp_packet = check!(UdpPacket::new_checked(ip_payload));
-                let udp_repr = check!(UdpRepr::parse(
-                    &udp_packet,
-                    &ipv4_repr.src_addr.into(),
-                    &ipv4_repr.dst_addr.into(),
-                    &self.checksum_caps(),
-                ));
-
-                self.process_udp(
-                    sockets,
-                    meta,
-                    ip_repr,
-                    udp_repr,
-                    handled_by_raw_socket,
-                    udp_packet.payload(),
-                    ip_payload,
-                )
+                self.process_udp(sockets, meta, handled_by_raw_socket, ip_repr, ip_payload)
             }
 
             #[cfg(feature = "socket-tcp")]

--- a/src/iface/interface/ipv6.rs
+++ b/src/iface/interface/ipv6.rs
@@ -143,25 +143,13 @@ impl InterfaceInner {
             IpProtocol::Icmpv6 => self.process_icmpv6(sockets, ipv6_repr.into(), ip_payload),
 
             #[cfg(any(feature = "socket-udp", feature = "socket-dns"))]
-            IpProtocol::Udp => {
-                let udp_packet = check!(UdpPacket::new_checked(ip_payload));
-                let udp_repr = check!(UdpRepr::parse(
-                    &udp_packet,
-                    &ipv6_repr.src_addr.into(),
-                    &ipv6_repr.dst_addr.into(),
-                    &self.checksum_caps(),
-                ));
-
-                self.process_udp(
-                    sockets,
-                    meta,
-                    ipv6_repr.into(),
-                    udp_repr,
-                    handled_by_raw_socket,
-                    udp_packet.payload(),
-                    ip_payload,
-                )
-            }
+            IpProtocol::Udp => self.process_udp(
+                sockets,
+                meta,
+                handled_by_raw_socket,
+                ipv6_repr.into(),
+                ip_payload,
+            ),
 
             #[cfg(feature = "socket-tcp")]
             IpProtocol::Tcp => self.process_tcp(sockets, ipv6_repr.into(), ip_payload),

--- a/src/iface/interface/tests/ipv4.rs
+++ b/src/iface/interface/tests/ipv4.rs
@@ -236,15 +236,9 @@ fn test_icmp_error_port_unreachable(#[case] medium: Medium) {
     // Ensure that the unknown protocol triggers an error response.
     // And we correctly handle no payload.
     assert_eq!(
-        iface.inner.process_udp(
-            &mut sockets,
-            PacketMeta::default(),
-            ip_repr,
-            udp_repr,
-            false,
-            &UDP_PAYLOAD,
-            data
-        ),
+        iface
+            .inner
+            .process_udp(&mut sockets, PacketMeta::default(), false, ip_repr, data),
         Some(expected_repr)
     );
 
@@ -273,10 +267,8 @@ fn test_icmp_error_port_unreachable(#[case] medium: Medium) {
         iface.inner.process_udp(
             &mut sockets,
             PacketMeta::default(),
-            ip_repr,
-            udp_repr,
             false,
-            &UDP_PAYLOAD,
+            ip_repr,
             packet_broadcast.into_inner(),
         ),
         None
@@ -954,10 +946,8 @@ fn test_icmp_reply_size(#[case] medium: Medium) {
         iface.inner.process_udp(
             &mut sockets,
             PacketMeta::default(),
-            ip_repr.into(),
-            udp_repr,
             false,
-            &vec![0x2a; MAX_PAYLOAD_LEN],
+            ip_repr.into(),
             payload,
         ),
         Some(Packet::new_ipv4(

--- a/src/iface/interface/tests/ipv6.rs
+++ b/src/iface/interface/tests/ipv6.rs
@@ -853,10 +853,8 @@ fn test_icmp_reply_size(#[case] medium: Medium) {
         iface.inner.process_udp(
             &mut sockets,
             PacketMeta::default(),
-            ip_repr.into(),
-            udp_repr,
             false,
-            &vec![0x2a; MAX_PAYLOAD_LEN],
+            ip_repr.into(),
             payload,
         ),
         Some(Packet::new_ipv6(

--- a/src/iface/interface/tests/mod.rs
+++ b/src/iface/interface/tests/mod.rs
@@ -129,10 +129,8 @@ fn test_handle_udp_broadcast(
         iface.inner.process_udp(
             &mut sockets,
             PacketMeta::default(),
-            ip_repr,
-            udp_repr,
             false,
-            &UDP_PAYLOAD,
+            ip_repr,
             packet.into_inner(),
         ),
         None


### PR DESCRIPTION
Just like TCP, UDP packets are now parsed in the process_udp function, instead of being parsed in the caller.