### PR TITLE
Fix compilation errors when socket-dns is enabled but socket-udp isn't

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -42,6 +42,7 @@ FEATURES_CHECK=(
     "medium-ip,medium-ethernet,medium-ieee802154,proto-ipv6,proto-ipv6,multicast,proto-dhcpv4,proto-ipsec,socket-raw,socket-udp,socket-tcp,socket-icmp,socket-dns,async"
     "defmt,medium-ip,medium-ethernet,proto-ipv6,proto-ipv6,multicast,proto-dhcpv4,socket-raw,socket-udp,socket-tcp,socket-icmp,socket-dns,async"
     "defmt,alloc,medium-ip,medium-ethernet,proto-ipv6,proto-ipv6,multicast,proto-dhcpv4,socket-raw,socket-udp,socket-tcp,socket-icmp,socket-dns,async"
+    "medium-ieee802154,proto-sixlowpan,socket-dns"
 )
 
 test() {

--- a/src/iface/packet.rs
+++ b/src/iface/packet.rs
@@ -239,7 +239,7 @@ impl<'p> IpPayload<'p> {
             Self::Igmp(_) => unreachable!(),
             #[cfg(feature = "socket-tcp")]
             Self::Tcp(_) => SixlowpanNextHeader::Uncompressed(IpProtocol::Tcp),
-            #[cfg(feature = "socket-udp")]
+            #[cfg(any(feature = "socket-udp", feature = "socket-dns"))]
             Self::Udp(..) => SixlowpanNextHeader::Compressed,
             #[cfg(feature = "socket-raw")]
             Self::Raw(_) => todo!(),


### PR DESCRIPTION
Fixes: #1040

I added a test case that would've caught this specific issue, but it likely won't catch any issues in the future. Since I couldn't come up with a better method of testing it more generally, I just left it at that. 