### PR TITLE
Fix benchmark and update results

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,14 +513,14 @@ cargo run --release --example benchmark -- --tap tap0 [reader|writer]
 It establishes a connection to itself from a different thread and reads or writes a large amount
 of data in one direction.
 
-A typical result (achieved on a Intel Core i7-7500U CPU and a Linux 4.9.65 x86_64 kernel running
-on a Dell XPS 13 9360 laptop) is as follows:
+A typical result (achieved on a Intel Core i5-13500H CPU and a Linux 6.9.9 x86_64 kernel running
+on a LENOVO XiaoXinPro 14 IRH8 laptop) is as follows:
 
 ```
 $ cargo run -q --release --example benchmark -- --tap tap0 reader
-throughput: 2.556 Gbps
+throughput: 3.673 Gbps
 $ cargo run -q --release --example benchmark -- --tap tap0 writer
-throughput: 5.301 Gbps
+throughput: 7.905 Gbps
 ```
 
 ## Bare-metal usage examples

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::collapsible_if)]
-
 mod utils;
 
 use std::cmp;
@@ -121,16 +119,14 @@ fn main() {
             socket.listen(1234).unwrap();
         }
 
-        if socket.can_send() {
-            if processed < AMOUNT {
-                let length = socket
-                    .send(|buffer| {
-                        let length = cmp::min(buffer.len(), AMOUNT - processed);
-                        (length, length)
-                    })
-                    .unwrap();
-                processed += length;
-            }
+        while socket.can_send() && processed < AMOUNT {
+            let length = socket
+                .send(|buffer| {
+                    let length = cmp::min(buffer.len(), AMOUNT - processed);
+                    (length, length)
+                })
+                .unwrap();
+            processed += length;
         }
 
         // tcp:1235: sink data
@@ -139,16 +135,14 @@ fn main() {
             socket.listen(1235).unwrap();
         }
 
-        if socket.can_recv() {
-            if processed < AMOUNT {
-                let length = socket
-                    .recv(|buffer| {
-                        let length = cmp::min(buffer.len(), AMOUNT - processed);
-                        (length, length)
-                    })
-                    .unwrap();
-                processed += length;
-            }
+        while socket.can_recv() && processed < AMOUNT {
+            let length = socket
+                .recv(|buffer| {
+                    let length = cmp::min(buffer.len(), AMOUNT - processed);
+                    (length, length)
+                })
+                .unwrap();
+            processed += length;
         }
 
         match iface.poll_at(timestamp, &sockets) {


### PR DESCRIPTION
Quoted from https://github.com/smoltcp-rs/smoltcp/pull/935#issuecomment-2226161931:
> Since the TCP buffer is a ring buffer, the following `recv` call may not receive all the data:
> https://github.com/smoltcp-rs/smoltcp/blob/c937695d4238c6df9556d21b464c949c7b43842c/examples/benchmark.rs#L142-L152
> 
> This is problematic because after receiving the trailing part of the ring buffer in this `poll` round, we can only receive the leading part of the ring buffer in the next `poll` round, but when we start the next `poll` round depends on many things, such as whether we have the delayed ACK timer and whether the sender sends data to the receiver immediately (the answer may be false if the receive window is less than one packet).
> 
> I believe the intention here is to receive all the data, like:
> ```rust
>         while socket.can_recv() && processed < AMOUNT {
>             let length = socket
>                 .recv(|buffer| {
>                     let length = cmp::min(buffer.len(), AMOUNT - processed);
>                     (length, length)
>                 })
>                 .unwrap();
>             processed += length;
>         }
> ```
> 
> After I made this change, the throughput of `benchmark -- --tap tap0 writer` is increased from ~1Gbps to ~8Gbps in my laptop, _without the mechanisms in this PR_.

Note that the throughput increase from 1Gbps to 8Gbps is measured on my laptop, but the diff cannot show the exact increase, either because the previous throughput statistics are outdated or because the laptop configuration has changed.