### PR TITLE
rename Scope to MulticastScope

### DIFF
--- a/src/iface/interface/ipv6.rs
+++ b/src/iface/interface/ipv6.rs
@@ -32,9 +32,9 @@ impl InterfaceInner {
             }
 
             if dst_addr.is_multicast()
-                && matches!(dst_addr.scope(), Ipv6AddressScope::LinkLocal)
+                && matches!(dst_addr.multicast_scope(), Ipv6MulticastScope::LinkLocal)
                 && src_addr.is_multicast()
-                && !matches!(src_addr.scope(), Ipv6AddressScope::LinkLocal)
+                && !matches!(src_addr.multicast_scope(), Ipv6MulticastScope::LinkLocal)
             {
                 return false;
             }
@@ -96,11 +96,16 @@ impl InterfaceInner {
             }
 
             // Rule 2: prefer appropriate scope.
-            if (candidate.address().scope() as u8) < (addr.address().scope() as u8) {
-                if (candidate.address().scope() as u8) < (dst_addr.scope() as u8) {
+            if (candidate.address().multicast_scope() as u8)
+                < (addr.address().multicast_scope() as u8)
+            {
+                if (candidate.address().multicast_scope() as u8)
+                    < (dst_addr.multicast_scope() as u8)
+                {
                     candidate = addr;
                 }
-            } else if (addr.address().scope() as u8) > (dst_addr.scope() as u8) {
+            } else if (addr.address().multicast_scope() as u8) > (dst_addr.multicast_scope() as u8)
+            {
                 candidate = addr;
             }
 

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -191,7 +191,7 @@ pub use self::ipv4::{
 };
 
 #[cfg(feature = "proto-ipv6")]
-pub(crate) use self::ipv6::Scope as Ipv6AddressScope;
+pub(crate) use self::ipv6::MulticastScope as Ipv6MulticastScope;
 #[cfg(feature = "proto-ipv6")]
 pub use self::ipv6::{
     Address as Ipv6Address, Cidr as Ipv6Cidr, Packet as Ipv6Packet, Repr as Ipv6Repr,


### PR DESCRIPTION
It was not clear what scope meant. Renaming it to MulticastScope makes it clear that it is only used for multicast addresses.