### PR TITLE
Remove ieee802154 from IphcRepr

### DIFF
--- a/src/iface/interface/sixlowpan.rs
+++ b/src/iface/interface/sixlowpan.rs
@@ -748,6 +748,7 @@ fn decompress_ext_hdr<'d>(
 }
 
 // NOTE: we always inline this function into the sixlowpan_to_ipv6 function, since it is only used there.
+#[allow(clippy::too_many_arguments)]
 #[inline(always)]
 fn decompress_udp(
     address_context: &[SixlowpanAddressContext],

--- a/src/iface/interface/tests/sixlowpan.rs
+++ b/src/iface/interface/tests/sixlowpan.rs
@@ -138,20 +138,29 @@ fn test_echo_request_sixlowpan_128_bytes() {
     let request_first_part_iphc_packet =
         SixlowpanIphcPacket::new_checked(request_first_part_packet.payload()).unwrap();
 
-    let request_first_part_iphc_repr = SixlowpanIphcRepr::parse(
-        &request_first_part_iphc_packet,
-        ieee802154_repr.src_addr,
-        ieee802154_repr.dst_addr,
-        &iface.inner.sixlowpan_address_context,
-    )
-    .unwrap();
+    let request_first_part_iphc_repr =
+        SixlowpanIphcRepr::parse(&request_first_part_iphc_packet).unwrap();
 
     assert_eq!(
-        request_first_part_iphc_repr.src_addr,
+        request_first_part_iphc_repr
+            .src_addr
+            .resolve(
+                ieee802154_repr.src_addr,
+                &iface.inner.sixlowpan_address_context,
+                request_first_part_iphc_repr.context_identifier
+            )
+            .unwrap(),
         Ipv6Address::new(0xfe80, 0, 0, 0, 0x4042, 0x4242, 0x4242, 0x0b1a),
     );
     assert_eq!(
-        request_first_part_iphc_repr.dst_addr,
+        request_first_part_iphc_repr
+            .dst_addr
+            .resolve(
+                ieee802154_repr.dst_addr,
+                &iface.inner.sixlowpan_address_context,
+                request_first_part_iphc_repr.context_identifier
+            )
+            .unwrap(),
         Ipv6Address::new(0xfe80, 0, 0, 0, 0x92fc, 0x48c2, 0xa441, 0xfc76),
     );
 

--- a/src/wire/rpl.rs
+++ b/src/wire/rpl.rs
@@ -2440,8 +2440,8 @@ mod tests {
             &mut buffer[..repr.buffer_len()],
         ));
         icmp_repr.emit(
-            &src_addr.into(),
-            &dst_addr.into(),
+            &src_addr,
+            &dst_addr,
             &mut Icmpv6Packet::new_unchecked(
                 &mut buffer[repr.buffer_len()..][..icmp_repr.buffer_len()],
             ),


### PR DESCRIPTION
First part of #1031 .

The `IphcRepr` type was written in terms of ieee802154 addresses.
I've replaced the ieee802154 address for structures that closer match the RFC and can be used on other mediums like BLE.

After this, I need to do the same for `sixlowpan/mod.rs` and move the ieee802154 bits into the `wire/ieee802154.rs` file.
