### PR TITLE
use core::net types for IpAddress

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -13,9 +13,9 @@ mod wire {
     extern crate test;
 
     #[cfg(feature = "proto-ipv6")]
-    const SRC_ADDR: IpAddress = IpAddress::Ipv6(Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 1));
+    const SRC_ADDR: IpAddress = IpAddress::V6(Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 1));
     #[cfg(feature = "proto-ipv6")]
-    const DST_ADDR: IpAddress = IpAddress::Ipv6(Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 2));
+    const DST_ADDR: IpAddress = IpAddress::V6(Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 2));
 
     #[cfg(all(not(feature = "proto-ipv6"), feature = "proto-ipv4"))]
     const SRC_ADDR: IpAddress = IpAddress::Ipv4(Ipv4Address::new(192, 168, 1, 1));

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -11,7 +11,7 @@ use smoltcp::iface::{Config, Interface, SocketSet};
 use smoltcp::phy::{wait as phy_wait, Device, Medium};
 use smoltcp::socket::tcp;
 use smoltcp::time::{Duration, Instant};
-use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr};
+use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr, Ipv4Address};
 
 const AMOUNT: usize = 1_000_000_000;
 
@@ -98,7 +98,10 @@ fn main() {
     let mut iface = Interface::new(config, &mut device, Instant::now());
     iface.update_ip_addrs(|ip_addrs| {
         ip_addrs
-            .push(IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24))
+            .push(IpCidr::new(
+                IpAddress::V4(Ipv4Address::new(192, 168, 69, 1)),
+                24,
+            ))
             .unwrap();
     });
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -41,13 +41,22 @@ fn main() {
     let mut iface = Interface::new(config, &mut device, Instant::now());
     iface.update_ip_addrs(|ip_addrs| {
         ip_addrs
-            .push(IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24))
+            .push(IpCidr::new(
+                IpAddress::V4(Ipv4Address::new(192, 168, 69, 1)),
+                24,
+            ))
             .unwrap();
         ip_addrs
-            .push(IpCidr::new(IpAddress::v6(0xfdaa, 0, 0, 0, 0, 0, 0, 1), 64))
+            .push(IpCidr::new(
+                IpAddress::V6(Ipv6Address::new(0xfdaa, 0, 0, 0, 0, 0, 0, 1)),
+                64,
+            ))
             .unwrap();
         ip_addrs
-            .push(IpCidr::new(IpAddress::v6(0xfe80, 0, 0, 0, 0, 0, 0, 1), 64))
+            .push(IpCidr::new(
+                IpAddress::V6(Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)),
+                64,
+            ))
             .unwrap();
     });
     iface

--- a/examples/dns.rs
+++ b/examples/dns.rs
@@ -36,13 +36,22 @@ fn main() {
     let mut iface = Interface::new(config, &mut device, Instant::now());
     iface.update_ip_addrs(|ip_addrs| {
         ip_addrs
-            .push(IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24))
+            .push(IpCidr::new(
+                IpAddress::V4(Ipv4Address::new(192, 168, 69, 1)),
+                24,
+            ))
             .unwrap();
         ip_addrs
-            .push(IpCidr::new(IpAddress::v6(0xfdaa, 0, 0, 0, 0, 0, 0, 1), 64))
+            .push(IpCidr::new(
+                IpAddress::V6(Ipv6Address::new(0xfdaa, 0, 0, 0, 0, 0, 0, 1)),
+                64,
+            ))
             .unwrap();
         ip_addrs
-            .push(IpCidr::new(IpAddress::v6(0xfe80, 0, 0, 0, 0, 0, 0, 1), 64))
+            .push(IpCidr::new(
+                IpAddress::V6(Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)),
+                64,
+            ))
             .unwrap();
     });
     iface

--- a/examples/httpclient.rs
+++ b/examples/httpclient.rs
@@ -41,13 +41,22 @@ fn main() {
     let mut iface = Interface::new(config, &mut device, Instant::now());
     iface.update_ip_addrs(|ip_addrs| {
         ip_addrs
-            .push(IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24))
+            .push(IpCidr::new(
+                IpAddress::V4(Ipv4Address::new(192, 168, 69, 1)),
+                24,
+            ))
             .unwrap();
         ip_addrs
-            .push(IpCidr::new(IpAddress::v6(0xfdaa, 0, 0, 0, 0, 0, 0, 1), 64))
+            .push(IpCidr::new(
+                IpAddress::V6(Ipv6Address::new(0xfdaa, 0, 0, 0, 0, 0, 0, 1)),
+                64,
+            ))
             .unwrap();
         ip_addrs
-            .push(IpCidr::new(IpAddress::v6(0xfe80, 0, 0, 0, 0, 0, 0, 1), 64))
+            .push(IpCidr::new(
+                IpAddress::V6(Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)),
+                64,
+            ))
             .unwrap();
     });
     iface

--- a/examples/loopback.rs
+++ b/examples/loopback.rs
@@ -12,7 +12,7 @@ use smoltcp::iface::{Config, Interface, SocketSet};
 use smoltcp::phy::{Device, Loopback, Medium};
 use smoltcp::socket::tcp;
 use smoltcp::time::{Duration, Instant};
-use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr};
+use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr, Ipv4Address};
 
 #[cfg(not(feature = "std"))]
 mod mock {
@@ -93,7 +93,10 @@ fn main() {
     let mut iface = Interface::new(config, &mut device, Instant::now());
     iface.update_ip_addrs(|ip_addrs| {
         ip_addrs
-            .push(IpCidr::new(IpAddress::v4(127, 0, 0, 1), 8))
+            .push(IpCidr::new(
+                IpAddress::V4(Ipv4Address::new(127, 0, 0, 1)),
+                8,
+            ))
             .unwrap();
     });
 
@@ -153,7 +156,11 @@ fn main() {
             if !did_connect {
                 debug!("connecting");
                 socket
-                    .connect(cx, (IpAddress::v4(127, 0, 0, 1), 1234), 65000)
+                    .connect(
+                        cx,
+                        (IpAddress::V4(Ipv4Address::new(127, 0, 0, 1)), 1234),
+                        65000,
+                    )
                     .unwrap();
                 did_connect = true;
             }

--- a/examples/loopback_benchmark.rs
+++ b/examples/loopback_benchmark.rs
@@ -6,7 +6,7 @@ use smoltcp::iface::{Config, Interface, SocketSet};
 use smoltcp::phy::{Device, Loopback, Medium};
 use smoltcp::socket::tcp;
 use smoltcp::time::Instant;
-use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr};
+use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr, Ipv4Address};
 
 fn main() {
     let device = Loopback::new(Medium::Ethernet);
@@ -33,7 +33,10 @@ fn main() {
     let mut iface = Interface::new(config, &mut device, Instant::now());
     iface.update_ip_addrs(|ip_addrs| {
         ip_addrs
-            .push(IpCidr::new(IpAddress::v4(127, 0, 0, 1), 8))
+            .push(IpCidr::new(
+                IpAddress::V4(Ipv4Address::new(127, 0, 0, 1)),
+                8,
+            ))
             .unwrap();
     });
 
@@ -81,7 +84,11 @@ fn main() {
         if !socket.is_open() && !did_connect {
             debug!("connecting");
             socket
-                .connect(cx, (IpAddress::v4(127, 0, 0, 1), 1234), 65000)
+                .connect(
+                    cx,
+                    (IpAddress::V4(Ipv4Address::new(127, 0, 0, 1)), 1234),
+                    65000,
+                )
                 .unwrap();
             did_connect = true;
         }

--- a/examples/multicast.rs
+++ b/examples/multicast.rs
@@ -7,8 +7,8 @@ use smoltcp::phy::{wait as phy_wait, Device, Medium};
 use smoltcp::socket::{raw, udp};
 use smoltcp::time::Instant;
 use smoltcp::wire::{
-    EthernetAddress, IgmpPacket, IgmpRepr, IpAddress, IpCidr, IpProtocol, IpVersion, Ipv4Address,
-    Ipv4Packet, Ipv6Address,
+    EthernetAddress, IgmpPacket, IgmpRepr, IpAddress, IpCidr, IpProtocol, Ipv4Address, Ipv4Packet,
+    Ipv6Address,
 };
 
 const MDNS_PORT: u16 = 5353;
@@ -40,13 +40,22 @@ fn main() {
     let mut iface = Interface::new(config, &mut device, Instant::now());
     iface.update_ip_addrs(|ip_addrs| {
         ip_addrs
-            .push(IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24))
+            .push(IpCidr::new(
+                IpAddress::V4(Ipv4Address::new(192, 168, 69, 1)),
+                24,
+            ))
             .unwrap();
         ip_addrs
-            .push(IpCidr::new(IpAddress::v6(0xfdaa, 0, 0, 0, 0, 0, 0, 1), 64))
+            .push(IpCidr::new(
+                IpAddress::V6(Ipv6Address::new(0xfdaa, 0, 0, 0, 0, 0, 0, 1)),
+                64,
+            ))
             .unwrap();
         ip_addrs
-            .push(IpCidr::new(IpAddress::v6(0xfe80, 0, 0, 0, 0, 0, 0, 1), 64))
+            .push(IpCidr::new(
+                IpAddress::V6(Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)),
+                64,
+            ))
             .unwrap();
     });
     iface
@@ -65,12 +74,7 @@ fn main() {
     let raw_rx_buffer = raw::PacketBuffer::new(vec![raw::PacketMetadata::EMPTY; 2], vec![0; 512]);
     // Will not send IGMP
     let raw_tx_buffer = raw::PacketBuffer::new(vec![], vec![]);
-    let raw_socket = raw::Socket::new(
-        IpVersion::Ipv4,
-        IpProtocol::Igmp,
-        raw_rx_buffer,
-        raw_tx_buffer,
-    );
+    let raw_socket = raw::Socket::new_v4(IpProtocol::Igmp, raw_rx_buffer, raw_tx_buffer);
     let raw_handle = sockets.add(raw_socket);
 
     // Must fit mDNS payload of at least one packet

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -117,13 +117,22 @@ fn main() {
     let mut iface = Interface::new(config, &mut device, Instant::now());
     iface.update_ip_addrs(|ip_addrs| {
         ip_addrs
-            .push(IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24))
+            .push(IpCidr::new(
+                IpAddress::V4(Ipv4Address::new(192, 168, 69, 1)),
+                24,
+            ))
             .unwrap();
         ip_addrs
-            .push(IpCidr::new(IpAddress::v6(0xfdaa, 0, 0, 0, 0, 0, 0, 1), 64))
+            .push(IpCidr::new(
+                IpAddress::V6(Ipv6Address::new(0xfdaa, 0, 0, 0, 0, 0, 0, 1)),
+                64,
+            ))
             .unwrap();
         ip_addrs
-            .push(IpCidr::new(IpAddress::v6(0xfe80, 0, 0, 0, 0, 0, 0, 1), 64))
+            .push(IpCidr::new(
+                IpAddress::V6(Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)),
+                64,
+            ))
             .unwrap();
     });
     iface
@@ -164,7 +173,7 @@ fn main() {
             NetworkEndian::write_i64(&mut echo_payload, timestamp.total_millis());
 
             match remote_addr {
-                IpAddress::Ipv4(_) => {
+                IpAddress::V4(_) => {
                     let (icmp_repr, mut icmp_packet) = send_icmp_ping!(
                         Icmpv4Repr,
                         Icmpv4Packet,
@@ -176,7 +185,7 @@ fn main() {
                     );
                     icmp_repr.emit(&mut icmp_packet, &device_caps.checksum);
                 }
-                IpAddress::Ipv6(address) => {
+                IpAddress::V6(address) => {
                     let (icmp_repr, mut icmp_packet) = send_icmp_ping!(
                         Icmpv6Repr,
                         Icmpv6Packet,
@@ -204,7 +213,7 @@ fn main() {
             let (payload, _) = socket.recv().unwrap();
 
             match remote_addr {
-                IpAddress::Ipv4(_) => {
+                IpAddress::V4(_) => {
                     let icmp_packet = Icmpv4Packet::new_checked(&payload).unwrap();
                     let icmp_repr = Icmpv4Repr::parse(&icmp_packet, &device_caps.checksum).unwrap();
                     get_icmp_pong!(
@@ -217,7 +226,7 @@ fn main() {
                         received
                     );
                 }
-                IpAddress::Ipv6(address) => {
+                IpAddress::V6(address) => {
                     let icmp_packet = Icmpv6Packet::new_checked(&payload).unwrap();
                     let icmp_repr = Icmpv6Repr::parse(
                         &address,

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -37,13 +37,22 @@ fn main() {
     let mut iface = Interface::new(config, &mut device, Instant::now());
     iface.update_ip_addrs(|ip_addrs| {
         ip_addrs
-            .push(IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24))
+            .push(IpCidr::new(
+                IpAddress::V4(Ipv4Address::new(192, 168, 69, 1)),
+                24,
+            ))
             .unwrap();
         ip_addrs
-            .push(IpCidr::new(IpAddress::v6(0xfdaa, 0, 0, 0, 0, 0, 0, 1), 64))
+            .push(IpCidr::new(
+                IpAddress::V6(Ipv6Address::new(0xfdaa, 0, 0, 0, 0, 0, 0, 1)),
+                64,
+            ))
             .unwrap();
         ip_addrs
-            .push(IpCidr::new(IpAddress::v6(0xfe80, 0, 0, 0, 0, 0, 0, 1), 64))
+            .push(IpCidr::new(
+                IpAddress::V6(Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)),
+                64,
+            ))
             .unwrap();
     });
     iface

--- a/examples/sixlowpan.rs
+++ b/examples/sixlowpan.rs
@@ -51,7 +51,9 @@ use smoltcp::phy::{wait as phy_wait, Device, Medium, RawSocket};
 use smoltcp::socket::tcp;
 use smoltcp::socket::udp;
 use smoltcp::time::Instant;
-use smoltcp::wire::{EthernetAddress, Ieee802154Address, Ieee802154Pan, IpAddress, IpCidr};
+use smoltcp::wire::{
+    EthernetAddress, Ieee802154Address, Ieee802154Pan, IpAddress, IpCidr, Ipv6Address,
+};
 
 fn main() {
     utils::setup_logging("");
@@ -83,7 +85,9 @@ fn main() {
     iface.update_ip_addrs(|ip_addrs| {
         ip_addrs
             .push(IpCidr::new(
-                IpAddress::v6(0xfe80, 0, 0, 0, 0x180b, 0x4242, 0x4242, 0x4242),
+                IpAddress::V6(Ipv6Address::new(
+                    0xfe80, 0, 0, 0, 0x180b, 0x4242, 0x4242, 0x4242,
+                )),
                 64,
             ))
             .unwrap();

--- a/examples/sixlowpan_benchmark.rs
+++ b/examples/sixlowpan_benchmark.rs
@@ -49,7 +49,9 @@ use std::str;
 use smoltcp::iface::{Config, Interface, SocketSet};
 use smoltcp::phy::{wait as phy_wait, Device, Medium, RawSocket};
 use smoltcp::socket::tcp;
-use smoltcp::wire::{EthernetAddress, Ieee802154Address, Ieee802154Pan, IpAddress, IpCidr};
+use smoltcp::wire::{
+    EthernetAddress, Ieee802154Address, Ieee802154Pan, IpAddress, IpCidr, Ipv6Address,
+};
 
 //For benchmark
 use smoltcp::time::{Duration, Instant};
@@ -163,7 +165,9 @@ fn main() {
     iface.update_ip_addrs(|ip_addrs| {
         ip_addrs
             .push(IpCidr::new(
-                IpAddress::v6(0xfe80, 0, 0, 0, 0x180b, 0x4242, 0x4242, 0x4242),
+                IpAddress::V6(Ipv6Address::new(
+                    0xfe80, 0, 0, 0, 0x180b, 0x4242, 0x4242, 0x4242,
+                )),
                 64,
             ))
             .unwrap();

--- a/src/iface/interface/ipv4.rs
+++ b/src/iface/interface/ipv4.rs
@@ -197,7 +197,7 @@ impl InterfaceInner {
 
             if self
                 .routes
-                .lookup(&IpAddress::Ipv4(ipv4_repr.dst_addr), self.now)
+                .lookup(&IpAddress::V4(ipv4_repr.dst_addr), self.now)
                 .map_or(true, |router_addr| !self.has_ip_addr(router_addr))
             {
                 net_trace!("Rejecting IPv4 packet; no matching routes");
@@ -209,7 +209,7 @@ impl InterfaceInner {
         #[cfg(feature = "medium-ethernet")]
         if self.is_unicast_v4(ipv4_repr.dst_addr) {
             self.neighbor_cache.reset_expiry_if_existing(
-                IpAddress::Ipv4(ipv4_repr.src_addr),
+                IpAddress::V4(ipv4_repr.src_addr),
                 source_hardware_addr,
                 self.now,
             );
@@ -279,7 +279,7 @@ impl InterfaceInner {
                     return None;
                 }
 
-                if !self.in_same_network(&IpAddress::Ipv4(source_protocol_addr)) {
+                if !self.in_same_network(&IpAddress::V4(source_protocol_addr)) {
                     net_debug!("arp: source IP address not in same network as us");
                     return None;
                 }
@@ -437,11 +437,11 @@ impl InterfaceInner {
             frame.set_src_addr(src_addr);
             frame.set_dst_addr(frag.ipv4.dst_hardware_addr);
 
-            match repr.version() {
+            match repr {
                 #[cfg(feature = "proto-ipv4")]
-                IpVersion::Ipv4 => frame.set_ethertype(EthernetProtocol::Ipv4),
+                IpRepr::Ipv4(_) => frame.set_ethertype(EthernetProtocol::Ipv4),
                 #[cfg(feature = "proto-ipv6")]
-                IpVersion::Ipv6 => frame.set_ethertype(EthernetProtocol::Ipv6),
+                IpRepr::Ipv6(_) => frame.set_ethertype(EthernetProtocol::Ipv6),
             }
         };
 

--- a/src/iface/interface/ipv6.rs
+++ b/src/iface/interface/ipv6.rs
@@ -227,7 +227,7 @@ impl InterfaceInner {
 
             if self
                 .routes
-                .lookup(&IpAddress::Ipv6(ipv6_repr.dst_addr), self.now)
+                .lookup(&IpAddress::V6(ipv6_repr.dst_addr), self.now)
                 .map_or(true, |router_addr| !self.has_ip_addr(router_addr))
             {
                 net_trace!("Rejecting IPv6 packet; no matching routes");
@@ -244,7 +244,7 @@ impl InterfaceInner {
         #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
         if ipv6_repr.dst_addr.x_is_unicast() {
             self.neighbor_cache.reset_expiry_if_existing(
-                IpAddress::Ipv6(ipv6_repr.src_addr),
+                IpAddress::V6(ipv6_repr.src_addr),
                 source_hardware_addr,
                 self.now,
             );

--- a/src/iface/interface/multicast.rs
+++ b/src/iface/interface/multicast.rs
@@ -156,7 +156,7 @@ impl Interface {
         {
             match addr {
                 #[cfg(feature = "proto-ipv4")]
-                IpAddress::Ipv4(addr) => {
+                IpAddress::V4(addr) => {
                     if let Some(pkt) = self.inner.igmp_report_packet(IgmpVersion::Version2, addr) {
                         let Some(tx_token) = device.transmit(self.inner.now) else {
                             break;
@@ -169,7 +169,7 @@ impl Interface {
                     }
                 }
                 #[cfg(feature = "proto-ipv6")]
-                IpAddress::Ipv6(addr) => {
+                IpAddress::V6(addr) => {
                     if let Some(pkt) = self.inner.mldv2_report_packet(&[MldAddressRecordRepr::new(
                         MldRecordType::ChangeToInclude,
                         addr,
@@ -184,6 +184,8 @@ impl Interface {
                             .unwrap();
                     }
                 }
+                #[allow(unreachable_patterns)]
+                _ => unreachable!(),
             }
 
             // NOTE(unwrap): this is always replacing an existing entry, so it can't fail due to the map being full.
@@ -204,7 +206,7 @@ impl Interface {
         {
             match addr {
                 #[cfg(feature = "proto-ipv4")]
-                IpAddress::Ipv4(addr) => {
+                IpAddress::V4(addr) => {
                     if let Some(pkt) = self.inner.igmp_leave_packet(addr) {
                         let Some(tx_token) = device.transmit(self.inner.now) else {
                             break;
@@ -217,7 +219,7 @@ impl Interface {
                     }
                 }
                 #[cfg(feature = "proto-ipv6")]
-                IpAddress::Ipv6(addr) => {
+                IpAddress::V6(addr) => {
                     if let Some(pkt) = self.inner.mldv2_report_packet(&[MldAddressRecordRepr::new(
                         MldRecordType::ChangeToExclude,
                         addr,
@@ -232,6 +234,8 @@ impl Interface {
                             .unwrap();
                     }
                 }
+                #[allow(unreachable_patterns)]
+                _ => unreachable!(),
             }
 
             self.inner.multicast.groups.remove(&addr);
@@ -267,7 +271,7 @@ impl Interface {
                     .groups
                     .iter()
                     .filter_map(|(addr, _)| match addr {
-                        IpAddress::Ipv4(addr) => Some(*addr),
+                        IpAddress::V4(addr) => Some(*addr),
                         #[allow(unreachable_patterns)]
                         _ => None,
                     })
@@ -339,7 +343,7 @@ impl InterfaceInner {
                         .multicast
                         .groups
                         .keys()
-                        .filter(|a| matches!(a, IpAddress::Ipv4(_)))
+                        .filter(|a| matches!(a, IpAddress::V4(_)))
                         .count();
 
                     // Are we member in any groups?

--- a/src/iface/interface/tests/ipv4.rs
+++ b/src/iface/interface/tests/ipv4.rs
@@ -322,7 +322,7 @@ fn test_icmp_error_port_unreachable(#[case] medium: Medium) {
     udp_repr.emit(
         &mut packet_broadcast,
         &ip_repr.src_addr(),
-        &IpAddress::Ipv4(Ipv4Address::BROADCAST),
+        &IpAddress::V4(Ipv4Address::BROADCAST),
         UDP_PAYLOAD.len(),
         |buf| buf.copy_from_slice(&UDP_PAYLOAD),
         &ChecksumCapabilities::default(),
@@ -464,7 +464,7 @@ fn test_handle_valid_arp_request(#[case] medium: Medium) {
     assert_eq!(
         iface.inner.lookup_hardware_addr(
             MockTxToken,
-            &IpAddress::Ipv4(remote_ip_addr),
+            &IpAddress::V4(remote_ip_addr),
             &mut iface.fragmenter,
         ),
         Ok((HardwareAddress::Ethernet(remote_hw_addr), MockTxToken))
@@ -512,7 +512,7 @@ fn test_handle_other_arp_request(#[case] medium: Medium) {
     assert_eq!(
         iface.inner.lookup_hardware_addr(
             MockTxToken,
-            &IpAddress::Ipv4(remote_ip_addr),
+            &IpAddress::V4(remote_ip_addr),
             &mut iface.fragmenter,
         ),
         Err(DispatchError::NeighborPending)
@@ -570,7 +570,7 @@ fn test_arp_flush_after_update_ip(#[case] medium: Medium) {
     assert_eq!(
         iface.inner.lookup_hardware_addr(
             MockTxToken,
-            &IpAddress::Ipv4(remote_ip_addr),
+            &IpAddress::V4(remote_ip_addr),
             &mut iface.fragmenter,
         ),
         Ok((HardwareAddress::Ethernet(remote_hw_addr), MockTxToken))
@@ -585,7 +585,7 @@ fn test_arp_flush_after_update_ip(#[case] medium: Medium) {
     });
 
     // ARP cache flush after address change
-    assert!(!iface.inner.has_neighbor(&IpAddress::Ipv4(remote_ip_addr)));
+    assert!(!iface.inner.has_neighbor(&IpAddress::V4(remote_ip_addr)));
 }
 
 #[rstest]
@@ -660,7 +660,7 @@ fn test_icmpv4_socket(#[case] medium: Medium) {
         socket.recv(),
         Ok((
             icmp_data,
-            IpAddress::Ipv4(Ipv4Address::new(0x7f, 0x00, 0x00, 0x02))
+            IpAddress::V4(Ipv4Address::new(0x7f, 0x00, 0x00, 0x02))
         ))
     );
 }
@@ -765,7 +765,7 @@ fn test_handle_igmp(#[case] medium: Medium) {
 #[case(Medium::Ethernet)]
 #[cfg(all(feature = "socket-raw", feature = "medium-ethernet"))]
 fn test_raw_socket_no_reply(#[case] medium: Medium) {
-    use crate::wire::{IpVersion, UdpPacket, UdpRepr};
+    use crate::wire::{UdpPacket, UdpRepr};
 
     let (mut iface, mut sockets, _) = setup(medium);
 
@@ -776,7 +776,7 @@ fn test_raw_socket_no_reply(#[case] medium: Medium) {
         vec![raw::PacketMetadata::EMPTY; packets],
         vec![0; 48 * packets],
     );
-    let raw_socket = raw::Socket::new(IpVersion::Ipv4, IpProtocol::Udp, rx_buffer, tx_buffer);
+    let raw_socket = raw::Socket::new_v4(IpProtocol::Udp, rx_buffer, tx_buffer);
     sockets.add(raw_socket);
 
     let src_addr = Ipv4Address::new(127, 0, 0, 2);
@@ -847,7 +847,7 @@ fn test_raw_socket_no_reply(#[case] medium: Medium) {
 ))]
 fn test_raw_socket_with_udp_socket(#[case] medium: Medium) {
     use crate::socket::udp;
-    use crate::wire::{IpEndpoint, IpVersion, UdpPacket, UdpRepr};
+    use crate::wire::{IpEndpoint, UdpPacket, UdpRepr};
 
     static UDP_PAYLOAD: [u8; 5] = [0x48, 0x65, 0x6c, 0x6c, 0x6f];
 
@@ -871,12 +871,7 @@ fn test_raw_socket_with_udp_socket(#[case] medium: Medium) {
         vec![raw::PacketMetadata::EMPTY; packets],
         vec![0; 48 * packets],
     );
-    let raw_socket = raw::Socket::new(
-        IpVersion::Ipv4,
-        IpProtocol::Udp,
-        raw_rx_buffer,
-        raw_tx_buffer,
-    );
+    let raw_socket = raw::Socket::new_v4(IpProtocol::Udp, raw_rx_buffer, raw_tx_buffer);
     sockets.add(raw_socket);
 
     let src_addr = Ipv4Address::new(127, 0, 0, 2);

--- a/src/iface/interface/tests/ipv6.rs
+++ b/src/iface/interface/tests/ipv6.rs
@@ -73,7 +73,7 @@ fn any_ip(#[case] medium: Medium) {
                     Ipv6Address::new(0xfdbe, 0, 0, 0, 0, 0, 0, 0),
                     64,
                 )),
-                via_router: IpAddress::Ipv6(Ipv6Address::new(0xfdbe, 0, 0, 0, 0, 0, 0, 0x0001)),
+                via_router: IpAddress::V6(Ipv6Address::new(0xfdbe, 0, 0, 0, 0, 0, 0, 0x0001)),
                 preferred_until: None,
                 expires_at: None,
             })
@@ -644,7 +644,7 @@ fn ndsic_neighbor_advertisement_ethernet(#[case] medium: Medium) {
 
     assert_eq!(
         iface.inner.neighbor_cache.lookup(
-            &IpAddress::Ipv6(Ipv6Address::new(0xfdbe, 0, 0, 0, 0, 0, 0, 0x0002)),
+            &IpAddress::V6(Ipv6Address::new(0xfdbe, 0, 0, 0, 0, 0, 0, 0x0002)),
             iface.inner.now,
         ),
         NeighborAnswer::Found(HardwareAddress::Ethernet(EthernetAddress::from_bytes(&[
@@ -701,7 +701,7 @@ fn ndsic_neighbor_advertisement_ethernet_multicast_addr(#[case] medium: Medium) 
 
     assert_eq!(
         iface.inner.neighbor_cache.lookup(
-            &IpAddress::Ipv6(Ipv6Address::new(0xfdbe, 0, 0, 0, 0, 0, 0, 0x0002)),
+            &IpAddress::V6(Ipv6Address::new(0xfdbe, 0, 0, 0, 0, 0, 0, 0x0002)),
             iface.inner.now,
         ),
         NeighborAnswer::NotFound,
@@ -754,7 +754,7 @@ fn ndsic_neighbor_advertisement_ieee802154(#[case] medium: Medium) {
 
     assert_eq!(
         iface.inner.neighbor_cache.lookup(
-            &IpAddress::Ipv6(Ipv6Address::new(0xfdbe, 0, 0, 0, 0, 0, 0, 0x0002)),
+            &IpAddress::V6(Ipv6Address::new(0xfdbe, 0, 0, 0, 0, 0, 0, 0x0002)),
             iface.inner.now,
         ),
         NeighborAnswer::Found(HardwareAddress::Ieee802154(Ieee802154Address::from_bytes(
@@ -832,7 +832,7 @@ fn test_handle_valid_ndisc_request(#[case] medium: Medium) {
     assert_eq!(
         iface.inner.lookup_hardware_addr(
             MockTxToken,
-            &IpAddress::Ipv6(remote_ip_addr),
+            &IpAddress::V6(remote_ip_addr),
             &mut iface.fragmenter,
         ),
         Ok((HardwareAddress::Ethernet(remote_hw_addr), MockTxToken))
@@ -850,11 +850,14 @@ fn test_solicited_node_addrs(#[case] medium: Medium) {
     let (mut iface, _, _) = setup(medium);
     let mut new_addrs = heapless::Vec::<IpCidr, IFACE_MAX_ADDR_COUNT>::new();
     new_addrs
-        .push(IpCidr::new(IpAddress::v6(0xfe80, 0, 0, 0, 1, 2, 0, 2), 64))
+        .push(IpCidr::new(
+            IpAddress::V6(Ipv6Address::new(0xfe80, 0, 0, 0, 1, 2, 0, 2)),
+            64,
+        ))
         .unwrap();
     new_addrs
         .push(IpCidr::new(
-            IpAddress::v6(0xfe80, 0, 0, 0, 3, 4, 0, 0xffff),
+            IpAddress::V6(Ipv6Address::new(0xfe80, 0, 0, 0, 3, 4, 0, 0xffff)),
             64,
         ))
         .unwrap();

--- a/src/iface/interface/tests/sixlowpan.rs
+++ b/src/iface/interface/tests/sixlowpan.rs
@@ -215,7 +215,7 @@ fn test_echo_request_sixlowpan_128_bytes() {
     );
 
     iface.inner.neighbor_cache.fill(
-        IpAddress::Ipv6(Ipv6Address::new(
+        IpAddress::V6(Ipv6Address::new(
             0xfe80, 0, 0, 0, 0x4042, 0x4242, 0x4242, 0x0b1a,
         )),
         HardwareAddress::Ieee802154(Ieee802154Address::default()),
@@ -361,7 +361,7 @@ In at rhoncus tortor. Cras blandit tellus diam, varius vestibulum nibh commodo n
                     Ipv6Address::new(0xfe80, 0, 0, 0, 0x92fc, 0x48c2, 0xa441, 0xfc76).into()
                 ),
                 ..IpEndpoint {
-                    addr: IpAddress::Ipv6(Ipv6Address::new(
+                    addr: IpAddress::V6(Ipv6Address::new(
                         0xfe80, 0, 0, 0, 0x4042, 0x4242, 0x4242, 0x0b1a
                     )),
                     port: 54217,

--- a/src/iface/neighbor.rs
+++ b/src/iface/neighbor.rs
@@ -5,7 +5,7 @@ use heapless::LinearMap;
 
 use crate::config::IFACE_NEIGHBOR_CACHE_COUNT;
 use crate::time::{Duration, Instant};
-use crate::wire::{HardwareAddress, IpAddress};
+use crate::wire::{HardwareAddress, IpAddress, IpAddressExt};
 
 /// A cached neighbor.
 ///
@@ -86,7 +86,7 @@ impl Cache {
         hardware_addr: HardwareAddress,
         timestamp: Instant,
     ) {
-        debug_assert!(protocol_addr.is_unicast());
+        debug_assert!(protocol_addr.x_is_unicast());
         debug_assert!(hardware_addr.is_unicast());
 
         let expires_at = timestamp + Self::ENTRY_LIFETIME;
@@ -99,7 +99,7 @@ impl Cache {
         hardware_addr: HardwareAddress,
         expires_at: Instant,
     ) {
-        debug_assert!(protocol_addr.is_unicast());
+        debug_assert!(protocol_addr.x_is_unicast());
         debug_assert!(hardware_addr.is_unicast());
 
         let neighbor = Neighbor {
@@ -148,7 +148,7 @@ impl Cache {
     }
 
     pub(crate) fn lookup(&self, protocol_addr: &IpAddress, timestamp: Instant) -> Answer {
-        assert!(protocol_addr.is_unicast());
+        assert!(protocol_addr.x_is_unicast());
 
         if let Some(&Neighbor {
             expires_at,

--- a/src/iface/route.rs
+++ b/src/iface/route.rs
@@ -2,7 +2,7 @@ use heapless::Vec;
 
 use crate::config::IFACE_MAX_ROUTE_COUNT;
 use crate::time::Instant;
-use crate::wire::{IpAddress, IpCidr};
+use crate::wire::{IpAddress, IpAddressExt, IpCidr};
 #[cfg(feature = "proto-ipv4")]
 use crate::wire::{Ipv4Address, Ipv4Cidr};
 #[cfg(feature = "proto-ipv6")]
@@ -147,7 +147,7 @@ impl Routes {
     }
 
     pub(crate) fn lookup(&self, addr: &IpAddress, timestamp: Instant) -> Option<IpAddress> {
-        assert!(addr.is_unicast());
+        assert!(addr.x_is_unicast());
 
         self.storage
             .iter()

--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -5,9 +5,9 @@ use crate::iface::Context;
 use crate::time::{Duration, Instant};
 use crate::wire::dhcpv4::field as dhcpv4_field;
 use crate::wire::{
-    DhcpMessageType, DhcpPacket, DhcpRepr, IpAddress, IpProtocol, Ipv4Address, Ipv4AddressExt,
-    Ipv4Cidr, Ipv4Repr, UdpRepr, DHCP_CLIENT_PORT, DHCP_MAX_DNS_SERVER_COUNT, DHCP_SERVER_PORT,
-    UDP_HEADER_LEN,
+    DhcpMessageType, DhcpPacket, DhcpRepr, IpAddress, IpAddressExt, IpProtocol, Ipv4Address,
+    Ipv4AddressExt, Ipv4Cidr, Ipv4Repr, UdpRepr, DHCP_CLIENT_PORT, DHCP_MAX_DNS_SERVER_COUNT,
+    DHCP_SERVER_PORT, UDP_HEADER_LEN,
 };
 use crate::wire::{DhcpOption, HardwareAddress};
 use heapless::Vec;
@@ -454,7 +454,7 @@ impl<'a> Socket<'a> {
             }
         };
 
-        let prefix_len = match IpAddress::Ipv4(subnet_mask).prefix_len() {
+        let prefix_len = match IpAddress::V4(subnet_mask).prefix_len() {
             Some(prefix_len) => prefix_len,
             None => {
                 net_debug!("DHCP ignoring ACK because subnet_mask is not a valid mask");

--- a/src/socket/dns.rs
+++ b/src/socket/dns.rs
@@ -22,13 +22,13 @@ const RETRANSMIT_TIMEOUT: Duration = Duration::from_millis(10_000); // Should ge
 
 #[cfg(feature = "proto-ipv6")]
 #[allow(unused)]
-const MDNS_IPV6_ADDR: IpAddress = IpAddress::Ipv6(crate::wire::Ipv6Address::new(
+const MDNS_IPV6_ADDR: IpAddress = IpAddress::V6(crate::wire::Ipv6Address::new(
     0xff02, 0, 0, 0, 0, 0, 0, 0xfb,
 ));
 
 #[cfg(feature = "proto-ipv4")]
 #[allow(unused)]
-const MDNS_IPV4_ADDR: IpAddress = IpAddress::Ipv4(crate::wire::Ipv4Address::new(224, 0, 0, 251));
+const MDNS_IPV4_ADDR: IpAddress = IpAddress::V4(crate::wire::Ipv4Address::new(224, 0, 0, 251));
 
 /// Error returned by [`Socket::start_query`]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/src/socket/icmp.rs
+++ b/src/socket/icmp.rs
@@ -561,7 +561,7 @@ impl<'a> Socket<'a> {
             );
             match *remote_endpoint {
                 #[cfg(feature = "proto-ipv4")]
-                IpAddress::Ipv4(dst_addr) => {
+                IpAddress::V4(dst_addr) => {
                     let src_addr = match cx.get_source_address_ipv4(&dst_addr) {
                         Some(addr) => addr,
                         None => {
@@ -593,7 +593,7 @@ impl<'a> Socket<'a> {
                     emit(cx, (ip_repr, IcmpRepr::Ipv4(repr)))
                 }
                 #[cfg(feature = "proto-ipv6")]
-                IpAddress::Ipv6(dst_addr) => {
+                IpAddress::V6(dst_addr) => {
                     let src_addr = cx.get_source_address_ipv6(&dst_addr);
 
                     let packet = Icmpv6Packet::new_unchecked(&*packet_buf);
@@ -621,6 +621,8 @@ impl<'a> Socket<'a> {
                     });
                     emit(cx, (ip_repr, IcmpRepr::Ipv6(repr)))
                 }
+                #[allow(unreachable_patterns)]
+                _ => unreachable!(),
             }
         });
         match res {
@@ -681,7 +683,7 @@ mod test_ipv4 {
     const REMOTE_IPV4: Ipv4Address = Ipv4Address::new(192, 168, 1, 2);
     const LOCAL_IPV4: Ipv4Address = Ipv4Address::new(192, 168, 1, 1);
     const LOCAL_END_V4: IpEndpoint = IpEndpoint {
-        addr: IpAddress::Ipv4(LOCAL_IPV4),
+        addr: IpAddress::V4(LOCAL_IPV4),
         port: LOCAL_PORT,
     };
 
@@ -711,7 +713,7 @@ mod test_ipv4 {
     fn test_send_unaddressable() {
         let mut socket = socket(buffer(0), buffer(1));
         assert_eq!(
-            socket.send_slice(b"abcdef", IpAddress::Ipv4(Ipv4Address::new(0, 0, 0, 0))),
+            socket.send_slice(b"abcdef", IpAddress::V4(Ipv4Address::new(0, 0, 0, 0))),
             Err(SendError::Unaddressable)
         );
         assert_eq!(socket.send_slice(b"abcdef", REMOTE_IPV4.into()), Ok(()));
@@ -943,7 +945,7 @@ mod test_ipv6 {
     const REMOTE_IPV6: Ipv6Address = Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 2);
     const LOCAL_IPV6: Ipv6Address = Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
     const LOCAL_END_V6: IpEndpoint = IpEndpoint {
-        addr: IpAddress::Ipv6(LOCAL_IPV6),
+        addr: IpAddress::V6(LOCAL_IPV6),
         port: LOCAL_PORT,
     };
     static ECHOV6_REPR: Icmpv6Repr = Icmpv6Repr::EchoRequest {
@@ -972,7 +974,7 @@ mod test_ipv6 {
     fn test_send_unaddressable() {
         let mut socket = socket(buffer(0), buffer(1));
         assert_eq!(
-            socket.send_slice(b"abcdef", IpAddress::Ipv6(Ipv6Address::UNSPECIFIED)),
+            socket.send_slice(b"abcdef", IpAddress::V6(Ipv6Address::UNSPECIFIED)),
             Err(SendError::Unaddressable)
         );
         assert_eq!(socket.send_slice(b"abcdef", REMOTE_IPV6.into()), Ok(()));

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -624,11 +624,11 @@ mod test {
             const OTHER_ADDR: IpvXAddress = IpvXAddress::new(192, 168, 1, 3);
 
             const LOCAL_END: IpEndpoint = IpEndpoint {
-                addr: IpAddress::Ipv4(LOCAL_ADDR),
+                addr: IpAddress::V4(LOCAL_ADDR),
                 port: LOCAL_PORT,
             };
             const REMOTE_END: IpEndpoint = IpEndpoint {
-                addr: IpAddress::Ipv4(REMOTE_ADDR),
+                addr: IpAddress::V4(REMOTE_ADDR),
                 port: REMOTE_PORT,
             };
         } else {
@@ -641,11 +641,11 @@ mod test {
             const OTHER_ADDR: IpvXAddress = IpvXAddress::new(0xfe80, 0, 0, 0, 0, 0, 0, 3);
 
             const LOCAL_END: IpEndpoint = IpEndpoint {
-                addr: IpAddress::Ipv6(LOCAL_ADDR),
+                addr: IpAddress::V6(LOCAL_ADDR),
                 port: LOCAL_PORT,
             };
             const REMOTE_END: IpEndpoint = IpEndpoint {
-                addr: IpAddress::Ipv6(REMOTE_ADDR),
+                addr: IpAddress::V6(REMOTE_ADDR),
                 port: REMOTE_PORT,
             };
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -27,10 +27,16 @@ pub(crate) fn setup<'a>(medium: Medium) -> (Interface, SocketSet<'a>, TestingDev
     {
         iface.update_ip_addrs(|ip_addrs| {
             ip_addrs
-                .push(IpCidr::new(IpAddress::v4(192, 168, 1, 1), 24))
+                .push(IpCidr::new(
+                    IpAddress::V4(Ipv4Address::new(192, 168, 1, 1)),
+                    24,
+                ))
                 .unwrap();
             ip_addrs
-                .push(IpCidr::new(IpAddress::v4(127, 0, 0, 1), 8))
+                .push(IpCidr::new(
+                    IpAddress::V4(Ipv4Address::new(127, 0, 0, 1)),
+                    8,
+                ))
                 .unwrap();
         });
     }
@@ -39,13 +45,22 @@ pub(crate) fn setup<'a>(medium: Medium) -> (Interface, SocketSet<'a>, TestingDev
     {
         iface.update_ip_addrs(|ip_addrs| {
             ip_addrs
-                .push(IpCidr::new(IpAddress::v6(0xfe80, 0, 0, 0, 0, 0, 0, 1), 64))
+                .push(IpCidr::new(
+                    IpAddress::V6(Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)),
+                    64,
+                ))
                 .unwrap();
             ip_addrs
-                .push(IpCidr::new(IpAddress::v6(0, 0, 0, 0, 0, 0, 0, 1), 128))
+                .push(IpCidr::new(
+                    IpAddress::V6(Ipv6Address::new(0, 0, 0, 0, 0, 0, 0, 1)),
+                    128,
+                ))
                 .unwrap();
             ip_addrs
-                .push(IpCidr::new(IpAddress::v6(0xfdbe, 0, 0, 0, 0, 0, 0, 1), 64))
+                .push(IpCidr::new(
+                    IpAddress::V6(Ipv6Address::new(0xfdbe, 0, 0, 0, 0, 0, 0, 1)),
+                    64,
+                ))
                 .unwrap();
         });
     }

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -181,8 +181,9 @@ pub use self::ieee802154::{
 pub use self::ip::{
     Address as IpAddress, Cidr as IpCidr, Endpoint as IpEndpoint,
     ListenEndpoint as IpListenEndpoint, Protocol as IpProtocol, Repr as IpRepr,
-    Version as IpVersion,
 };
+
+pub(crate) use self::ip::{AddressExt as IpAddressExt, Version as IpVersion};
 
 #[cfg(feature = "proto-ipv4")]
 pub use self::ipv4::{

--- a/src/wire/udp.rs
+++ b/src/wire/udp.rs
@@ -234,7 +234,7 @@ impl Repr {
             match (src_addr, dst_addr) {
                 // ... except on UDP-over-IPv4, where it can be omitted.
                 #[cfg(feature = "proto-ipv4")]
-                (&IpAddress::Ipv4(_), &IpAddress::Ipv4(_)) if packet.checksum() == 0 => (),
+                (&IpAddress::V4(_), &IpAddress::V4(_)) if packet.checksum() == 0 => (),
                 _ => return Err(Error),
             }
         }


### PR DESCRIPTION
Similar to what was done for Ipv4Address and Ipv6Address.

- use core::net::IpAddr as the ip address type
- remote v4() and v6() constructor, use core IpAddr::V4(Ipv4Addr::new(_)) instead
- Remove IpVersion from public API