### PR TITLE
fix: 6lowpan could panic when frag datagram_size < 40

### DIFF
--- a/src/iface/interface/sixlowpan.rs
+++ b/src/iface/interface/sixlowpan.rs
@@ -114,6 +114,15 @@ impl InterfaceInner {
         // unless we have a complete one after processing this fragment.
         let frag = check!(SixlowpanFragPacket::new_checked(payload));
 
+        // From RFC 4944 § 5.3: "The value of datagram_size SHALL be 40 octets more than the value
+        // of Payload Length in the IPv6 header of the packet."
+        // We should check that this is true, otherwise `buffer.split_at_mut(40)` will panic, since
+        // we assume that the decompressed packet is at least 40 bytes.
+        if frag.datagram_size() < 40 {
+            net_debug!("6LoWPAN: fragment size too small");
+            return None;
+        }
+
         // The key specifies to which 6LoWPAN fragment it belongs too.
         // It is based on the link layer addresses, the tag and the size.
         let key = FragKey::Sixlowpan(frag.get_key(ieee802154_repr));


### PR DESCRIPTION
6LoWPAN fragmentation could panic when the datagram_size in the fragmentation header is less than 40. When converting 6LoWPAN to IPv6 a minimum size of 40 bytes is required to put the IPv6 header in the buffer.