### PR TITLE
iface: socketset missing match case when using noalloc

### DIFF
--- a/src/iface/socket_set.rs
+++ b/src/iface/socket_set.rs
@@ -81,6 +81,8 @@ impl<'a> SocketSet<'a> {
 
         match &mut self.sockets {
             ManagedSlice::Borrowed(_) => panic!("adding a socket to a full SocketSet"),
+            #[cfg(not(feature = "alloc"))]
+            ManagedSlice::Owned(_) => panic!("adding a socket to a full SocketSet"),
             #[cfg(feature = "alloc")]
             ManagedSlice::Owned(sockets) => {
                 sockets.push(SocketStorage { inner: None });


### PR DESCRIPTION
Clippy complains that not all cases are matched.