### PR TITLE
tcp: Don't accept RST packets on listening sockets

### DIFF
--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1513,10 +1513,12 @@ impl<'a> Socket<'a> {
             return false;
         }
 
-        // If we're still listening for SYNs and the packet has an ACK, it cannot
-        // be destined to this socket, but another one may well listen on the same
-        // local endpoint.
-        if self.state == State::Listen && repr.ack_number.is_some() {
+        // If we're still listening for SYNs and the packet has an ACK or a RST,
+        // it cannot be destined to this socket, but another one may well listen
+        // on the same local endpoint.
+        if self.state == State::Listen
+            && (repr.ack_number.is_some() || repr.control == TcpControl::Rst)
+        {
             return false;
         }
 

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -3286,15 +3286,13 @@ mod test {
     #[test]
     fn test_listen_rst() {
         let mut s = socket_listen();
-        send!(
-            s,
-            TcpRepr {
-                control: TcpControl::Rst,
-                seq_number: REMOTE_SEQ,
-                ack_number: None,
-                ..SEND_TEMPL
-            }
-        );
+        let tcp_repr = TcpRepr {
+            control: TcpControl::Rst,
+            seq_number: REMOTE_SEQ,
+            ack_number: None,
+            ..SEND_TEMPL
+        };
+        assert!(!s.socket.accepts(&mut s.cx, &SEND_IP_TEMPL, &tcp_repr));
         assert_eq!(s.state, State::Listen);
     }
 


### PR DESCRIPTION
I ran into the following sequence of events:

- Two TCP sockets are open to a remote host.
- The remote host closes its end of both connections.
- The application tries to write some data to socket 1.
    - The remote host replies with an RST.
    - Socket 1 closes.
    - The application places Socket 1 in listening mode so it can accept a new connection.
- The application tries to write some data to socket 2.
    - The remote host replies with an RST.
    - Socket 1 accepts and discards the RST, because:
        - The packet's destination address and port matches.
        - Socket 1 is in listening mode, so it has no source address and port to compare.
        - The RST packet does not have the ACK flag set, because the remote host does not consider the data packets it recieved to be associated with an open connection.
    - Since socket 1 accepted the RST, it is not delivered to socket 2.
    - Socket 2 eventually retransmits its data packet, and the remote host replies with another RST which is again eaten by socket 1. This repeats indefinitely.

To fix this: a listening socket should not accept a RST packet [that is just going to be ignored anyway](https://github.com/smoltcp-rs/smoltcp/blob/242e02c8400d7419f1fe88986ca515871a8b9f17/src/socket/tcp.rs#L1794). This allows the packet to be delivered to the correct socket, or [discarded at the iface level](https://github.com/smoltcp-rs/smoltcp/blob/242e02c8400d7419f1fe88986ca515871a8b9f17/src/iface/interface/tcp.rs#L32) if the RST packet does not match any active connection.