### PR TITLE
ICMP socket: split ICMPv4/v6 accept and process

### DIFF
--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -187,11 +187,8 @@ fn main() {
                         remote_addr
                     );
                     icmp_repr.emit(
-                        &iface
-                            .get_source_address_ipv6(&address)
-                            .unwrap()
-                            .into_address(),
-                        &remote_addr,
+                        &iface.get_source_address_ipv6(&address).unwrap(),
+                        &address,
                         &mut icmp_packet,
                         &device_caps.checksum,
                     );
@@ -223,11 +220,8 @@ fn main() {
                 IpAddress::Ipv6(address) => {
                     let icmp_packet = Icmpv6Packet::new_checked(&payload).unwrap();
                     let icmp_repr = Icmpv6Repr::parse(
-                        &remote_addr,
-                        &iface
-                            .get_source_address_ipv6(&address)
-                            .unwrap()
-                            .into_address(),
+                        &address,
+                        &iface.get_source_address_ipv6(&address).unwrap(),
                         &icmp_packet,
                         &device_caps.checksum,
                     )

--- a/src/iface/interface/sixlowpan.rs
+++ b/src/iface/interface/sixlowpan.rs
@@ -508,8 +508,8 @@ impl InterfaceInner {
         match &mut packet.payload {
             IpPayload::Icmpv6(icmp_repr) => {
                 icmp_repr.emit(
-                    &packet.header.src_addr.into(),
-                    &packet.header.dst_addr.into(),
+                    &packet.header.src_addr,
+                    &packet.header.dst_addr,
                     &mut Icmpv6Packet::new_unchecked(&mut buffer[..icmp_repr.buffer_len()]),
                     checksum_caps,
                 );

--- a/src/iface/interface/tests/ipv4.rs
+++ b/src/iface/interface/tests/ipv4.rs
@@ -565,7 +565,6 @@ fn test_icmpv4_socket(#[case] medium: Medium) {
         payload_len: 24,
         hop_limit: 64,
     };
-    let ip_repr = IpRepr::Ipv4(ipv4_repr);
 
     // Open a socket and ensure the packet is handled due to the listening
     // socket.
@@ -583,7 +582,9 @@ fn test_icmpv4_socket(#[case] medium: Medium) {
         ..ipv4_repr
     };
     assert_eq!(
-        iface.inner.process_icmpv4(&mut sockets, ip_repr, icmp_data),
+        iface
+            .inner
+            .process_icmpv4(&mut sockets, ipv4_repr, icmp_data),
         Some(Packet::new_ipv4(ipv4_reply, IpPayload::Icmpv4(echo_reply)))
     );
 

--- a/src/iface/interface/tests/ipv6.rs
+++ b/src/iface/interface/tests/ipv6.rs
@@ -16,8 +16,8 @@ fn parse_ipv6(data: &[u8]) -> crate::wire::Result<Packet<'_>> {
         IpProtocol::IpSecAh => todo!(),
         IpProtocol::Icmpv6 => {
             let icmp = Icmpv6Repr::parse(
-                &ipv6.src_addr.into(),
-                &ipv6.dst_addr.into(),
+                &ipv6.src_addr,
+                &ipv6.dst_addr,
                 &Icmpv6Packet::new_checked(ipv6_header.payload())?,
                 &Default::default(),
             )?;
@@ -707,8 +707,8 @@ fn test_handle_valid_ndisc_request(#[case] medium: Medium) {
     frame.set_ethertype(EthernetProtocol::Ipv6);
     ip_repr.emit(frame.payload_mut(), &ChecksumCapabilities::default());
     solicit.emit(
-        &remote_ip_addr.into(),
-        &local_ip_addr.solicited_node().into(),
+        &remote_ip_addr,
+        &local_ip_addr.solicited_node(),
         &mut Icmpv6Packet::new_unchecked(&mut frame.payload_mut()[ip_repr.header_len()..]),
         &ChecksumCapabilities::default(),
     );

--- a/src/iface/neighbor.rs
+++ b/src/iface/neighbor.rs
@@ -163,7 +163,10 @@ impl Cache {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::wire::ip::test::{MOCK_IP_ADDR_1, MOCK_IP_ADDR_2, MOCK_IP_ADDR_3, MOCK_IP_ADDR_4};
+    #[cfg(all(feature = "proto-ipv4", not(feature = "proto-ipv6")))]
+    use crate::wire::ipv4::test::{MOCK_IP_ADDR_1, MOCK_IP_ADDR_2, MOCK_IP_ADDR_3, MOCK_IP_ADDR_4};
+    #[cfg(feature = "proto-ipv6")]
+    use crate::wire::ipv6::test::{MOCK_IP_ADDR_1, MOCK_IP_ADDR_2, MOCK_IP_ADDR_3, MOCK_IP_ADDR_4};
 
     use crate::wire::EthernetAddress;
 
@@ -177,30 +180,30 @@ mod test {
         let mut cache = Cache::new();
 
         assert!(!cache
-            .lookup(&MOCK_IP_ADDR_1, Instant::from_millis(0))
+            .lookup(&MOCK_IP_ADDR_1.into(), Instant::from_millis(0))
             .found());
         assert!(!cache
-            .lookup(&MOCK_IP_ADDR_2, Instant::from_millis(0))
+            .lookup(&MOCK_IP_ADDR_2.into(), Instant::from_millis(0))
             .found());
 
-        cache.fill(MOCK_IP_ADDR_1, HADDR_A, Instant::from_millis(0));
+        cache.fill(MOCK_IP_ADDR_1.into(), HADDR_A, Instant::from_millis(0));
         assert_eq!(
-            cache.lookup(&MOCK_IP_ADDR_1, Instant::from_millis(0)),
+            cache.lookup(&MOCK_IP_ADDR_1.into(), Instant::from_millis(0)),
             Answer::Found(HADDR_A)
         );
         assert!(!cache
-            .lookup(&MOCK_IP_ADDR_2, Instant::from_millis(0))
+            .lookup(&MOCK_IP_ADDR_2.into(), Instant::from_millis(0))
             .found());
         assert!(!cache
             .lookup(
-                &MOCK_IP_ADDR_1,
+                &MOCK_IP_ADDR_1.into(),
                 Instant::from_millis(0) + Cache::ENTRY_LIFETIME * 2
             )
             .found(),);
 
-        cache.fill(MOCK_IP_ADDR_1, HADDR_A, Instant::from_millis(0));
+        cache.fill(MOCK_IP_ADDR_1.into(), HADDR_A, Instant::from_millis(0));
         assert!(!cache
-            .lookup(&MOCK_IP_ADDR_2, Instant::from_millis(0))
+            .lookup(&MOCK_IP_ADDR_2.into(), Instant::from_millis(0))
             .found());
     }
 
@@ -208,14 +211,14 @@ mod test {
     fn test_expire() {
         let mut cache = Cache::new();
 
-        cache.fill(MOCK_IP_ADDR_1, HADDR_A, Instant::from_millis(0));
+        cache.fill(MOCK_IP_ADDR_1.into(), HADDR_A, Instant::from_millis(0));
         assert_eq!(
-            cache.lookup(&MOCK_IP_ADDR_1, Instant::from_millis(0)),
+            cache.lookup(&MOCK_IP_ADDR_1.into(), Instant::from_millis(0)),
             Answer::Found(HADDR_A)
         );
         assert!(!cache
             .lookup(
-                &MOCK_IP_ADDR_1,
+                &MOCK_IP_ADDR_1.into(),
                 Instant::from_millis(0) + Cache::ENTRY_LIFETIME * 2
             )
             .found(),);
@@ -225,14 +228,14 @@ mod test {
     fn test_replace() {
         let mut cache = Cache::new();
 
-        cache.fill(MOCK_IP_ADDR_1, HADDR_A, Instant::from_millis(0));
+        cache.fill(MOCK_IP_ADDR_1.into(), HADDR_A, Instant::from_millis(0));
         assert_eq!(
-            cache.lookup(&MOCK_IP_ADDR_1, Instant::from_millis(0)),
+            cache.lookup(&MOCK_IP_ADDR_1.into(), Instant::from_millis(0)),
             Answer::Found(HADDR_A)
         );
-        cache.fill(MOCK_IP_ADDR_1, HADDR_B, Instant::from_millis(0));
+        cache.fill(MOCK_IP_ADDR_1.into(), HADDR_B, Instant::from_millis(0));
         assert_eq!(
-            cache.lookup(&MOCK_IP_ADDR_1, Instant::from_millis(0)),
+            cache.lookup(&MOCK_IP_ADDR_1.into(), Instant::from_millis(0)),
             Answer::Found(HADDR_B)
         );
     }
@@ -241,23 +244,23 @@ mod test {
     fn test_evict() {
         let mut cache = Cache::new();
 
-        cache.fill(MOCK_IP_ADDR_1, HADDR_A, Instant::from_millis(100));
-        cache.fill(MOCK_IP_ADDR_2, HADDR_B, Instant::from_millis(50));
-        cache.fill(MOCK_IP_ADDR_3, HADDR_C, Instant::from_millis(200));
+        cache.fill(MOCK_IP_ADDR_1.into(), HADDR_A, Instant::from_millis(100));
+        cache.fill(MOCK_IP_ADDR_2.into(), HADDR_B, Instant::from_millis(50));
+        cache.fill(MOCK_IP_ADDR_3.into(), HADDR_C, Instant::from_millis(200));
         assert_eq!(
-            cache.lookup(&MOCK_IP_ADDR_2, Instant::from_millis(1000)),
+            cache.lookup(&MOCK_IP_ADDR_2.into(), Instant::from_millis(1000)),
             Answer::Found(HADDR_B)
         );
         assert!(!cache
-            .lookup(&MOCK_IP_ADDR_4, Instant::from_millis(1000))
+            .lookup(&MOCK_IP_ADDR_4.into(), Instant::from_millis(1000))
             .found());
 
-        cache.fill(MOCK_IP_ADDR_4, HADDR_D, Instant::from_millis(300));
+        cache.fill(MOCK_IP_ADDR_4.into(), HADDR_D, Instant::from_millis(300));
         assert!(!cache
-            .lookup(&MOCK_IP_ADDR_2, Instant::from_millis(1000))
+            .lookup(&MOCK_IP_ADDR_2.into(), Instant::from_millis(1000))
             .found());
         assert_eq!(
-            cache.lookup(&MOCK_IP_ADDR_4, Instant::from_millis(1000)),
+            cache.lookup(&MOCK_IP_ADDR_4.into(), Instant::from_millis(1000)),
             Answer::Found(HADDR_D)
         );
     }
@@ -267,17 +270,17 @@ mod test {
         let mut cache = Cache::new();
 
         assert_eq!(
-            cache.lookup(&MOCK_IP_ADDR_1, Instant::from_millis(0)),
+            cache.lookup(&MOCK_IP_ADDR_1.into(), Instant::from_millis(0)),
             Answer::NotFound
         );
 
         cache.limit_rate(Instant::from_millis(0));
         assert_eq!(
-            cache.lookup(&MOCK_IP_ADDR_1, Instant::from_millis(100)),
+            cache.lookup(&MOCK_IP_ADDR_1.into(), Instant::from_millis(100)),
             Answer::RateLimited
         );
         assert_eq!(
-            cache.lookup(&MOCK_IP_ADDR_1, Instant::from_millis(2000)),
+            cache.lookup(&MOCK_IP_ADDR_1.into(), Instant::from_millis(2000)),
             Answer::NotFound
         );
     }
@@ -286,21 +289,21 @@ mod test {
     fn test_flush() {
         let mut cache = Cache::new();
 
-        cache.fill(MOCK_IP_ADDR_1, HADDR_A, Instant::from_millis(0));
+        cache.fill(MOCK_IP_ADDR_1.into(), HADDR_A, Instant::from_millis(0));
         assert_eq!(
-            cache.lookup(&MOCK_IP_ADDR_1, Instant::from_millis(0)),
+            cache.lookup(&MOCK_IP_ADDR_1.into(), Instant::from_millis(0)),
             Answer::Found(HADDR_A)
         );
         assert!(!cache
-            .lookup(&MOCK_IP_ADDR_2, Instant::from_millis(0))
+            .lookup(&MOCK_IP_ADDR_2.into(), Instant::from_millis(0))
             .found());
 
         cache.flush();
         assert!(!cache
-            .lookup(&MOCK_IP_ADDR_1, Instant::from_millis(0))
+            .lookup(&MOCK_IP_ADDR_1.into(), Instant::from_millis(0))
             .found());
         assert!(!cache
-            .lookup(&MOCK_IP_ADDR_1, Instant::from_millis(0))
+            .lookup(&MOCK_IP_ADDR_1.into(), Instant::from_millis(0))
             .found());
     }
 }

--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -796,8 +796,19 @@ impl<T: AsRef<[u8]>> PrettyPrint for Packet<T> {
 }
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test {
     use super::*;
+
+    #[allow(unused)]
+    pub(crate) const MOCK_IP_ADDR_1: Address = Address([192, 168, 1, 1]);
+    #[allow(unused)]
+    pub(crate) const MOCK_IP_ADDR_2: Address = Address([192, 168, 1, 2]);
+    #[allow(unused)]
+    pub(crate) const MOCK_IP_ADDR_3: Address = Address([192, 168, 1, 3]);
+    #[allow(unused)]
+    pub(crate) const MOCK_IP_ADDR_4: Address = Address([192, 168, 1, 4]);
+    #[allow(unused)]
+    pub(crate) const MOCK_UNSPECIFIED: Address = Address::UNSPECIFIED;
 
     static PACKET_BYTES: [u8; 30] = [
         0x45, 0x00, 0x00, 0x1e, 0x01, 0x02, 0x62, 0x03, 0x1a, 0x01, 0xd5, 0x6e, 0x11, 0x12, 0x13,

--- a/src/wire/ipv6.rs
+++ b/src/wire/ipv6.rs
@@ -897,7 +897,7 @@ impl<T: AsRef<[u8]>> PrettyPrint for Packet<T> {
 }
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test {
     use super::Error;
     use super::{Address, Cidr};
     use super::{Packet, Protocol, Repr};
@@ -905,6 +905,21 @@ mod test {
 
     #[cfg(feature = "proto-ipv4")]
     use crate::wire::ipv4::Address as Ipv4Address;
+
+    #[allow(unused)]
+    pub(crate) const MOCK_IP_ADDR_1: Address =
+        Address([0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+    #[allow(unused)]
+    pub(crate) const MOCK_IP_ADDR_2: Address =
+        Address([0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2]);
+    #[allow(unused)]
+    pub(crate) const MOCK_IP_ADDR_3: Address =
+        Address([0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3]);
+    #[allow(unused)]
+    pub(crate) const MOCK_IP_ADDR_4: Address =
+        Address([0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4]);
+    #[allow(unused)]
+    pub(crate) const MOCK_UNSPECIFIED: Address = Address::UNSPECIFIED;
 
     const LINK_LOCAL_ADDR: Address = Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
     const UNIQUE_LOCAL_ADDR: Address = Address::new(0xfd00, 0, 0, 201, 1, 1, 1, 1);

--- a/src/wire/mld.rs
+++ b/src/wire/mld.rs
@@ -476,8 +476,8 @@ mod test {
             .copy_from_slice(Ipv6Address::LINK_LOCAL_ALL_ROUTERS.as_bytes());
         packet.clear_reserved();
         packet.fill_checksum(
-            &Ipv6Address::LINK_LOCAL_ALL_NODES.into(),
-            &Ipv6Address::LINK_LOCAL_ALL_ROUTERS.into(),
+            &Ipv6Address::LINK_LOCAL_ALL_NODES,
+            &Ipv6Address::LINK_LOCAL_ALL_ROUTERS,
         );
         assert_eq!(&*packet.into_inner(), &QUERY_PACKET_BYTES[..]);
     }
@@ -519,8 +519,8 @@ mod test {
                 .copy_from_slice(Ipv6Address::LINK_LOCAL_ALL_ROUTERS.as_bytes());
         }
         packet.fill_checksum(
-            &Ipv6Address::LINK_LOCAL_ALL_NODES.into(),
-            &Ipv6Address::LINK_LOCAL_ALL_ROUTERS.into(),
+            &Ipv6Address::LINK_LOCAL_ALL_NODES,
+            &Ipv6Address::LINK_LOCAL_ALL_ROUTERS,
         );
         assert_eq!(&*packet.into_inner(), &REPORT_PACKET_BYTES[..]);
     }
@@ -529,8 +529,8 @@ mod test {
     fn test_query_repr_parse() {
         let packet = Packet::new_unchecked(&QUERY_PACKET_BYTES[..]);
         let repr = Icmpv6Repr::parse(
-            &Ipv6Address::LINK_LOCAL_ALL_NODES.into(),
-            &Ipv6Address::LINK_LOCAL_ALL_ROUTERS.into(),
+            &Ipv6Address::LINK_LOCAL_ALL_NODES,
+            &Ipv6Address::LINK_LOCAL_ALL_ROUTERS,
             &packet,
             &ChecksumCapabilities::default(),
         );
@@ -541,8 +541,8 @@ mod test {
     fn test_report_repr_parse() {
         let packet = Packet::new_unchecked(&REPORT_PACKET_BYTES[..]);
         let repr = Icmpv6Repr::parse(
-            &Ipv6Address::LINK_LOCAL_ALL_NODES.into(),
-            &Ipv6Address::LINK_LOCAL_ALL_ROUTERS.into(),
+            &Ipv6Address::LINK_LOCAL_ALL_NODES,
+            &Ipv6Address::LINK_LOCAL_ALL_ROUTERS,
             &packet,
             &ChecksumCapabilities::default(),
         );
@@ -555,8 +555,8 @@ mod test {
         let mut packet = Packet::new_unchecked(&mut bytes[..]);
         let repr = create_repr(Message::MldQuery);
         repr.emit(
-            &Ipv6Address::LINK_LOCAL_ALL_NODES.into(),
-            &Ipv6Address::LINK_LOCAL_ALL_ROUTERS.into(),
+            &Ipv6Address::LINK_LOCAL_ALL_NODES,
+            &Ipv6Address::LINK_LOCAL_ALL_ROUTERS,
             &mut packet,
             &ChecksumCapabilities::default(),
         );
@@ -569,8 +569,8 @@ mod test {
         let mut packet = Packet::new_unchecked(&mut bytes[..]);
         let repr = create_repr(Message::MldReport);
         repr.emit(
-            &Ipv6Address::LINK_LOCAL_ALL_NODES.into(),
-            &Ipv6Address::LINK_LOCAL_ALL_ROUTERS.into(),
+            &Ipv6Address::LINK_LOCAL_ALL_NODES,
+            &Ipv6Address::LINK_LOCAL_ALL_ROUTERS,
             &mut packet,
             &ChecksumCapabilities::default(),
         );

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -97,9 +97,9 @@ pub mod ieee802154;
 mod igmp;
 pub(crate) mod ip;
 #[cfg(feature = "proto-ipv4")]
-mod ipv4;
+pub(crate) mod ipv4;
 #[cfg(feature = "proto-ipv6")]
-mod ipv6;
+pub(crate) mod ipv6;
 #[cfg(feature = "proto-ipv6")]
 mod ipv6ext_header;
 #[cfg(feature = "proto-ipv6")]

--- a/src/wire/ndisc.rs
+++ b/src/wire/ndisc.rs
@@ -459,9 +459,13 @@ impl<'a> Repr<'a> {
 mod test {
     use super::*;
     use crate::phy::ChecksumCapabilities;
-    use crate::wire::ip::test::{MOCK_IP_ADDR_1, MOCK_IP_ADDR_2};
     use crate::wire::EthernetAddress;
     use crate::wire::Icmpv6Repr;
+
+    const MOCK_IP_ADDR_1: Ipv6Address =
+        Ipv6Address([0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+    const MOCK_IP_ADDR_2: Ipv6Address =
+        Ipv6Address([0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2]);
 
     static ROUTER_ADVERT_BYTES: [u8; 24] = [
         0x86, 0x00, 0xa9, 0xde, 0x40, 0x80, 0x03, 0x84, 0x00, 0x00, 0x03, 0x84, 0x00, 0x00, 0x03,

--- a/src/wire/rpl.rs
+++ b/src/wire/rpl.rs
@@ -2414,8 +2414,8 @@ mod tests {
             SixlowpanNextHeader::Uncompressed(IpProtocol::Icmpv6) => {
                 let icmp_packet = Icmpv6Packet::new_checked(packet.payload()).unwrap();
                 match Icmpv6Repr::parse(
-                    &IpAddress::Ipv6(repr.src_addr),
-                    &IpAddress::Ipv6(repr.dst_addr),
+                    &repr.src_addr,
+                    &repr.dst_addr,
                     &icmp_packet,
                     &ChecksumCapabilities::ignored(),
                 ) {

--- a/src/wire/sixlowpan/nhc.rs
+++ b/src/wire/sixlowpan/nhc.rs
@@ -4,12 +4,7 @@
 use super::{Error, NextHeader, Result, DISPATCH_EXT_HEADER, DISPATCH_UDP_HEADER};
 use crate::{
     phy::ChecksumCapabilities,
-    wire::{
-        ip::{checksum, Address as IpAddress},
-        ipv6,
-        udp::Repr as UdpRepr,
-        IpProtocol,
-    },
+    wire::{ip::checksum, ipv6, udp::Repr as UdpRepr, IpProtocol},
 };
 use byteorder::{ByteOrder, NetworkEndian};
 use ipv6::Address;
@@ -708,9 +703,9 @@ impl<'a> UdpNhcRepr {
         if checksum_caps.udp.rx() {
             let payload_len = packet.payload().len();
             let chk_sum = !checksum::combine(&[
-                checksum::pseudo_header(
-                    &IpAddress::Ipv6(*src_addr),
-                    &IpAddress::Ipv6(*dst_addr),
+                checksum::pseudo_header_v6(
+                    src_addr,
+                    dst_addr,
                     crate::wire::ip::Protocol::Udp,
                     payload_len as u32 + 8,
                 ),
@@ -763,9 +758,9 @@ impl<'a> UdpNhcRepr {
 
         if checksum_caps.udp.tx() {
             let chk_sum = !checksum::combine(&[
-                checksum::pseudo_header(
-                    &IpAddress::Ipv6(*src_addr),
-                    &IpAddress::Ipv6(*dst_addr),
+                checksum::pseudo_header_v6(
+                    src_addr,
+                    dst_addr,
                     crate::wire::ip::Protocol::Udp,
                     payload_len as u32 + 8,
                 ),


### PR DESCRIPTION
Splitting the accept and process functions of the ICMP socket into separate functions for IPv4 and IPv6 allows us to avoid the `IpRepr` enum and instead use the `Ipv4Repr` and `Ipv6Repr` structs directly.

This leads to a reduction in binary size:
example/server: 197.3KiB -> 195.9KiB
example/client: 198.0KiB -> 196.7KiB
example/sixlowpan: 194.7KiB -> 193.3KiB

Since the functions are only `pub(crate)`, the impact is only internal.