### PR TITLE
fix raw_socket  on macos

### DIFF
--- a/src/phy/raw_socket.rs
+++ b/src/phy/raw_socket.rs
@@ -43,7 +43,10 @@ impl RawSocket {
             mtu += 2;
         }
 
-        #[cfg(feature = "medium-ethernet")]
+        #[cfg(all(
+            feature = "medium-ethernet",
+            not(any(target_os = "macos", target_os = "openbsd"))
+        ))]
         if medium == Medium::Ethernet {
             // SIOCGIFMTU returns the IP MTU (typically 1500 bytes.)
             // smoltcp counts the entire Ethernet packet in the MTU, so add the Ethernet header size to it.


### PR DESCRIPTION
Currently BfpDevice::interface_mtu() return 4096, and RawSocket::new() would add it with EthernetFrame::header_len(), so BfpDevice::recv() would return  "Invalid argument (os error 22)".
This patch avoids adding mtu with ether_hdr_len for raw_socket on macos, maybe we will also avoid adding Ieee802154 extral hdr_len.