### PR TITLE
Update actions/checkout to v4

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ jobs:
   coverage:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install `cargo llvm-cov`
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Run Coverage

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,7 +10,7 @@ jobs:
     env:
       RUSTUP_TOOLCHAIN: nightly
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
       - name: Fuzz

--- a/.github/workflows/rustfmt.yaml
+++ b/.github/workflows/rustfmt.yaml
@@ -7,6 +7,6 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Check fmt
         run: cargo fmt -- --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,28 +15,28 @@ jobs:
   check-msrv:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run Checks MSRV
         run: ./ci.sh check msrv
 
   test-msrv:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run Tests MSRV
         run: ./ci.sh test msrv
 
   clippy:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run Clippy
         run: ./ci.sh clippy
 
   test-stable:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run Tests stable
         run: ./ci.sh test stable
 
@@ -44,21 +44,6 @@ jobs:
     runs-on: ubuntu-22.04
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run Tests nightly
         run: ./ci.sh test nightly
-
-  #check-stable:
-    #runs-on: ubuntu-22.04
-    #steps:
-      #- uses: actions/checkout@v2
-      #- name: Run Tests
-        #run: ./ci.sh check stable
-
-  #check-nightly:
-    #runs-on: ubuntu-22.04
-    #continue-on-error: true
-    #steps:
-      #- uses: actions/checkout@v2
-      #- name: Run Tests
-        #run: ./ci.sh check nightly


### PR DESCRIPTION
I think https://github.com/smoltcp-rs/smoltcp/pull/983 is hitting https://github.com/actions/checkout/issues/299 where the wrong commit is used at checkout.

When looking at the logs in CI, the job is checking out:
```
/usr/bin/git log -1 --format='%H'
'07baa01daedd72ccf79dd1331e9a0eed402c63c9'
```
while the latest commit for that PR is `916f450ca061026dfa5686043c95e3d5d22deb2e`.

Maybe updating `actions/checkout` to the latest version might fix the issue. The latest release of checkout v2 was in 2022.