### PR TITLE
Update DHCP example

### DIFF
--- a/examples/dhcp_client.rs
+++ b/examples/dhcp_client.rs
@@ -7,7 +7,7 @@ use std::os::unix::io::AsRawFd;
 use smoltcp::iface::{Config, Interface, SocketSet};
 use smoltcp::socket::dhcpv4;
 use smoltcp::time::Instant;
-use smoltcp::wire::{EthernetAddress, IpCidr, Ipv4Address, Ipv4Cidr};
+use smoltcp::wire::{EthernetAddress, IpCidr, Ipv4Cidr};
 use smoltcp::{
     phy::{wait as phy_wait, Device, Medium},
     time::Duration,

--- a/examples/dhcp_client.rs
+++ b/examples/dhcp_client.rs
@@ -38,6 +38,9 @@ fn main() {
     config.random_seed = rand::random();
     let mut iface = Interface::new(config, &mut device, Instant::now());
 
+    // Initialize with an unspecified address
+    set_ipv4_addr(&mut iface, Ipv4Cidr::new(Ipv4Address::UNSPECIFIED, 0));
+
     // Create sockets
     let mut dhcp_socket = dhcpv4::Socket::new();
 
@@ -86,9 +89,10 @@ fn main() {
     }
 }
 
+/// Clear any existing IP addresses & add the new one
 fn set_ipv4_addr(iface: &mut Interface, cidr: Ipv4Cidr) {
     iface.update_ip_addrs(|addrs| {
-        let dest = addrs.iter_mut().next().unwrap();
-        *dest = IpCidr::Ipv4(cidr);
+        addrs.clear();
+        addrs.push(IpCidr::Ipv4(cidr)).unwrap();
     });
 }

--- a/examples/dhcp_client.rs
+++ b/examples/dhcp_client.rs
@@ -38,9 +38,6 @@ fn main() {
     config.random_seed = rand::random();
     let mut iface = Interface::new(config, &mut device, Instant::now());
 
-    // Initialize with an unspecified address
-    set_ipv4_addr(&mut iface, Ipv4Cidr::new(Ipv4Address::UNSPECIFIED, 0));
-
     // Create sockets
     let mut dhcp_socket = dhcpv4::Socket::new();
 
@@ -80,7 +77,7 @@ fn main() {
             }
             Some(dhcpv4::Event::Deconfigured) => {
                 debug!("DHCP lost config!");
-                set_ipv4_addr(&mut iface, Ipv4Cidr::new(Ipv4Address::UNSPECIFIED, 0));
+                iface.update_ip_addrs(|addrs| addrs.clear());
                 iface.routes_mut().remove_default_ipv4_route();
             }
         }


### PR DESCRIPTION
Fixes #783 

* Initialize interface with an unspecified (but populated) IP address so that there is something in place to mutate later
* Update set_ipv4_addr to clear existing addresses and push a new one, and add a small docstring