### PR TITLE
Reuse server DHCPOFFER transaction id in DHCPREQUEST

### DIFF
--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -574,13 +574,9 @@ impl<'a> Socket<'a> {
         // 0x0f * 4 = 60 bytes.
         const MAX_IPV4_HEADER_LEN: usize = 60;
 
-        // We don't directly modify self.transaction_id because sending the packet
-        // may fail. We only want to update state after successfully sending.
-        let next_transaction_id = Self::random_transaction_id(cx);
-
         let mut dhcp_repr = DhcpRepr {
             message_type: DhcpMessageType::Discover,
-            transaction_id: next_transaction_id,
+            transaction_id: self.transaction_id,
             secs: 0,
             client_hardware_address: ethernet_addr,
             client_ip: Ipv4Address::UNSPECIFIED,
@@ -624,6 +620,9 @@ impl<'a> Socket<'a> {
                     return Ok(());
                 }
 
+                let next_transaction_id = Self::random_transaction_id(cx);
+                dhcp_repr.transaction_id = next_transaction_id;
+
                 // send packet
                 net_debug!(
                     "DHCP send DISCOVER to {}: {:?}",
@@ -652,7 +651,6 @@ impl<'a> Socket<'a> {
                 dhcp_repr.message_type = DhcpMessageType::Request;
                 dhcp_repr.requested_ip = Some(state.requested_ip);
                 dhcp_repr.server_identifier = Some(state.server.identifier);
-                dhcp_repr.transaction_id = self.transaction_id;
 
                 net_debug!(
                     "DHCP send request to {}: {:?}",
@@ -691,6 +689,9 @@ impl<'a> Socket<'a> {
                 }
                 dhcp_repr.message_type = DhcpMessageType::Request;
                 dhcp_repr.client_ip = state.config.address.address();
+
+                let next_transaction_id = Self::random_transaction_id(cx);
+                dhcp_repr.transaction_id = next_transaction_id;
 
                 net_debug!("DHCP send renew to {}: {:?}", ipv4_repr.dst_addr, dhcp_repr);
                 ipv4_repr.payload_len = udp_repr.header_len() + dhcp_repr.buffer_len();

--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -72,8 +72,6 @@ struct RequestState {
     server: ServerInfo,
     /// IP address that we're trying to request.
     requested_ip: Ipv4Address,
-    /// Transaction ID from server's `Offer` message
-    offer_transaction_id: u32,
 }
 
 #[derive(Debug)]
@@ -381,7 +379,6 @@ impl<'a> Socket<'a> {
                         identifier: server_identifier,
                     },
                     requested_ip: dhcp_repr.your_ip, // use the offered ip
-                    offer_transaction_id: dhcp_repr.transaction_id,
                 });
             }
             (ClientState::Requesting(state), DhcpMessageType::Ack) => {
@@ -655,7 +652,7 @@ impl<'a> Socket<'a> {
                 dhcp_repr.message_type = DhcpMessageType::Request;
                 dhcp_repr.requested_ip = Some(state.requested_ip);
                 dhcp_repr.server_identifier = Some(state.server.identifier);
-                dhcp_repr.transaction_id = state.offer_transaction_id;
+                dhcp_repr.transaction_id = self.transaction_id;
 
                 net_debug!(
                     "DHCP send request to {}: {:?}",
@@ -670,7 +667,6 @@ impl<'a> Socket<'a> {
                     + (self.retry_config.initial_request_timeout << (state.retry as u32 / 2));
                 state.retry += 1;
 
-                self.transaction_id = state.offer_transaction_id;
                 Ok(())
             }
             ClientState::Renewing(state) => {


### PR DESCRIPTION
Hello! From my understanding of the DHCP specification [rfc2131](https://datatracker.ietf.org/doc/html/rfc2131) smoltcp currently does not follow the specification when it comes to the `transaction id` used for DHCPREQUEST messages. I initially saw this mentioned in a discussion here https://github.com/esp-rs/esp-hal/discussions/2345#discussioncomment-11179188.

If I understand the spec. correctly, when a DHCPOFFER is received from a server, the follow-up DHCPREQUEST should reuse the `transaction id` from the DHCPOFFER message. Currently a new random `transaction id`is used for the request instead. 

The relevant parts of the RFC is Table 5 and the text just after it (page 36-37).

I have only been able to test this on my home setup so far but it seems to work as expected there at least. I'm not sure how to add a proper test for this or if the change might interact with retries in some way that needs additional handling.