### PR TITLE
Change mutability of `RxToken`'s `consume` argument.

### DIFF
--- a/src/phy/fault_injector.rs
+++ b/src/phy/fault_injector.rs
@@ -274,7 +274,7 @@ pub struct RxToken<'a> {
 impl<'a> phy::RxToken for RxToken<'a> {
     fn consume<R, F>(self, f: F) -> R
     where
-        F: FnOnce(&mut [u8]) -> R,
+        F: FnOnce(&[u8]) -> R,
     {
         f(self.buf)
     }

--- a/src/phy/fuzz_injector.rs
+++ b/src/phy/fuzz_injector.rs
@@ -1,3 +1,6 @@
+extern crate alloc;
+use alloc::vec::Vec;
+
 use crate::phy::{self, Device, DeviceCapabilities};
 use crate::time::Instant;
 
@@ -92,11 +95,12 @@ pub struct RxToken<'a, Rx: phy::RxToken, F: Fuzzer + 'a> {
 impl<'a, Rx: phy::RxToken, FRx: Fuzzer> phy::RxToken for RxToken<'a, Rx, FRx> {
     fn consume<R, F>(self, f: F) -> R
     where
-        F: FnOnce(&mut [u8]) -> R,
+        F: FnOnce(&[u8]) -> R,
     {
         self.token.consume(|buffer| {
-            self.fuzzer.fuzz_packet(buffer);
-            f(buffer)
+            let mut new_buffer: Vec<u8> = buffer.to_vec();
+            self.fuzzer.fuzz_packet(&mut new_buffer);
+            f(&mut new_buffer)
         })
     }
 

--- a/src/phy/loopback.rs
+++ b/src/phy/loopback.rs
@@ -61,11 +61,11 @@ pub struct RxToken {
 }
 
 impl phy::RxToken for RxToken {
-    fn consume<R, F>(mut self, f: F) -> R
+    fn consume<R, F>(self, f: F) -> R
     where
-        F: FnOnce(&mut [u8]) -> R,
+        F: FnOnce(&[u8]) -> R,
     {
-        f(&mut self.buffer)
+        f(&self.buffer)
     }
 }
 

--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -62,11 +62,11 @@ impl phy::Device for StmPhy {
 struct StmPhyRxToken<'a>(&'a mut [u8]);
 
 impl<'a> phy::RxToken for StmPhyRxToken<'a> {
-    fn consume<R, F>(mut self, f: F) -> R
-        where F: FnOnce(&mut [u8]) -> R
+    fn consume<R, F>(self, f: F) -> R
+        where F: FnOnce(& [u8]) -> R
     {
         // TODO: receive packet into buffer
-        let result = f(&mut self.0);
+        let result = f(&self.0);
         println!("rx called");
         result
     }
@@ -372,7 +372,7 @@ pub trait RxToken {
     /// packet bytes as argument.
     fn consume<R, F>(self, f: F) -> R
     where
-        F: FnOnce(&mut [u8]) -> R;
+        F: FnOnce(&[u8]) -> R;
 
     /// The Packet ID associated with the frame received by this [`RxToken`]
     fn meta(&self) -> PacketMeta {

--- a/src/phy/pcap_writer.rs
+++ b/src/phy/pcap_writer.rs
@@ -219,7 +219,7 @@ pub struct RxToken<'a, Rx: phy::RxToken, S: PcapSink> {
 }
 
 impl<'a, Rx: phy::RxToken, S: PcapSink> phy::RxToken for RxToken<'a, Rx, S> {
-    fn consume<R, F: FnOnce(&mut [u8]) -> R>(self, f: F) -> R {
+    fn consume<R, F: FnOnce(&[u8]) -> R>(self, f: F) -> R {
         self.token.consume(|buffer| {
             match self.mode {
                 PcapMode::Both | PcapMode::RxOnly => self

--- a/src/phy/raw_socket.rs
+++ b/src/phy/raw_socket.rs
@@ -104,11 +104,11 @@ pub struct RxToken {
 }
 
 impl phy::RxToken for RxToken {
-    fn consume<R, F>(mut self, f: F) -> R
+    fn consume<R, F>(self, f: F) -> R
     where
-        F: FnOnce(&mut [u8]) -> R,
+        F: FnOnce(&[u8]) -> R,
     {
-        f(&mut self.buffer[..])
+        f(&self.buffer[..])
     }
 }
 

--- a/src/phy/tracer.rs
+++ b/src/phy/tracer.rs
@@ -94,7 +94,7 @@ pub struct RxToken<Rx: phy::RxToken> {
 impl<Rx: phy::RxToken> phy::RxToken for RxToken<Rx> {
     fn consume<R, F>(self, f: F) -> R
     where
-        F: FnOnce(&mut [u8]) -> R,
+        F: FnOnce(&[u8]) -> R,
     {
         self.token.consume(|buffer| {
             (self.writer)(

--- a/src/phy/tuntap_interface.rs
+++ b/src/phy/tuntap_interface.rs
@@ -93,11 +93,11 @@ pub struct RxToken {
 }
 
 impl phy::RxToken for RxToken {
-    fn consume<R, F>(mut self, f: F) -> R
+    fn consume<R, F>(self, f: F) -> R
     where
-        F: FnOnce(&mut [u8]) -> R,
+        F: FnOnce(&[u8]) -> R,
     {
-        f(&mut self.buffer[..])
+        f(&self.buffer[..])
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -120,11 +120,11 @@ pub struct RxToken {
 }
 
 impl phy::RxToken for RxToken {
-    fn consume<R, F>(mut self, f: F) -> R
+    fn consume<R, F>(self, f: F) -> R
     where
-        F: FnOnce(&mut [u8]) -> R,
+        F: FnOnce(&[u8]) -> R,
     {
-        f(&mut self.buffer)
+        f(&self.buffer)
     }
 }
 


### PR DESCRIPTION
This pull request drops the requirement that we can mutate the receive buffer.

I noticed issue #443  already discussed this, but was closed without making the change. Even though the suggestion was to change it.
