### PR TITLE
Prevent Panic in DNS Socket by Truncating Server List

### DIFF
--- a/src/socket/dns.rs
+++ b/src/socket/dns.rs
@@ -1,3 +1,4 @@
+use core::cmp::min;
 #[cfg(feature = "async")]
 use core::task::Waker;
 
@@ -149,15 +150,15 @@ pub struct Socket<'a> {
 impl<'a> Socket<'a> {
     /// Create a DNS socket.
     ///
-    /// # Panics
-    ///
-    /// Panics if `servers.len() > MAX_SERVER_COUNT`
+    /// Truncates the server list if `servers.len() > MAX_SERVER_COUNT`
     pub fn new<Q>(servers: &[IpAddress], queries: Q) -> Socket<'a>
     where
         Q: Into<ManagedSlice<'a, Option<DnsQuery>>>,
     {
+        let truncated_servers = &servers[..min(servers.len(), DNS_MAX_SERVER_COUNT)];
+
         Socket {
-            servers: Vec::from_slice(servers).unwrap(),
+            servers: Vec::from_slice(truncated_servers).unwrap(),
             queries: queries.into(),
             hop_limit: None,
         }
@@ -165,11 +166,14 @@ impl<'a> Socket<'a> {
 
     /// Update the list of DNS servers, will replace all existing servers
     ///
-    /// # Panics
-    ///
-    /// Panics if `servers.len() > MAX_SERVER_COUNT`
+    /// Truncates the server list if `servers.len() > MAX_SERVER_COUNT`
     pub fn update_servers(&mut self, servers: &[IpAddress]) {
-        self.servers = Vec::from_slice(servers).unwrap();
+        if servers.len() > DNS_MAX_SERVER_COUNT {
+            net_trace!("Max DNS Servers exceeded. Increase MAX_SERVER_COUNT");
+            self.servers = Vec::from_slice(&servers[..DNS_MAX_SERVER_COUNT]).unwrap();
+        } else {
+            self.servers = Vec::from_slice(servers).unwrap();
+        }
     }
 
     /// Return the time-to-live (IPv4) or hop limit (IPv6) value used in outgoing packets.


### PR DESCRIPTION
**Summary**
This PR addresses an issue in the Socket constructor where passing a server list longer than `DNS_MAX_SERVER_COUNT` would cause a panic. The number of DNS servers available is often dictated by the network configuration, especially when using DHCP, and is not something the developer can directly control. As such, the previous behaviour of panicking when more servers are provided than allowed feels like a landmine. 
The code now safely truncates the server list to ensure it does not exceed the maximum allowed number of servers, preventing any runtime panics.

**Changes**

- Truncated the input servers slice to a maximum of DNS_MAX_SERVER_COUNT before creating the Socket.
- When tracing/logging is enabled, it warns that the list would be overflowed
- This modification makes the function resilient to server lists longer than the allowed maximum.

**Why This Fix?**
This fix is essential for environments where the number of servers may dynamically change or where input server lists might inadvertently exceed the allowed limit. The developer cannot know ahead of time how many DNS servers might be available to a user, and although setting `DNS_MAX_SERVER_COUNT` to a higher value limits the likelihood of this happening, it can still happen. The previous behaviour would result in a panic, whereas the new implementation gracefully handles the case by truncating the server list.