### PR TITLE
 feat: Automatically join solicited-node multicast addresses 

### DIFF
--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -361,7 +361,12 @@ impl Interface {
     pub fn update_ip_addrs<F: FnOnce(&mut Vec<IpCidr, IFACE_MAX_ADDR_COUNT>)>(&mut self, f: F) {
         f(&mut self.inner.ip_addrs);
         InterfaceInner::flush_neighbor_cache(&mut self.inner);
-        InterfaceInner::check_ip_addrs(&self.inner.ip_addrs)
+        InterfaceInner::check_ip_addrs(&self.inner.ip_addrs);
+
+        #[cfg(all(feature = "proto-ipv6", feature = "multicast"))]
+        if self.inner.caps.medium == Medium::Ethernet {
+            self.update_solicited_node_groups();
+        }
     }
 
     /// Check whether the interface has the given IP address assigned.

--- a/src/iface/interface/multicast.rs
+++ b/src/iface/interface/multicast.rs
@@ -164,15 +164,8 @@ impl Interface {
             .multicast
             .groups
             .keys()
-            .filter_map(|group_addr| match group_addr {
-                IpAddress::Ipv6(address)
-                    if address.is_solicited_node_multicast()
-                        && !self.inner.has_solicited_node(*address) =>
-                {
-                    Some(*group_addr)
-                }
-                _ => None,
-            })
+            .cloned()
+            .filter(|a| matches!(a, IpAddress::Ipv6(a) if a.is_solicited_node_multicast() && !self.inner.has_solicited_node(*a)))
             .collect();
         for removal in removals {
             let _ = self.leave_multicast_group(removal);

--- a/src/iface/interface/multicast.rs
+++ b/src/iface/interface/multicast.rs
@@ -167,7 +167,7 @@ impl Interface {
             .filter_map(|group_addr| match group_addr {
                 IpAddress::Ipv6(address)
                     if address.is_solicited_node_multicast()
-                        && self.inner.has_solicited_node(*address) =>
+                        && !self.inner.has_solicited_node(*address) =>
                 {
                     Some(*group_addr)
                 }

--- a/src/iface/interface/tests/ipv6.rs
+++ b/src/iface/interface/tests/ipv6.rs
@@ -1420,15 +1420,12 @@ fn test_handle_valid_multicast_query(#[case] medium: Medium) {
 
     let mut eth_bytes = vec![0u8; 86];
 
-    let local_ip_addr = Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 101);
+    let local_ip_addr = Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
     let remote_ip_addr = Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 100);
     let remote_hw_addr = EthernetAddress([0x52, 0x54, 0x00, 0x00, 0x00, 0x00]);
     let query_ip_addr = Ipv6Address::new(0xff02, 0, 0, 0, 0, 0, 0, 0x1234);
 
     iface.join_multicast_group(query_ip_addr).unwrap();
-    iface
-        .join_multicast_group(local_ip_addr.solicited_node())
-        .unwrap();
 
     iface.poll(timestamp, &mut device, &mut sockets);
     // flush multicast reports from the join_multicast_group calls
@@ -1439,7 +1436,7 @@ fn test_handle_valid_multicast_query(#[case] medium: Medium) {
         (
             Ipv6Address::UNSPECIFIED,
             IPV6_LINK_LOCAL_ALL_NODES,
-            vec![query_ip_addr, local_ip_addr.solicited_node()],
+            vec![local_ip_addr.solicited_node(), query_ip_addr],
         ),
         // Address specific query, expect only the queried address back
         (query_ip_addr, query_ip_addr, vec![query_ip_addr]),


### PR DESCRIPTION
IPv6 over Ethernet should join the solicited-node multicast
addresses required by the configured IPv6 addresses, as neighbor
solicitations for these addresses have the solicited-node multicast
address as destination address.

This commit automatically leaves old solicited-node multicast addresses
and joins the new set when the IP addresses on the interface are
updated.
