### PR TITLE
UDP: Store local and use local address in metadata

### DIFF
--- a/src/iface/interface/tests/ipv4.rs
+++ b/src/iface/interface/tests/ipv4.rs
@@ -938,7 +938,10 @@ fn test_raw_socket_with_udp_socket(#[case] medium: Medium) {
         socket.recv(),
         Ok((
             &UDP_PAYLOAD[..],
-            IpEndpoint::new(src_addr.into(), 67).into()
+            udp::UdpMetadata {
+                local_address: Some(dst_addr.into()),
+                ..IpEndpoint::new(src_addr.into(), 67).into()
+            }
         ))
     );
 }

--- a/src/iface/interface/tests/mod.rs
+++ b/src/iface/interface/tests/mod.rs
@@ -109,6 +109,7 @@ fn test_handle_udp_broadcast(
         payload_len: udp_repr.header_len() + UDP_PAYLOAD.len(),
         hop_limit: 0x40,
     });
+    let dst_addr = ip_repr.dst_addr();
 
     // Bind the socket to port 68
     let socket = sockets.get_mut::<udp::Socket>(socket_handle);
@@ -143,7 +144,13 @@ fn test_handle_udp_broadcast(
     assert!(socket.can_recv());
     assert_eq!(
         socket.recv(),
-        Ok((&UDP_PAYLOAD[..], IpEndpoint::new(src_ip.into(), 67).into()))
+        Ok((
+            &UDP_PAYLOAD[..],
+            udp::UdpMetadata {
+                local_address: Some(dst_addr),
+                ..IpEndpoint::new(src_ip.into(), 67).into()
+            }
+        ))
     );
 }
 

--- a/src/iface/interface/tests/sixlowpan.rs
+++ b/src/iface/interface/tests/sixlowpan.rs
@@ -368,14 +368,23 @@ In at rhoncus tortor. Cras blandit tellus diam, varius vestibulum nibh commodo n
         socket.recv(),
         Ok((
             &udp_data[..],
-            IpEndpoint {
-                addr: IpAddress::Ipv6(Ipv6Address([
-                    0xfe, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x40, 0x42, 0x42, 0x42, 0x42, 0x42,
-                    0xb, 0x1a,
-                ])),
-                port: 54217,
+            udp::UdpMetadata {
+                local_address: Some(
+                    Ipv6Address([
+                        0xfe, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x92, 0xfc, 0x48, 0xc2, 0xa4,
+                        0x41, 0xfc, 0x76,
+                    ])
+                    .into()
+                ),
+                ..IpEndpoint {
+                    addr: IpAddress::Ipv6(Ipv6Address([
+                        0xfe, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x40, 0x42, 0x42, 0x42, 0x42,
+                        0x42, 0xb, 0x1a,
+                    ])),
+                    port: 54217,
+                }
+                .into()
             }
-            .into()
         ))
     );
 

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -743,6 +743,17 @@ mod test {
         assert_eq!(socket.send_slice(b"abcdef", REMOTE_END), Ok(()));
     }
 
+    #[test]
+    fn test_send_with_source() {
+        let mut socket = socket(buffer(0), buffer(1));
+
+        assert_eq!(socket.bind(LOCAL_PORT), Ok(()));
+        assert_eq!(
+            socket.send_slice(b"abcdef", remote_metadata_with_local()),
+            Ok(())
+        );
+    }
+
     #[rstest]
     #[case::ip(Medium::Ip)]
     #[cfg(feature = "medium-ip")]

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -8,13 +8,19 @@ use crate::socket::PollAt;
 #[cfg(feature = "async")]
 use crate::socket::WakerRegistration;
 use crate::storage::Empty;
-use crate::wire::{IpEndpoint, IpListenEndpoint, IpProtocol, IpRepr, UdpRepr};
+use crate::wire::{IpAddress, IpEndpoint, IpListenEndpoint, IpProtocol, IpRepr, UdpRepr};
 
 /// Metadata for a sent or received UDP packet.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct UdpMetadata {
     pub endpoint: IpEndpoint,
+    /// The IP address to which an incoming datagram was sent, or to which an outgoing datagram
+    /// will be sent. Incoming datagrams always have this set. On outgoing datagrams, if it is not
+    /// set, and the socket is not bound to a single address anyway, a suitable address will be
+    /// determined using the algorithms of RFC 6724 (candidate source address selection) or some
+    /// heuristic (for IPv4).
+    pub local_address: Option<IpAddress>,
     pub meta: PacketMeta,
 }
 
@@ -22,6 +28,7 @@ impl<T: Into<IpEndpoint>> From<T> for UdpMetadata {
     fn from(value: T) -> Self {
         Self {
             endpoint: value.into(),
+            local_address: None,
             meta: PacketMeta::default(),
         }
     }
@@ -493,6 +500,7 @@ impl<'a> Socket<'a> {
 
         let metadata = UdpMetadata {
             endpoint: remote_endpoint,
+            local_address: Some(ip_repr.dst_addr()),
             meta,
         };
 
@@ -517,19 +525,23 @@ impl<'a> Socket<'a> {
         let hop_limit = self.hop_limit.unwrap_or(64);
 
         let res = self.tx_buffer.dequeue_with(|packet_meta, payload_buf| {
-            let src_addr = match endpoint.addr {
-                Some(addr) => addr,
-                None => match cx.get_source_address(&packet_meta.endpoint.addr) {
+            let src_addr = if let Some(s) = packet_meta.local_address {
+                s
+            } else {
+                match endpoint.addr {
                     Some(addr) => addr,
-                    None => {
-                        net_trace!(
-                            "udp:{}:{}: cannot find suitable source address, dropping.",
-                            endpoint,
-                            packet_meta.endpoint
-                        );
-                        return Ok(());
-                    }
-                },
+                    None => match cx.get_source_address(&packet_meta.endpoint.addr) {
+                        Some(addr) => addr,
+                        None => {
+                            net_trace!(
+                                "udp:{}:{}: cannot find suitable source address, dropping.",
+                                endpoint,
+                                packet_meta.endpoint
+                            );
+                            return Ok(());
+                        }
+                    },
+                }
             };
 
             net_trace!(


### PR DESCRIPTION
Closes: https://github.com/smoltcp-rs/smoltcp/issues/903

As discussed there, this is a breaking change, and no feature flag is set for it right now.

I'm surprised that things were this easy. So far, my only tests were whether this builds, thus leaving this as a draft PR. I expect to test this with code that would resolve https://github.com/embassy-rs/embassy/issues/2516, at which point I'll mark it as ready.