### PR TITLE
Limiting the number of poll loops to prevent DoS events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No unreleased changes yet.
+### Changed
+- iface: The `poll` function now only performs a single cycle of processing sockets ([#954](https://github.com/smoltcp-rs/smoltcp/pull/954))
 
 ## [0.11.0] - 2023-12-23
 


### PR DESCRIPTION
This PR fixes #848 by limiting the number of ingress/egress tokens processed by observing the characteristics of the sockets contained in the polled socket set.

---
Edit: Further information on hardware testing can be found in https://github.com/quartiq/booster/pull/423