### PR TITLE
rustfmt fails new PRs

### DIFF
--- a/src/phy/fault_injector.rs
+++ b/src/phy/fault_injector.rs
@@ -196,10 +196,12 @@ impl<D: Device> FaultInjector<D> {
 }
 
 impl<D: Device> Device for FaultInjector<D> {
-    type RxToken<'a> = RxToken<'a>
+    type RxToken<'a>
+        = RxToken<'a>
     where
         Self: 'a;
-    type TxToken<'a> = TxToken<'a, D::TxToken<'a>>
+    type TxToken<'a>
+        = TxToken<'a, D::TxToken<'a>>
     where
         Self: 'a;
 

--- a/src/phy/fuzz_injector.rs
+++ b/src/phy/fuzz_injector.rs
@@ -47,10 +47,12 @@ where
     FTx: Fuzzer,
     FRx: Fuzzer,
 {
-    type RxToken<'a> = RxToken<'a, D::RxToken<'a>, FRx>
+    type RxToken<'a>
+        = RxToken<'a, D::RxToken<'a>, FRx>
     where
         Self: 'a;
-    type TxToken<'a> = TxToken<'a, D::TxToken<'a>, FTx>
+    type TxToken<'a>
+        = TxToken<'a, D::TxToken<'a>, FTx>
     where
         Self: 'a;
 

--- a/src/phy/pcap_writer.rs
+++ b/src/phy/pcap_writer.rs
@@ -165,10 +165,12 @@ impl<D: Device, S> Device for PcapWriter<D, S>
 where
     S: PcapSink,
 {
-    type RxToken<'a> = RxToken<'a, D::RxToken<'a>, S>
+    type RxToken<'a>
+        = RxToken<'a, D::RxToken<'a>, S>
     where
         Self: 'a;
-    type TxToken<'a> = TxToken<'a, D::TxToken<'a>, S>
+    type TxToken<'a>
+        = TxToken<'a, D::TxToken<'a>, S>
     where
         Self: 'a;
 

--- a/src/phy/raw_socket.rs
+++ b/src/phy/raw_socket.rs
@@ -59,10 +59,12 @@ impl RawSocket {
 }
 
 impl Device for RawSocket {
-    type RxToken<'a> = RxToken
+    type RxToken<'a>
+        = RxToken
     where
         Self: 'a;
-    type TxToken<'a> = TxToken
+    type TxToken<'a>
+        = TxToken
     where
         Self: 'a;
 

--- a/src/phy/tracer.rs
+++ b/src/phy/tracer.rs
@@ -42,10 +42,12 @@ impl<D: Device> Tracer<D> {
 }
 
 impl<D: Device> Device for Tracer<D> {
-    type RxToken<'a> = RxToken<D::RxToken<'a>>
+    type RxToken<'a>
+        = RxToken<D::RxToken<'a>>
     where
         Self: 'a;
-    type TxToken<'a> = TxToken<D::TxToken<'a>>
+    type TxToken<'a>
+        = TxToken<D::TxToken<'a>>
     where
         Self: 'a;
 


### PR DESCRIPTION
Current PRs fail due to a `rustfmt` check, on files unrelated to them, so this PR fixes the formatting