### PR TITLE
Add minimum support for iOS

### DIFF
--- a/src/phy/sys/bpf.rs
+++ b/src/phy/sys/bpf.rs
@@ -9,16 +9,31 @@ use crate::phy::Medium;
 use crate::wire::ETHERNET_HEADER_LEN;
 
 /// set interface
-#[cfg(any(target_os = "macos", target_os = "netbsd", target_os = "openbsd"))]
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
 const BIOCSETIF: libc::c_ulong = 0x8020426c;
 /// get buffer length
-#[cfg(any(target_os = "macos", target_os = "netbsd", target_os = "openbsd"))]
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
 const BIOCGBLEN: libc::c_ulong = 0x40044266;
 /// set immediate/nonblocking read
-#[cfg(any(target_os = "macos", target_os = "netbsd", target_os = "openbsd"))]
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
 const BIOCIMMEDIATE: libc::c_ulong = 0x80044270;
 /// set bpf_hdr struct size
-#[cfg(any(target_os = "macos", target_os = "netbsd"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "netbsd"))]
 const SIZEOF_BPF_HDR: usize = 18;
 /// set bpf_hdr struct size
 #[cfg(target_os = "openbsd")]
@@ -27,7 +42,12 @@ const SIZEOF_BPF_HDR: usize = 24;
 /// see https://github.com/openbsd/src/blob/37ecb4d066e5566411cc16b362d3960c93b1d0be/sys/net/bpf.c#L1649
 /// and https://github.com/apple/darwin-xnu/blob/8f02f2a044b9bb1ad951987ef5bab20ec9486310/bsd/net/bpf.c#L3580
 /// and https://github.com/NetBSD/src/blob/13d937d9ba3db87c9a898a40a8ed9d2aab2b1b95/sys/net/bpf.c#L1988
-#[cfg(any(target_os = "macos", target_os = "netbsd", target_os = "openbsd"))]
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
 const BPF_HDRLEN: usize = (((SIZEOF_BPF_HDR + ETHERNET_HEADER_LEN) + mem::align_of::<u32>() - 1)
     & !(mem::align_of::<u32>() - 1))
     - ETHERNET_HEADER_LEN;


### PR DESCRIPTION
Below is my usage of smoltcp on iOS:
- https://github.com/Chilledheart/tun2proxy/blob/master/src/context_interface.rs (replacing the raw socket)
- https://github.com/Chilledheart/yass/blob/develop/src/ios/extensions/tun2proxy.mm (hooks for iOS's packet tunnel side)
- https://github.com/Chilledheart/tun2proxy/blob/master/src/ios.rs (hooks for smoltcp side)

Tested on iOS 17 and iOS on ARM macOS.

The minimum requirement for smoltcp is making it compile when targeting iOS, so there is the patch.