### PR TITLE
`extern crate alloc` was added accidentally breaking downstream `no_std`

### DIFF
--- a/src/phy/fuzz_injector.rs
+++ b/src/phy/fuzz_injector.rs
@@ -1,8 +1,6 @@
-extern crate alloc;
-use alloc::vec::Vec;
-
 use crate::phy::{self, Device, DeviceCapabilities};
 use crate::time::Instant;
+use alloc::vec::Vec;
 
 // This could be fixed once associated consts are stable.
 const MTU: usize = 1536;

--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -97,6 +97,7 @@ use crate::time::Instant;
 mod sys;
 
 mod fault_injector;
+#[cfg(feature = "alloc")]
 mod fuzz_injector;
 #[cfg(feature = "alloc")]
 mod loopback;
@@ -117,6 +118,7 @@ mod tuntap_interface;
 pub use self::sys::wait;
 
 pub use self::fault_injector::FaultInjector;
+#[cfg(feature = "alloc")]
 pub use self::fuzz_injector::{FuzzInjector, Fuzzer};
 #[cfg(feature = "alloc")]
 pub use self::loopback::Loopback;


### PR DESCRIPTION
It was accidentally added in https://github.com/smoltcp-rs/smoltcp/commit/4055a19bc3a0838ac1799f8248f06793b57fdacc