### PR TITLE
Fix the error of specific length IP packets not being fragmented

### DIFF
--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -1201,7 +1201,7 @@ impl InterfaceInner {
             #[cfg(feature = "proto-ipv4")]
             IpRepr::Ipv4(repr) => {
                 // If we have an IPv4 packet, then we need to check if we need to fragment it.
-                if total_ip_len > self.caps.max_transmission_unit {
+                if total_ip_len > self.caps.ip_mtu() {
                     #[cfg(feature = "proto-ipv4-fragmentation")]
                     {
                         net_debug!("start fragmentation");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub mod config {
     pub const DNS_MAX_NAME_SIZE: usize = 255;
     pub const DNS_MAX_RESULT_COUNT: usize = 1;
     pub const DNS_MAX_SERVER_COUNT: usize = 1;
-    pub const FRAGMENTATION_BUFFER_SIZE: usize = 1500;
+    pub const FRAGMENTATION_BUFFER_SIZE: usize = 4096;
     pub const IFACE_MAX_ADDR_COUNT: usize = 8;
     pub const IFACE_MAX_MULTICAST_GROUP_COUNT: usize = 4;
     pub const IFACE_MAX_ROUTE_COUNT: usize = 4;


### PR DESCRIPTION
There is an obvious mistake at `src/iface/interface/mod.rs:1204`:  `total_ip_len` represents the length of the IP packet, while `self.caps.max_transmission_unit` is the max length of link-layer packets. The correct comparison should be with self.caps.ip_mtu(). 

When using Medium Ethernet, since `self.caps.max_transmission_unit` is 14 octets larger than `self.caps.ip_mtu()`, IP packets with length of 1501~1514 octets should be fragmented, but mistakenly entered the non-fragment branch.

Additionally, I added a test case sending IPv4 packets of different lengths, which can trigger this error.