### PR TITLE
Use `core` instead of `std` for net types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "smoltcp"
 version = "0.11.0"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.77"
 authors = ["whitequark <whitequark@whitequark.org>"]
 description = "A TCP/IP stack designed for bare-metal, real-time systems without a heap."
 documentation = "https://docs.rs/smoltcp/"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ include complicated compile-time computations, such as macro or type tricks, eve
 at cost of performance degradation.
 
 _smoltcp_ does not need heap allocation *at all*, is [extensively documented][docs],
-and compiles on stable Rust 1.65 and later.
+and compiles on stable Rust 1.77 and later.
 
 _smoltcp_ achieves [~Gbps of throughput](#examplesbenchmarkrs) when tested against
 the Linux TCP stack in loopback mode.

--- a/ci.sh
+++ b/ci.sh
@@ -4,7 +4,7 @@ set -eox pipefail
 
 export DEFMT_LOG=trace
 
-MSRV="1.65.0"
+MSRV="1.77.0"
 
 RUSTC_VERSIONS=(
     $MSRV

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -580,7 +580,7 @@ impl Interface {
 
         enum EgressError {
             Exhausted,
-            Dispatch(DispatchError),
+            Dispatch,
         }
 
         let mut emitted_any = false;
@@ -602,7 +602,7 @@ impl Interface {
 
                 inner
                     .dispatch_ip(t, meta, response, &mut self.fragmenter)
-                    .map_err(EgressError::Dispatch)?;
+                    .map_err(|_| EgressError::Dispatch)?;
 
                 emitted_any = true;
 
@@ -673,7 +673,7 @@ impl Interface {
 
             match result {
                 Err(EgressError::Exhausted) => break, // Device buffer full.
-                Err(EgressError::Dispatch(_)) => {
+                Err(EgressError::Dispatch) => {
                     // `NeighborCache` already takes care of rate limiting the neighbor discovery
                     // requests from the socket. However, without an additional rate limiting
                     // mechanism, we would spin on every socket that has yet to discover its

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 //!
 //! # Minimum Supported Rust Version (MSRV)
 //!
-//! This crate is guaranteed to compile on stable Rust 1.65 and up with any valid set of features.
+//! This crate is guaranteed to compile on stable Rust 1.77 and up with any valid set of features.
 //! It *might* compile on older versions but that may change in any new patch release.
 //!
 //! The exception is when using the `defmt` feature, in which case `defmt`'s MSRV applies, which

--- a/src/phy/loopback.rs
+++ b/src/phy/loopback.rs
@@ -1,4 +1,5 @@
 use alloc::collections::VecDeque;
+use alloc::vec;
 use alloc::vec::Vec;
 
 use crate::phy::{self, ChecksumCapabilities, Device, DeviceCapabilities, Medium};

--- a/src/phy/loopback.rs
+++ b/src/phy/loopback.rs
@@ -80,8 +80,7 @@ impl<'a> phy::TxToken for TxToken<'a> {
     where
         F: FnOnce(&mut [u8]) -> R,
     {
-        let mut buffer = Vec::new();
-        buffer.resize(len, 0);
+        let mut buffer = vec![0; len];
         let result = f(&mut buffer);
         self.queue.push_back(buffer);
         result

--- a/src/phy/sys/bpf.rs
+++ b/src/phy/sys/bpf.rs
@@ -172,7 +172,7 @@ impl BpfDevice {
             );
 
             if len == -1 {
-                Err(io::Error::last_os_error()).unwrap()
+                panic!("{:?}", io::Error::last_os_error())
             }
 
             Ok(len as usize)

--- a/src/wire/dns.rs
+++ b/src/wire/dns.rs
@@ -417,9 +417,9 @@ impl<'a> Repr<'a> {
     }
 
     /// Emit a high-level representation into a DNS packet.
-    pub fn emit<T: ?Sized>(&self, packet: &mut Packet<&mut T>)
+    pub fn emit<T>(&self, packet: &mut Packet<&mut T>)
     where
-        T: AsRef<[u8]> + AsMut<[u8]>,
+        T: AsRef<[u8]> + AsMut<[u8]> + ?Sized,
     {
         packet.set_transaction_id(self.transaction_id);
         packet.set_flags(self.flags);

--- a/src/wire/dns.rs
+++ b/src/wire/dns.rs
@@ -779,8 +779,7 @@ mod test {
             },
         };
 
-        let mut buf = Vec::new();
-        buf.resize(repr.buffer_len(), 0);
+        let mut buf = vec![0; repr.buffer_len()];
         repr.emit(&mut Packet::new_unchecked(&mut buf));
 
         let want = &[

--- a/src/wire/ip.rs
+++ b/src/wire/ip.rs
@@ -195,38 +195,37 @@ impl Address {
     }
 }
 
-#[cfg(all(feature = "std", feature = "proto-ipv4", feature = "proto-ipv6"))]
-impl From<::std::net::IpAddr> for Address {
-    fn from(x: ::std::net::IpAddr) -> Address {
+#[cfg(all(feature = "proto-ipv4", feature = "proto-ipv6"))]
+impl From<::core::net::IpAddr> for Address {
+    fn from(x: ::core::net::IpAddr) -> Address {
         match x {
-            ::std::net::IpAddr::V4(ipv4) => Address::Ipv4(ipv4.into()),
-            ::std::net::IpAddr::V6(ipv6) => Address::Ipv6(ipv6.into()),
+            ::core::net::IpAddr::V4(ipv4) => Address::Ipv4(ipv4.into()),
+            ::core::net::IpAddr::V6(ipv6) => Address::Ipv6(ipv6.into()),
         }
     }
 }
 
-#[cfg(feature = "std")]
-impl From<Address> for ::std::net::IpAddr {
-    fn from(x: Address) -> ::std::net::IpAddr {
+impl From<Address> for ::core::net::IpAddr {
+    fn from(x: Address) -> ::core::net::IpAddr {
         match x {
             #[cfg(feature = "proto-ipv4")]
-            Address::Ipv4(ipv4) => ::std::net::IpAddr::V4(ipv4.into()),
+            Address::Ipv4(ipv4) => ::core::net::IpAddr::V4(ipv4.into()),
             #[cfg(feature = "proto-ipv6")]
-            Address::Ipv6(ipv6) => ::std::net::IpAddr::V6(ipv6.into()),
+            Address::Ipv6(ipv6) => ::core::net::IpAddr::V6(ipv6.into()),
         }
     }
 }
 
-#[cfg(all(feature = "std", feature = "proto-ipv4"))]
-impl From<::std::net::Ipv4Addr> for Address {
-    fn from(ipv4: ::std::net::Ipv4Addr) -> Address {
+#[cfg(feature = "proto-ipv4")]
+impl From<::core::net::Ipv4Addr> for Address {
+    fn from(ipv4: ::core::net::Ipv4Addr) -> Address {
         Address::Ipv4(ipv4.into())
     }
 }
 
-#[cfg(all(feature = "std", feature = "proto-ipv6"))]
-impl From<::std::net::Ipv6Addr> for Address {
-    fn from(ipv6: ::std::net::Ipv6Addr) -> Address {
+#[cfg(feature = "proto-ipv6")]
+impl From<::core::net::Ipv6Addr> for Address {
+    fn from(ipv6: ::core::net::Ipv6Addr) -> Address {
         Address::Ipv6(ipv6.into())
     }
 }
@@ -395,9 +394,9 @@ impl Endpoint {
     }
 }
 
-#[cfg(all(feature = "std", feature = "proto-ipv4", feature = "proto-ipv6"))]
-impl From<::std::net::SocketAddr> for Endpoint {
-    fn from(x: ::std::net::SocketAddr) -> Endpoint {
+#[cfg(all(feature = "proto-ipv4", feature = "proto-ipv6"))]
+impl From<::core::net::SocketAddr> for Endpoint {
+    fn from(x: ::core::net::SocketAddr) -> Endpoint {
         Endpoint {
             addr: x.ip().into(),
             port: x.port(),
@@ -405,9 +404,9 @@ impl From<::std::net::SocketAddr> for Endpoint {
     }
 }
 
-#[cfg(all(feature = "std", feature = "proto-ipv4"))]
-impl From<::std::net::SocketAddrV4> for Endpoint {
-    fn from(x: ::std::net::SocketAddrV4) -> Endpoint {
+#[cfg(feature = "proto-ipv4")]
+impl From<::core::net::SocketAddrV4> for Endpoint {
+    fn from(x: ::core::net::SocketAddrV4) -> Endpoint {
         Endpoint {
             addr: (*x.ip()).into(),
             port: x.port(),
@@ -415,9 +414,9 @@ impl From<::std::net::SocketAddrV4> for Endpoint {
     }
 }
 
-#[cfg(all(feature = "std", feature = "proto-ipv6"))]
-impl From<::std::net::SocketAddrV6> for Endpoint {
-    fn from(x: ::std::net::SocketAddrV6) -> Endpoint {
+#[cfg(feature = "proto-ipv6")]
+impl From<::core::net::SocketAddrV6> for Endpoint {
+    fn from(x: ::core::net::SocketAddrV6) -> Endpoint {
         Endpoint {
             addr: (*x.ip()).into(),
             port: x.port(),
@@ -466,9 +465,9 @@ impl ListenEndpoint {
     }
 }
 
-#[cfg(all(feature = "std", feature = "proto-ipv4", feature = "proto-ipv6"))]
-impl From<::std::net::SocketAddr> for ListenEndpoint {
-    fn from(x: ::std::net::SocketAddr) -> ListenEndpoint {
+#[cfg(all(feature = "proto-ipv4", feature = "proto-ipv6"))]
+impl From<::core::net::SocketAddr> for ListenEndpoint {
+    fn from(x: ::core::net::SocketAddr) -> ListenEndpoint {
         ListenEndpoint {
             addr: Some(x.ip().into()),
             port: x.port(),
@@ -476,9 +475,9 @@ impl From<::std::net::SocketAddr> for ListenEndpoint {
     }
 }
 
-#[cfg(all(feature = "std", feature = "proto-ipv4"))]
-impl From<::std::net::SocketAddrV4> for ListenEndpoint {
-    fn from(x: ::std::net::SocketAddrV4) -> ListenEndpoint {
+#[cfg(feature = "proto-ipv4")]
+impl From<::core::net::SocketAddrV4> for ListenEndpoint {
+    fn from(x: ::core::net::SocketAddrV4) -> ListenEndpoint {
         ListenEndpoint {
             addr: Some((*x.ip()).into()),
             port: x.port(),
@@ -486,9 +485,9 @@ impl From<::std::net::SocketAddrV4> for ListenEndpoint {
     }
 }
 
-#[cfg(all(feature = "std", feature = "proto-ipv6"))]
-impl From<::std::net::SocketAddrV6> for ListenEndpoint {
-    fn from(x: ::std::net::SocketAddrV6) -> ListenEndpoint {
+#[cfg(feature = "proto-ipv6")]
+impl From<::core::net::SocketAddrV6> for ListenEndpoint {
+    fn from(x: ::core::net::SocketAddrV6) -> ListenEndpoint {
         ListenEndpoint {
             addr: Some((*x.ip()).into()),
             port: x.port(),

--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -110,16 +110,14 @@ impl Address {
     }
 }
 
-#[cfg(feature = "std")]
-impl From<::std::net::Ipv4Addr> for Address {
-    fn from(x: ::std::net::Ipv4Addr) -> Address {
+impl From<::core::net::Ipv4Addr> for Address {
+    fn from(x: ::core::net::Ipv4Addr) -> Address {
         Address(x.octets())
     }
 }
 
-#[cfg(feature = "std")]
-impl From<Address> for ::std::net::Ipv4Addr {
-    fn from(Address(x): Address) -> ::std::net::Ipv4Addr {
+impl From<Address> for ::core::net::Ipv4Addr {
+    fn from(Address(x): Address) -> ::core::net::Ipv4Addr {
         x.into()
     }
 }

--- a/src/wire/ipv6.rs
+++ b/src/wire/ipv6.rs
@@ -312,16 +312,14 @@ impl Address {
     }
 }
 
-#[cfg(feature = "std")]
-impl From<::std::net::Ipv6Addr> for Address {
-    fn from(x: ::std::net::Ipv6Addr) -> Address {
+impl From<::core::net::Ipv6Addr> for Address {
+    fn from(x: ::core::net::Ipv6Addr) -> Address {
         Address(x.octets())
     }
 }
 
-#[cfg(feature = "std")]
-impl From<Address> for ::std::net::Ipv6Addr {
-    fn from(Address(x): Address) -> ::std::net::Ipv6Addr {
+impl From<Address> for ::core::net::Ipv6Addr {
+    fn from(Address(x): Address) -> ::core::net::Ipv6Addr {
         x.into()
     }
 }

--- a/src/wire/ipv6.rs
+++ b/src/wire/ipv6.rs
@@ -1425,7 +1425,7 @@ pub(crate) mod test {
 
     #[test]
     fn test_repr_parse_bad_version() {
-        let mut bytes = vec![0; 40];
+        let mut bytes = [0; 40];
         let mut packet = Packet::new_unchecked(&mut bytes[..]);
         packet.set_version(4);
         packet.set_payload_len(0);
@@ -1435,7 +1435,7 @@ pub(crate) mod test {
 
     #[test]
     fn test_repr_parse_smaller_than_header() {
-        let mut bytes = vec![0; 40];
+        let mut bytes = [0; 40];
         let mut packet = Packet::new_unchecked(&mut bytes[..]);
         packet.set_version(6);
         packet.set_payload_len(39);
@@ -1445,7 +1445,7 @@ pub(crate) mod test {
 
     #[test]
     fn test_repr_parse_smaller_than_payload() {
-        let mut bytes = vec![0; 40];
+        let mut bytes = [0; 40];
         let mut packet = Packet::new_unchecked(&mut bytes[..]);
         packet.set_version(6);
         packet.set_payload_len(1);

--- a/src/wire/mld.rs
+++ b/src/wire/mld.rs
@@ -526,7 +526,7 @@ mod test {
 
     #[test]
     fn test_query_construct() {
-        let mut bytes = vec![0xff; 44];
+        let mut bytes = [0xff; 44];
         let mut packet = Packet::new_unchecked(&mut bytes[..]);
         packet.set_msg_type(Message::MldQuery);
         packet.set_msg_code(0);
@@ -567,7 +567,7 @@ mod test {
 
     #[test]
     fn test_record_construct() {
-        let mut bytes = vec![0xff; 44];
+        let mut bytes = [0xff; 44];
         let mut packet = Packet::new_unchecked(&mut bytes[..]);
         packet.set_msg_type(Message::MldReport);
         packet.set_msg_code(0);

--- a/src/wire/ndisc.rs
+++ b/src/wire/ndisc.rs
@@ -534,7 +534,7 @@ mod test {
 
     #[test]
     fn test_router_advert_repr_emit() {
-        let mut bytes = vec![0x2a; 24];
+        let mut bytes = [0x2a; 24];
         let mut packet = Packet::new_unchecked(&mut bytes[..]);
         create_repr().emit(
             &MOCK_IP_ADDR_1,

--- a/src/wire/sixlowpan/iphc.rs
+++ b/src/wire/sixlowpan/iphc.rs
@@ -176,7 +176,7 @@ impl<T: AsRef<[u8]>> Packet<T> {
     /// Return the ECN field (when it is inlined).
     pub fn ecn_field(&self) -> Option<u8> {
         match self.tf_field() {
-            0b00 | 0b01 | 0b10 => {
+            0b00..=0b10 => {
                 let start = self.ip_fields_start() as usize;
                 Some(self.buffer.as_ref()[start..][0] & 0b1100_0000)
             }
@@ -341,7 +341,7 @@ impl<T: AsRef<[u8]>> Packet<T> {
                 0,
                 AddressMode::NotSupported,
             ))),
-            (1, 1, 0b01 | 0b10 | 0b11) => Ok(UnresolvedAddress::Reserved),
+            (1, 1, 0b01..=0b11) => Ok(UnresolvedAddress::Reserved),
             _ => Err(Error),
         }
     }

--- a/src/wire/udp.rs
+++ b/src/wire/udp.rs
@@ -255,9 +255,9 @@ impl Repr {
     /// This never calculates the checksum, and is intended for internal-use only,
     /// not for packets that are going to be actually sent over the network. For
     /// example, when decompressing 6lowpan.
-    pub(crate) fn emit_header<T: ?Sized>(&self, packet: &mut Packet<&mut T>, payload_len: usize)
+    pub(crate) fn emit_header<T>(&self, packet: &mut Packet<&mut T>, payload_len: usize)
     where
-        T: AsRef<[u8]> + AsMut<[u8]>,
+        T: AsRef<[u8]> + AsMut<[u8]> + ?Sized,
     {
         packet.set_src_port(self.src_port);
         packet.set_dst_port(self.dst_port);
@@ -266,7 +266,7 @@ impl Repr {
     }
 
     /// Emit a high-level representation into an User Datagram Protocol packet.
-    pub fn emit<T: ?Sized>(
+    pub fn emit<T>(
         &self,
         packet: &mut Packet<&mut T>,
         src_addr: &IpAddress,
@@ -275,7 +275,7 @@ impl Repr {
         emit_payload: impl FnOnce(&mut [u8]),
         checksum_caps: &ChecksumCapabilities,
     ) where
-        T: AsRef<[u8]> + AsMut<[u8]>,
+        T: AsRef<[u8]> + AsMut<[u8]> + ?Sized,
     {
         packet.set_src_port(self.src_port);
         packet.set_dst_port(self.dst_port);


### PR DESCRIPTION
Helpful for using `.into()` with these types on no_std platforms.