### PR TITLE
Single frame ingress to make custom Layer 2 protocols possible

### DIFF
--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -522,6 +522,8 @@ impl Interface {
         self.socket_ingress(device, sockets)
     }
 
+    /// Allows user to just ingress a single frame
+    /// This can be useful if TCP/IP stack is being used in combination with Layer 2 protocols
     pub fn poll_ingress_single_frame(
         &mut self,
         timestamp: Instant,
@@ -588,8 +590,6 @@ impl Interface {
         }
     }
 
-    /// Allows user to just ingress a single frame
-    /// This can be useful if Smoltcp is being used in combination with Layer 2 protocols
     fn ingress_single_frame(
         &mut self,
         tx_token: impl TxToken,


### PR DESCRIPTION
This is an idea how to make it simpler for users to handle non-IP packets externally, without passing though Smoltcp. This is just an Idea, how I implemented a quick and dirty fix for my problem.

https://github.com/smoltcp-rs/smoltcp/issues/942


```rust
pub fn poll(/*...*/) {
    // instead of using
    // iface.poll(now(), &mut &mut device, &mut sockets);
    // Only IP packets are getting passed to the TCP/IP stack

    let mut f = || {
        let Some((rx_token, tx_token)) = device.receive(now()) else {
            return PollIngressSingleResult::None;
        };

        let rx_meta = rx_token.meta();
        rx_token.consume(|frame| {
            if frame[12..12 + 2] == [0x88, 0xf7] { // filter out L2 traffic I want
                defmt::info!("PACKET {:x}", frame);
                return PollIngressSingleResult::PacketProcessed;
            }
           iface
                .poll_ingress_single_frame(&mut sockets, rx_meta, frame, tx_token)
        })
    };

    loop {
        match f() {
            PollIngressSingleResult::None => break,
            PollIngressSingleResult::PacketProcessed => {}
            PollIngressSingleResult::SocketStateChanged => {}
        }
    }
    // Process egress.
    match iface.poll_egress(now(), &mut &mut device, &mut sockets)
    {
        PollResult::None => {}
        PollResult::SocketStateChanged => {}
    }
}
```

Another possibility could be to add a closure for each frame received:
```rust
iface.poll_egress_frame(now(), &mut dma, &mut sockets, |frame| {
   if frame[12..12 + 2] == [0x88, 0xf7] {
      defmt::info!("PACKET {:x}", frame);
      return PollIngressSingleResult::PacketProcessed;
   }
   PollIngressSingleResult::None
})
```

It should also be possible to write a wrapper `impl Device` type, that makes L2 protocols possible, although I don't see an elegant way of implementing this without copying. 

Yet another option would be to outsource this problem to the drivers, and add `peek` support to the drivers.

What do you think?
 