### PR TITLE
Don't panic if no valid source address is found for the DNS query

### DIFF
--- a/src/socket/dns.rs
+++ b/src/socket/dns.rs
@@ -612,7 +612,15 @@ impl<'a> Socket<'a> {
                 };
 
                 let dst_addr = servers[pq.server_idx];
-                let src_addr = cx.get_source_address(&dst_addr).unwrap(); // TODO remove unwrap
+                let src_addr = match cx.get_source_address(&dst_addr) {
+                    Some(src_addr) => src_addr,
+                    None => {
+                        net_trace!("no source address for destination {}", dst_addr);
+                        q.set_state(State::Failure);
+                        continue;
+                    }
+                };
+
                 let ip_repr = IpRepr::new(
                     src_addr,
                     dst_addr,


### PR DESCRIPTION
Don't panic if there is no valid source address for the DNS query. The state of the query is set to `Failed` instead, and the query is abandoned.

Fixes #941 .