### PR TITLE
Add `Clone` trait to DHCP Event type

### DIFF
--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -140,7 +140,7 @@ impl Default for RetryConfig {
 }
 
 /// Return value for the `Dhcpv4Socket::poll` function
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Event<'a> {
     /// Configuration has been lost (for example, the lease has expired)


### PR DESCRIPTION
`Config` already has it, but `Event` does not.