### PR TITLE
Prevent panic in update_servers for Domain Name System Socket

### DIFF
--- a/src/socket/dns.rs
+++ b/src/socket/dns.rs
@@ -167,7 +167,7 @@ impl<'a> Socket<'a> {
     ///
     /// Panics if `servers.len() > MAX_SERVER_COUNT`
     pub fn update_servers(&mut self, servers: &[IpAddress]) {
-        self.servers = Vec::from_slice(servers).unwrap();
+        self.servers = Vec::from_slice(&servers[..DNS_MAX_SERVER_COUNT]).unwrap();
     }
 
     /// Return the time-to-live (IPv4) or hop limit (IPv6) value used in outgoing packets.

--- a/src/socket/dns.rs
+++ b/src/socket/dns.rs
@@ -167,7 +167,8 @@ impl<'a> Socket<'a> {
     ///
     /// Panics if `servers.len() > MAX_SERVER_COUNT`
     pub fn update_servers(&mut self, servers: &[IpAddress]) {
-        self.servers = Vec::from_slice(&servers[..servers.len().min(DNS_MAX_SERVER_COUNT)]).unwrap();
+        self.servers =
+            Vec::from_slice(&servers[..servers.len().min(DNS_MAX_SERVER_COUNT)]).unwrap();
     }
 
     /// Return the time-to-live (IPv4) or hop limit (IPv6) value used in outgoing packets.

--- a/src/socket/dns.rs
+++ b/src/socket/dns.rs
@@ -167,7 +167,7 @@ impl<'a> Socket<'a> {
     ///
     /// Panics if `servers.len() > MAX_SERVER_COUNT`
     pub fn update_servers(&mut self, servers: &[IpAddress]) {
-        self.servers = Vec::from_slice(&servers[..DNS_MAX_SERVER_COUNT]).unwrap();
+        self.servers = Vec::from_slice(&servers[..servers.len().min(DNS_MAX_SERVER_COUNT)]).unwrap();
     }
 
     /// Return the time-to-live (IPv4) or hop limit (IPv6) value used in outgoing packets.


### PR DESCRIPTION
I wanted to connect my microcontroller with the wifi, but this library caused panics, because it found more than just one DNS Server. So I needed to change one line in the src/socket/dns.rs file with the update_servers method.

Instead of causing panic if the length of the servers argument exceeds DNS_MAX_SERVER_COUNT, it should take a slice of servers for the first DNS_MAX_SERVER_COUNT elements.