### PR TITLE
feat: Add initial `serde:{Deserialize, Serialize}` implementation for `Ipv[4|6]Cidr`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ bitflags = { version = "1.0", default-features = false }
 defmt = { version = "0.3.8", optional = true, features = ["ip_in_core"] }
 cfg-if = "1.0.0"
 heapless = "0.8"
+serde = { version = "1.0.217", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 env_logger = "0.10"
@@ -41,6 +42,8 @@ std = ["managed/std", "alloc"]
 alloc = ["managed/alloc", "defmt?/alloc"]
 verbose = []
 defmt = ["dep:defmt", "heapless/defmt-03"]
+# Implement serde Serialize / Deserialize
+serde = ["dep:serde", "heapless/serde"]
 "medium-ethernet" = ["socket"]
 "medium-ip" = ["socket"]
 "medium-ieee802154" = ["socket", "proto-sixlowpan"]

--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -115,6 +115,7 @@ enum ClientState {
 /// Timeout and retry configuration.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[non_exhaustive]
 pub struct RetryConfig {
     pub discover_timeout: Duration,

--- a/src/time.rs
+++ b/src/time.rs
@@ -178,6 +178,7 @@ impl ops::Sub<Instant> for Instant {
 
 /// A relative amount of time.
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Duration {
     micros: u64,
 }

--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -100,6 +100,7 @@ impl AddressExt for Address {
 /// A specification of an IPv4 CIDR block, containing an address and a variable-length
 /// subnet masking prefix length.
 #[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Cidr {
     address: Address,
     prefix_len: u8,

--- a/src/wire/ipv6.rs
+++ b/src/wire/ipv6.rs
@@ -233,6 +233,7 @@ impl AddressExt for Address {
 /// A specification of an IPv6 CIDR block, containing an address and a variable-length
 /// subnet masking prefix length.
 #[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Cidr {
     address: Address,
     prefix_len: u8,


### PR DESCRIPTION
This PR adds an initial implementation for `serde:{Deserialize, Serialize}`, in preparation for implementing those traits into `embassy-net` types. I've added the minimal required in order to be able to implement `serde:{Deserialize, Serialize}` for `embassy_net::Config`.

Since IP types are now in `core::net`, most already implement serde, and only `Ipv[4|6]Cidr` were missing an implementation. I've also added the derive for `RetryConfig` in order to work with `embassy_net::DhcpConfig`.