### PR TITLE
Export `PollResult`

### DIFF
--- a/src/iface/mod.rs
+++ b/src/iface/mod.rs
@@ -18,7 +18,9 @@ mod packet;
 
 #[cfg(feature = "multicast")]
 pub use self::interface::multicast::MulticastError;
-pub use self::interface::{Config, Interface, InterfaceInner as Context};
+pub use self::interface::{
+    Config, Interface, InterfaceInner as Context, PollIngressSingleResult, PollResult,
+};
 
 pub use self::route::{Route, RouteTableFull, Routes};
 pub use self::socket_set::{SocketHandle, SocketSet, SocketStorage};


### PR DESCRIPTION
https://github.com/smoltcp-rs/smoltcp/pull/991 adds `PollResult` and `PollIngressSingleResult`. However, these two types are not accessible because they are in a private mod `interface`:
https://github.com/smoltcp-rs/smoltcp/blob/9cc06575ea03515fc4674a3e4f362688c5921ee3/src/iface/mod.rs#L8

This needs to be fixed, otherwise no one can check the result returned by `poll` or `poll_ingress_single`:
https://github.com/smoltcp-rs/smoltcp/blob/9cc06575ea03515fc4674a3e4f362688c5921ee3/src/iface/interface/mod.rs#L431-L436