### PR TITLE
Pin dev-dependencies `idna` to a version that compiles on 1.81 to fix CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ url = "2.0"
 rstest = "0.17"
 insta = "1.41.1"
 rand_chacha = "0.3.1"
+idna = { version = "=1.0.1" }
 
 [features]
 std = ["managed/std", "alloc"]


### PR DESCRIPTION
See title

Versions of `idna >= 1.0.2` pull in newer versions of the `icu` crates that no longer compile on `1.81`. `idna` is a transient dependency, pulled in through `url`.

Usually, pinning a version like this is _not_ a solution.  However, this is only a test dependency (which can, IIUC, never be depended on by others) it is probably fine.