### PR TITLE
Re-export `dhcpv4::Flags` and `dhcpv4::OpCode`

### DIFF
--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -267,8 +267,8 @@ pub use self::tcp::{
 
 #[cfg(feature = "proto-dhcpv4")]
 pub use self::dhcpv4::{
-    DhcpOption, DhcpOptionWriter, MessageType as DhcpMessageType, Packet as DhcpPacket,
-    Repr as DhcpRepr, CLIENT_PORT as DHCP_CLIENT_PORT,
+    DhcpOption, DhcpOptionWriter, Flags as DhcpFlags, MessageType as DhcpMessageType,
+    OpCode as DhcpOpCode, Packet as DhcpPacket, Repr as DhcpRepr, CLIENT_PORT as DHCP_CLIENT_PORT,
     MAX_DNS_SERVER_COUNT as DHCP_MAX_DNS_SERVER_COUNT, SERVER_PORT as DHCP_SERVER_PORT,
 };
 


### PR DESCRIPTION
Similar to issue #762 and PR #763, `DhcpPacket::set_flags` and `DhcpPacket::set_opcode` were not usable externally because `dhcpv4::Flags` and `dhcpv4::OpCode` were private types. Re-export these types as `smoltcp::wire::DhcpFlags` and `smoltcp::wire::DhcpOpCode`.
