### PR TITLE
Use `assert!()` to check `prefix_len` in `Ipv4Cidr::new`

### DIFF
--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -156,11 +156,8 @@ impl Cidr {
     ///
     /// # Panics
     /// This function panics if the prefix length is larger than 32.
-    #[allow(clippy::no_effect)]
     pub const fn new(address: Address, prefix_len: u8) -> Cidr {
-        // Replace with const panic (or assert) when stabilized
-        // see: https://github.com/rust-lang/rust/issues/51999
-        ["Prefix length should be <= 32"][(prefix_len > 32) as usize];
+        assert!(prefix_len <= 32);
         Cidr {
             address,
             prefix_len,


### PR DESCRIPTION
Updated to match [`Ipv6Cidr::new`](https://github.com/smoltcp-rs/smoltcp/blob/99ddd22cdbe4ca59f894c4ba2588b8d4f52a08a6/src/wire/ipv6.rs#L485)