### PR TITLE
Reset retransmit timer on ack regardless of the current timer state

### DIFF
--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -337,19 +337,12 @@ impl Timer {
 
     fn set_for_retransmit(&mut self, timestamp: Instant, delay: Duration) {
         match *self {
-            Timer::Idle { .. } | Timer::FastRetransmit { .. } => {
+            Timer::Idle { .. } | Timer::FastRetransmit { .. } | Timer::Retransmit { .. } => {
                 *self = Timer::Retransmit {
                     expires_at: timestamp + delay,
                     delay,
                 }
             }
-            Timer::Retransmit { expires_at, delay } if timestamp >= expires_at => {
-                *self = Timer::Retransmit {
-                    expires_at: timestamp + delay,
-                    delay: delay * 2,
-                }
-            }
-            Timer::Retransmit { .. } => (),
             Timer::Close { .. } => (),
         }
     }
@@ -7521,7 +7514,7 @@ mod test {
         assert_eq!(r.should_retransmit(Instant::from_millis(1200)), None);
         assert_eq!(
             r.should_retransmit(Instant::from_millis(1301)),
-            Some(Duration::from_millis(300))
+            Some(Duration::from_millis(200))
         );
         r.set_for_idle(Instant::from_millis(1301), None);
         assert_eq!(r.should_retransmit(Instant::from_millis(1350)), None);


### PR DESCRIPTION
As I explained in https://github.com/smoltcp-rs/smoltcp/issues/949#issuecomment-2227096481 in the current state if you have a link with limited bandwidth and high latency, timer state becomes `Timer::Retransmit` and won't become `Timer::Idle` since there is always some packets in the flight, and current code prevents the delay to be updated, so there would be an unnecessary retransmission which drops the bandwidth. After this PR, I'm able to utilize the full bandwidth of a link with high latency.

This PR doesn't completely fix the issue I mentioned above, there is still some problems when the middle switch drops packets, but it makes things much better.