### PR TITLE
fix: accept any ip for IPv6

### DIFF
--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -109,7 +109,6 @@ pub struct InterfaceInner {
     #[cfg(feature = "proto-sixlowpan-fragmentation")]
     tag: u16,
     ip_addrs: Vec<IpCidr, IFACE_MAX_ADDR_COUNT>,
-    #[cfg(feature = "proto-ipv4")]
     any_ip: bool,
     routes: Routes,
     #[cfg(feature = "proto-igmp")]
@@ -221,7 +220,6 @@ impl Interface {
                 caps,
                 hardware_addr: config.hardware_addr,
                 ip_addrs: Vec::new(),
-                #[cfg(feature = "proto-ipv4")]
                 any_ip: false,
                 routes: Routes::new(),
                 #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
@@ -358,16 +356,10 @@ impl Interface {
     /// Enable or disable the AnyIP capability.
     ///
     /// AnyIP allowins packets to be received
-    /// locally on IPv4 addresses other than the interface's configured [ip_addrs].
+    /// locally on IP addresses other than the interface's configured [ip_addrs].
     /// When AnyIP is enabled and a route prefix in [`routes`](Self::routes) specifies one of
     /// the interface's [`ip_addrs`](Self::ip_addrs) as its gateway, the interface will accept
     /// packets addressed to that prefix.
-    ///
-    /// # IPv6
-    ///
-    /// This option is not available or required for IPv6 as packets sent to
-    /// the interface are not filtered by IPv6 address.
-    #[cfg(feature = "proto-ipv4")]
     pub fn set_any_ip(&mut self, any_ip: bool) {
         self.inner.any_ip = any_ip;
     }
@@ -375,7 +367,6 @@ impl Interface {
     /// Get whether AnyIP is enabled.
     ///
     /// See [`set_any_ip`](Self::set_any_ip) for details on AnyIP
-    #[cfg(feature = "proto-ipv4")]
     pub fn any_ip(&self) -> bool {
         self.inner.any_ip
     }


### PR DESCRIPTION
Fixes #899 .

However, I'm not sure if this is the intended behaviour of Any IP. Should we check if the packet is routed locally, or should we just accept any packet?