### PR TITLE
TunTapInterface: do not automatically enable medium-ethernet feature when phy-tuntap_interface is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ defmt = ["dep:defmt", "heapless/defmt-03"]
 "medium-ieee802154" = ["socket", "proto-sixlowpan"]
 
 "phy-raw_socket" = ["std", "libc"]
-"phy-tuntap_interface" = ["std", "libc", "medium-ethernet"]
+"phy-tuntap_interface" = ["std", "libc"]
 
 "proto-ipv4" = []
 "proto-ipv4-fragmentation" = ["proto-ipv4", "_proto-fragmentation"]

--- a/src/phy/sys/tuntap_interface.rs
+++ b/src/phy/sys/tuntap_interface.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{phy::Medium, wire::EthernetFrame};
+use crate::phy::Medium;
 use std::io;
 use std::os::unix::io::{AsRawFd, RawFd};
 
@@ -80,7 +80,7 @@ impl TunTapInterfaceDesc {
             #[cfg(feature = "medium-ip")]
             Medium::Ip => ip_mtu,
             #[cfg(feature = "medium-ethernet")]
-            Medium::Ethernet => ip_mtu + EthernetFrame::<&[u8]>::header_len(),
+            Medium::Ethernet => ip_mtu + crate::wire::EthernetFrame::<&[u8]>::header_len(),
             #[cfg(feature = "medium-ieee802154")]
             Medium::Ieee802154 => todo!(),
         };


### PR DESCRIPTION
`TunTapInterface` can work in TUN L3 mode which does not require `medium-ethernet` feature. `TunTapInterface` already mostly respects `medium-ethernet` feature flag and enables relevant TAP L2 functionality only when `medium-ethernet` is enabled.

However, in Cargo.toml features configuration automatically enables `medium-ethernet` feature when `phy-tuntap_interface` feature is enabled, making it impossible to opt-out of Ether support when using TUN L3 interfaces.

In this change I'm updating Cargo.toml to not enable `medium-ethernet` feature when `phy-tuntap_interface` feature is enabled. With this change `phy-tuntap_interface` supports TUN L3 interfaces only by default. Users who want to use TAP L2 interfaces have to enable the support by enabling `medium-ethernet` in addition to `phy-tuntap_interface`

I confirmed that build passes in configuration where `phy-tuntap_interface` is enabled but `medium-ethernet` is not:

```
cargo build --no-default-features --features medium-ip,proto-ipv4,socket-tcp,phy-tuntap_interface
```