### PR TITLE
Enable dynamic TCP receive window resizing

### DIFF
--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -2660,9 +2660,7 @@ impl<'a> Socket<'a> {
                 .unwrap_or(&PollAt::Ingress)
         }
     }
-}
 
-impl Socket<'static> {
     /// Replace the receive buffer with a new one.
     ///
     /// The requirements for the new buffer are:
@@ -2678,10 +2676,10 @@ impl Socket<'static> {
     ///
     /// See also the [new_with_window_scaling](struct.Socket.html#method.new_with_window_scaling) and
     /// [local_recv_win_scale](struct.Socket.html#method.local_recv_win_scale) methods.
-    pub fn replace_recv_buffer<T: Into<SocketBuffer<'static>>>(
+    pub fn replace_recv_buffer<T: Into<SocketBuffer<'a>>>(
         &mut self,
         new_buffer: T,
-    ) -> Result<SocketBuffer<'static>, SocketBuffer<'static>> {
+    ) -> Result<SocketBuffer<'a>, SocketBuffer<'a>> {
         let mut replaced_buf = new_buffer.into();
         /* Check if the new buffer is valid
          * Requirements:

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -2668,7 +2668,7 @@ impl Socket<'static> {
             assert_eq!(enqueued_len, buf.len());
             (enqueued_len, replaced_buf.get_allocated(0, enqueued_len))
         });
-        if self.rx_buffer.len() > 0 {
+        if !self.rx_buffer.is_empty() {
             // copy the wrapped around part
             self.rx_buffer.dequeue_many_with(|buf| {
                 let enqueued_len = replaced_buf.enqueue_slice(buf);

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -2672,15 +2672,10 @@ impl<'a> Socket<'a> {
     /// 1. The new buffer must be larger than the length of remaining data in the current buffer
     /// 2. The new buffer must be multiple of (1 << self.remote_win_shift)
     ///
-    /// Note: self.remote_win_shift cannot be modified after the connection is established. Use
-    /// `new_with_window_scaling` to create a new socket with a pre-defined window scale. Details can
-    /// be found in [RFC 1323].
-    ///
     /// If the new buffer does not meet the requirements, the new buffer is returned as an error;
     /// otherwise, the old buffer is returned as an Ok value.
     ///
-    /// See also the [new_with_window_scaling](struct.Socket.html#method.new_with_window_scaling) and
-    /// [local_recv_win_scale](struct.Socket.html#method.local_recv_win_scale) methods.
+    /// See also the [local_recv_win_scale](struct.Socket.html#method.local_recv_win_scale) methods.
     pub fn replace_recv_buffer<T: Into<SocketBuffer<'a>>>(
         &mut self,
         new_buffer: T,

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -2632,7 +2632,21 @@ impl<'a> Socket<'a> {
 }
 
 impl Socket<'static> {
-    /// TODO: DOCS
+    /// Replace the receive buffer with a new one.
+    ///
+    /// The requirements for the new buffer are:
+    /// 1. The new buffer must be larger than the length of remaining data in the current buffer
+    /// 2. The new buffer must be multiple of (1 << self.remote_win_shift)
+    ///
+    /// Note: self.remote_win_shift cannot be modified after the connection is established. Use
+    /// `new_with_window_scaling` to create a new socket with a pre-defined window scale. Details can
+    /// be found in [RFC 1323].
+    ///
+    /// If the new buffer does not meet the requirements, the new buffer is returned as an error;
+    /// otherwise, the old buffer is returned as an Ok value.
+    ///
+    /// See also the [new_with_window_scaling](struct.Socket.html#method.new_with_window_scaling) and
+    /// [local_recv_win_scale](struct.Socket.html#method.local_recv_win_scale) methods.
     pub fn replace_recv_buffer<T: Into<SocketBuffer<'static>>>(
         &mut self,
         new_buffer: T,

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -529,11 +529,21 @@ impl<'a> Socket<'a> {
 
     /// Create a socket using the given buffers and window scaling factor defined in [RFC 1323].
     ///
+    /// # Panics
+    ///
+    /// Panics if the window scaling factor is greater than 14.
+    ///
     /// See also the [local_recv_win_scale](#method.local_recv_win_scale) method.
     pub fn new_with_window_scaling<T>(rx_buffer: T, tx_buffer: T, recv_win_scale: u8) -> Socket<'a>
     where
         T: Into<SocketBuffer<'a>>,
     {
+        if recv_win_scale > 14 {
+            panic!("window scaling factor too large, must be <= 14")
+        }
+
+        let (rx_buffer, tx_buffer) = (rx_buffer.into(), tx_buffer.into());
+
         Socket {
             state: State::Closed,
             timer: Timer::new(),


### PR DESCRIPTION
Closes #927.

This PR introduces the ability to resize TCP receive buffer after the connection is established, as well as helper getter functions. This feature will help implement "rwnd auto-tuning", for example [in Linux kernel](https://github.com/torvalds/linux/blob/e091caf99f3a5006c95baec24330bac6f7f17193/net/ipv4/tcp_input.c#L630), which can reduce memory footprint when establishing a lot of connections without sacrificing the maximum achievable throughput.

Current requirements include:
1. The new buffer must be larger than the length of remaining data in the current buffer.
2. The new buffer must be multiple of (1 << self.remote_win_shift), which is the window scaling negotiated in the handshake.