### PR TITLE
Fix target-arch names and remove unknonwn fuzzing cfg warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ license = "0BSD"
 # ensure that the correct features are enabled.
 autoexamples = false
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
+
 [dependencies]
 managed = { version = "0.8", default-features = false, features = ["map"] }
 byteorder = { version = "1.0", default-features = false }

--- a/src/phy/sys/linux.rs
+++ b/src/phy/sys/linux.rs
@@ -9,12 +9,12 @@ pub const ETH_P_IEEE802154: libc::c_short = 0x00F6;
 // https://github.com/golang/sys/blob/master/unix/zerrors_linux_<arch>.go
 pub const TUNSETIFF: libc::c_ulong = if cfg!(any(
     target_arch = "mips",
+    all(target_arch = "mips", target_endian = "little"),
     target_arch = "mips64",
-    target_arch = "mips64el",
-    target_arch = "mipsel",
+    all(target_arch = "mips64", target_endian = "little"),
     target_arch = "powerpc",
     target_arch = "powerpc64",
-    target_arch = "powerpc64le",
+    all(target_arch = "powerpc64", target_endian = "little"),
     target_arch = "sparc64"
 )) {
     0x800454CA


### PR DESCRIPTION
The endianness of the target architecture cannot be specified using target_arch. The endianness can be specified using target_endian.

The target description for mipsel-unknown-linux-gnu is found here:
https://github.com/rust-lang/rust/blob/master/compiler/rustc_target/src/spec/targets/mipsel_unknown_linux_gnu.rs
In this specification, the arch is set to "mips" and not "mipsel".

@blechschmidt: since you added this cfg for these architectures, could you check if smoltcp still compiles for you?