### PR TITLE
add a getter method for TCP listen_endpoint

### DIFF
--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -793,6 +793,12 @@ impl<'a> Socket<'a> {
         self.hop_limit = hop_limit
     }
 
+    /// Return the listen endpoint
+    #[inline]
+    pub fn listen_endpoint(&self) -> IpListenEndpoint {
+        self.listen_endpoint
+    }
+
     /// Return the local endpoint, or None if not connected.
     #[inline]
     pub fn local_endpoint(&self) -> Option<IpEndpoint> {


### PR DESCRIPTION
Currently there is no way to query a TCP socket about which address it listens on.
This seems in-line (pun intended) with the `remote_endpoint()` and `local_endpoint()` getters.