### PR TITLE
fix: don't panic if no suitable IPv6 src_addr is found

### DIFF
--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -187,7 +187,7 @@ fn main() {
                         remote_addr
                     );
                     icmp_repr.emit(
-                        &iface.get_source_address_ipv6(&address).unwrap(),
+                        &iface.get_source_address_ipv6(&address),
                         &address,
                         &mut icmp_packet,
                         &device_caps.checksum,
@@ -221,7 +221,7 @@ fn main() {
                     let icmp_packet = Icmpv6Packet::new_checked(&payload).unwrap();
                     let icmp_repr = Icmpv6Repr::parse(
                         &address,
-                        &iface.get_source_address_ipv6(&address).unwrap(),
+                        &iface.get_source_address_ipv6(&address),
                         &icmp_packet,
                         &device_caps.checksum,
                     )

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -328,7 +328,7 @@ impl Interface {
     /// Get an address from the interface that could be used as source address. The selection is
     /// based on RFC6724.
     #[cfg(feature = "proto-ipv6")]
-    pub fn get_source_address_ipv6(&self, dst_addr: &Ipv6Address) -> Option<Ipv6Address> {
+    pub fn get_source_address_ipv6(&self, dst_addr: &Ipv6Address) -> Ipv6Address {
         self.inner.get_source_address_ipv6(dst_addr)
     }
 
@@ -728,7 +728,7 @@ impl InterfaceInner {
             #[cfg(feature = "proto-ipv4")]
             IpAddress::Ipv4(addr) => self.get_source_address_ipv4(addr).map(|a| a.into()),
             #[cfg(feature = "proto-ipv6")]
-            IpAddress::Ipv6(addr) => self.get_source_address_ipv6(addr).map(|a| a.into()),
+            IpAddress::Ipv6(addr) => Some(self.get_source_address_ipv6(addr).into()),
         }
     }
 

--- a/src/iface/interface/tests/ipv6.rs
+++ b/src/iface/interface/tests/ipv6.rs
@@ -880,8 +880,6 @@ fn get_source_address() {
     //   fd00::201:1:1:1:2/64
     //   fd01::201:1:1:1:2/64
     //   2001:db8:3::1/64
-    //   ::1/128
-    //   ::/128
     iface.update_ip_addrs(|addrs| {
         addrs.clear();
 
@@ -897,17 +895,10 @@ fn get_source_address() {
         addrs
             .push(IpCidr::Ipv6(Ipv6Cidr::new(OWN_GLOBAL_UNICAST_ADDR1, 64)))
             .unwrap();
-
-        // These should never be used:
-        addrs
-            .push(IpCidr::Ipv6(Ipv6Cidr::new(Ipv6Address::LOOPBACK, 128)))
-            .unwrap();
-        addrs
-            .push(IpCidr::Ipv6(Ipv6Cidr::new(Ipv6Address::UNSPECIFIED, 128)))
-            .unwrap();
     });
 
     // List of addresses we test:
+    //   ::1               -> ::1
     //   fe80::42          -> fe80::1
     //   fd00::201:1:1:1:1 -> fd00::201:1:1:1:2
     //   fd01::201:1:1:1:1 -> fd01::201:1:1:1:2
@@ -925,62 +916,256 @@ fn get_source_address() {
         Ipv6Address::new(0x2001, 0x0db9, 0x0003, 0, 0, 0, 0, 2);
 
     assert_eq!(
+        iface.inner.get_source_address_ipv6(&Ipv6Address::LOOPBACK),
+        Ipv6Address::LOOPBACK
+    );
+
+    assert_eq!(
         iface.inner.get_source_address_ipv6(&LINK_LOCAL_ADDR),
-        Some(OWN_LINK_LOCAL_ADDR)
+        OWN_LINK_LOCAL_ADDR
     );
     assert_eq!(
         iface.inner.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR1),
-        Some(OWN_UNIQUE_LOCAL_ADDR1)
+        OWN_UNIQUE_LOCAL_ADDR1
     );
     assert_eq!(
         iface.inner.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR2),
-        Some(OWN_UNIQUE_LOCAL_ADDR2)
+        OWN_UNIQUE_LOCAL_ADDR2
     );
     assert_eq!(
         iface.inner.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR3),
-        Some(OWN_UNIQUE_LOCAL_ADDR1)
+        OWN_UNIQUE_LOCAL_ADDR1
     );
     assert_eq!(
         iface
             .inner
             .get_source_address_ipv6(&Ipv6Address::LINK_LOCAL_ALL_NODES),
-        Some(OWN_LINK_LOCAL_ADDR)
+        OWN_LINK_LOCAL_ADDR
     );
     assert_eq!(
         iface.inner.get_source_address_ipv6(&GLOBAL_UNICAST_ADDR1),
-        Some(OWN_GLOBAL_UNICAST_ADDR1)
+        OWN_GLOBAL_UNICAST_ADDR1
     );
     assert_eq!(
         iface.inner.get_source_address_ipv6(&GLOBAL_UNICAST_ADDR2),
-        Some(OWN_GLOBAL_UNICAST_ADDR1)
+        OWN_GLOBAL_UNICAST_ADDR1
     );
 
     assert_eq!(
         iface.get_source_address_ipv6(&LINK_LOCAL_ADDR),
-        Some(OWN_LINK_LOCAL_ADDR)
+        OWN_LINK_LOCAL_ADDR
     );
     assert_eq!(
         iface.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR1),
-        Some(OWN_UNIQUE_LOCAL_ADDR1)
+        OWN_UNIQUE_LOCAL_ADDR1
     );
     assert_eq!(
         iface.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR2),
-        Some(OWN_UNIQUE_LOCAL_ADDR2)
+        OWN_UNIQUE_LOCAL_ADDR2
     );
     assert_eq!(
         iface.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR3),
-        Some(OWN_UNIQUE_LOCAL_ADDR1)
+        OWN_UNIQUE_LOCAL_ADDR1
     );
     assert_eq!(
         iface.get_source_address_ipv6(&Ipv6Address::LINK_LOCAL_ALL_NODES),
-        Some(OWN_LINK_LOCAL_ADDR)
+        OWN_LINK_LOCAL_ADDR
     );
     assert_eq!(
         iface.get_source_address_ipv6(&GLOBAL_UNICAST_ADDR1),
-        Some(OWN_GLOBAL_UNICAST_ADDR1)
+        OWN_GLOBAL_UNICAST_ADDR1
     );
     assert_eq!(
         iface.get_source_address_ipv6(&GLOBAL_UNICAST_ADDR2),
-        Some(OWN_GLOBAL_UNICAST_ADDR1)
+        OWN_GLOBAL_UNICAST_ADDR1
+    );
+}
+
+#[cfg(feature = "medium-ip")]
+#[test]
+fn get_source_address_only_link_local() {
+    let (mut iface, _, _) = setup(Medium::Ip);
+
+    // List of addresses in the interface:
+    //   fe80::1/64
+    const OWN_LINK_LOCAL_ADDR: Ipv6Address = Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
+    iface.update_ip_addrs(|ips| {
+        ips.clear();
+        ips.push(IpCidr::Ipv6(Ipv6Cidr::new(OWN_LINK_LOCAL_ADDR, 64)))
+            .unwrap();
+    });
+
+    // List of addresses we test:
+    //   ::1               -> ::1
+    //   fe80::42          -> fe80::1
+    //   fd00::201:1:1:1:1 -> fe80::1
+    //   fd01::201:1:1:1:1 -> fe80::1
+    //   fd02::201:1:1:1:1 -> fe80::1
+    //   ff02::1           -> fe80::1
+    //   2001:db8:3::2     -> fe80::1
+    //   2001:db9:3::2     -> fe80::1
+    const LINK_LOCAL_ADDR: Ipv6Address = Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 42);
+    const UNIQUE_LOCAL_ADDR1: Ipv6Address = Ipv6Address::new(0xfd00, 0, 0, 201, 1, 1, 1, 1);
+    const UNIQUE_LOCAL_ADDR2: Ipv6Address = Ipv6Address::new(0xfd01, 0, 0, 201, 1, 1, 1, 1);
+    const UNIQUE_LOCAL_ADDR3: Ipv6Address = Ipv6Address::new(0xfd02, 0, 0, 201, 1, 1, 1, 1);
+    const GLOBAL_UNICAST_ADDR1: Ipv6Address =
+        Ipv6Address::new(0x2001, 0x0db8, 0x0003, 0, 0, 0, 0, 2);
+    const GLOBAL_UNICAST_ADDR2: Ipv6Address =
+        Ipv6Address::new(0x2001, 0x0db9, 0x0003, 0, 0, 0, 0, 2);
+
+    assert_eq!(
+        iface.inner.get_source_address_ipv6(&Ipv6Address::LOOPBACK),
+        Ipv6Address::LOOPBACK
+    );
+
+    assert_eq!(
+        iface.inner.get_source_address_ipv6(&LINK_LOCAL_ADDR),
+        OWN_LINK_LOCAL_ADDR
+    );
+    assert_eq!(
+        iface.inner.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR1),
+        OWN_LINK_LOCAL_ADDR
+    );
+    assert_eq!(
+        iface.inner.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR2),
+        OWN_LINK_LOCAL_ADDR
+    );
+    assert_eq!(
+        iface.inner.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR3),
+        OWN_LINK_LOCAL_ADDR
+    );
+    assert_eq!(
+        iface
+            .inner
+            .get_source_address_ipv6(&Ipv6Address::LINK_LOCAL_ALL_NODES),
+        OWN_LINK_LOCAL_ADDR
+    );
+    assert_eq!(
+        iface.inner.get_source_address_ipv6(&GLOBAL_UNICAST_ADDR1),
+        OWN_LINK_LOCAL_ADDR
+    );
+    assert_eq!(
+        iface.inner.get_source_address_ipv6(&GLOBAL_UNICAST_ADDR2),
+        OWN_LINK_LOCAL_ADDR
+    );
+
+    assert_eq!(
+        iface.get_source_address_ipv6(&LINK_LOCAL_ADDR),
+        OWN_LINK_LOCAL_ADDR
+    );
+    assert_eq!(
+        iface.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR1),
+        OWN_LINK_LOCAL_ADDR
+    );
+    assert_eq!(
+        iface.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR2),
+        OWN_LINK_LOCAL_ADDR
+    );
+    assert_eq!(
+        iface.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR3),
+        OWN_LINK_LOCAL_ADDR
+    );
+    assert_eq!(
+        iface.get_source_address_ipv6(&Ipv6Address::LINK_LOCAL_ALL_NODES),
+        OWN_LINK_LOCAL_ADDR
+    );
+    assert_eq!(
+        iface.get_source_address_ipv6(&GLOBAL_UNICAST_ADDR1),
+        OWN_LINK_LOCAL_ADDR
+    );
+    assert_eq!(
+        iface.get_source_address_ipv6(&GLOBAL_UNICAST_ADDR2),
+        OWN_LINK_LOCAL_ADDR
+    );
+}
+
+#[cfg(feature = "medium-ip")]
+#[test]
+fn get_source_address_empty_interface() {
+    let (mut iface, _, _) = setup(Medium::Ip);
+
+    iface.update_ip_addrs(|ips| ips.clear());
+
+    // List of addresses we test:
+    //   ::1               -> ::1
+    //   fe80::42          -> ::1
+    //   fd00::201:1:1:1:1 -> ::1
+    //   fd01::201:1:1:1:1 -> ::1
+    //   fd02::201:1:1:1:1 -> ::1
+    //   ff02::1           -> ::1
+    //   2001:db8:3::2     -> ::1
+    //   2001:db9:3::2     -> ::1
+    const LINK_LOCAL_ADDR: Ipv6Address = Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 42);
+    const UNIQUE_LOCAL_ADDR1: Ipv6Address = Ipv6Address::new(0xfd00, 0, 0, 201, 1, 1, 1, 1);
+    const UNIQUE_LOCAL_ADDR2: Ipv6Address = Ipv6Address::new(0xfd01, 0, 0, 201, 1, 1, 1, 1);
+    const UNIQUE_LOCAL_ADDR3: Ipv6Address = Ipv6Address::new(0xfd02, 0, 0, 201, 1, 1, 1, 1);
+    const GLOBAL_UNICAST_ADDR1: Ipv6Address =
+        Ipv6Address::new(0x2001, 0x0db8, 0x0003, 0, 0, 0, 0, 2);
+    const GLOBAL_UNICAST_ADDR2: Ipv6Address =
+        Ipv6Address::new(0x2001, 0x0db9, 0x0003, 0, 0, 0, 0, 2);
+
+    assert_eq!(
+        iface.inner.get_source_address_ipv6(&Ipv6Address::LOOPBACK),
+        Ipv6Address::LOOPBACK
+    );
+
+    assert_eq!(
+        iface.inner.get_source_address_ipv6(&LINK_LOCAL_ADDR),
+        Ipv6Address::LOOPBACK
+    );
+    assert_eq!(
+        iface.inner.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR1),
+        Ipv6Address::LOOPBACK
+    );
+    assert_eq!(
+        iface.inner.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR2),
+        Ipv6Address::LOOPBACK
+    );
+    assert_eq!(
+        iface.inner.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR3),
+        Ipv6Address::LOOPBACK
+    );
+    assert_eq!(
+        iface
+            .inner
+            .get_source_address_ipv6(&Ipv6Address::LINK_LOCAL_ALL_NODES),
+        Ipv6Address::LOOPBACK
+    );
+    assert_eq!(
+        iface.inner.get_source_address_ipv6(&GLOBAL_UNICAST_ADDR1),
+        Ipv6Address::LOOPBACK
+    );
+    assert_eq!(
+        iface.inner.get_source_address_ipv6(&GLOBAL_UNICAST_ADDR2),
+        Ipv6Address::LOOPBACK
+    );
+
+    assert_eq!(
+        iface.get_source_address_ipv6(&LINK_LOCAL_ADDR),
+        Ipv6Address::LOOPBACK
+    );
+    assert_eq!(
+        iface.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR1),
+        Ipv6Address::LOOPBACK
+    );
+    assert_eq!(
+        iface.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR2),
+        Ipv6Address::LOOPBACK
+    );
+    assert_eq!(
+        iface.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR3),
+        Ipv6Address::LOOPBACK
+    );
+    assert_eq!(
+        iface.get_source_address_ipv6(&Ipv6Address::LINK_LOCAL_ALL_NODES),
+        Ipv6Address::LOOPBACK
+    );
+    assert_eq!(
+        iface.get_source_address_ipv6(&GLOBAL_UNICAST_ADDR1),
+        Ipv6Address::LOOPBACK
+    );
+    assert_eq!(
+        iface.get_source_address_ipv6(&GLOBAL_UNICAST_ADDR2),
+        Ipv6Address::LOOPBACK
     );
 }

--- a/src/socket/icmp.rs
+++ b/src/socket/icmp.rs
@@ -594,16 +594,8 @@ impl<'a> Socket<'a> {
                 }
                 #[cfg(feature = "proto-ipv6")]
                 IpAddress::Ipv6(dst_addr) => {
-                    let src_addr = match cx.get_source_address_ipv6(&dst_addr) {
-                        Some(addr) => addr,
-                        None => {
-                            net_trace!(
-                                "icmp:{}: not find suitable source address, dropping",
-                                remote_endpoint
-                            );
-                            return Ok(());
-                        }
-                    };
+                    let src_addr = cx.get_source_address_ipv6(&dst_addr);
+
                     let packet = Icmpv6Packet::new_unchecked(&*packet_buf);
                     let repr = match Icmpv6Repr::parse(
                         &src_addr,


### PR DESCRIPTION
Prevent panic when no suitable source address is found. If no suitable address is found, the loopback address is used instead. The function can still panic when the destination address is unspecified.

More tests are added:
- Tests when the interface has no addresses. The loopback address is used as source address.
- Tests when the interface only has a link-local address. The link-local address is used as source address, unless the destination address is the loopback address. In this case, the loopback address is used as source address.

This should fix #894 .