### PR TITLE
Add missing exports in wire for DNS

### DIFF
--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -274,8 +274,9 @@ pub use self::dhcpv4::{
 
 #[cfg(feature = "proto-dns")]
 pub use self::dns::{
-    Flags as DnsFlags, Opcode as DnsOpcode, Packet as DnsPacket, Rcode as DnsRcode,
-    Repr as DnsRepr, Type as DnsQueryType,
+    Flags as DnsFlags, Opcode as DnsOpcode, Packet as DnsPacket, Question as DnsQuestion,
+    Rcode as DnsRcode, Record as DnsRecord, RecordData as DnsRecordData, Repr as DnsRepr,
+    Type as DnsQueryType,
 };
 
 #[cfg(feature = "proto-ipsec-ah")]


### PR DESCRIPTION
Exporting more things from DNS in wire.

Fixes #890 