### PR TITLE
Improve IPv4 source address selection for multi-subnet interfaces

### DIFF
--- a/src/iface/interface/ipv4.rs
+++ b/src/iface/interface/ipv4.rs
@@ -38,17 +38,27 @@ impl InterfaceInner {
 
     /// Get an IPv4 source address based on a destination address.
     ///
-    /// **NOTE**: unlike for IPv6, no specific selection algorithm is implemented. The first IPv4
-    /// address from the interface is returned.
+    /// This function tries to find the first IPv4 address from the interface
+    /// that is in the same subnet as the destination address. If no such
+    /// address is found, the first IPv4 address from the interface is returned.
     #[allow(unused)]
-    pub(crate) fn get_source_address_ipv4(&self, _dst_addr: &Ipv4Address) -> Option<Ipv4Address> {
+    pub(crate) fn get_source_address_ipv4(&self, dst_addr: &Ipv4Address) -> Option<Ipv4Address> {
+        let mut first_ipv4 = None;
         for cidr in self.ip_addrs.iter() {
             #[allow(irrefutable_let_patterns)] // if only ipv4 is enabled
             if let IpCidr::Ipv4(cidr) = cidr {
-                return Some(cidr.address());
+                // Return immediately if we find an address in the same subnet
+                if cidr.contains_addr(dst_addr) {
+                    return Some(cidr.address());
+                }
+
+                // Remember the first IPv4 address as fallback
+                if first_ipv4.is_none() {
+                    first_ipv4 = Some(cidr.address());
+                }
             }
         }
-        None
+        first_ipv4
     }
 
     /// Checks if an address is broadcast, taking into account ipv4 subnet-local

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -333,15 +333,18 @@ impl Interface {
         self.inner.ipv6_addr()
     }
 
-    /// Get an address from the interface that could be used as source address. For IPv4, this is
-    /// the first IPv4 address from the list of addresses. For IPv6, the address is based on the
-    /// destination address and uses RFC6724 for selecting the source address.
+    /// Get an address from the interface that could be used as source address.
+    /// For IPv4, this function tries to find a registered IPv4 address in the same
+    /// subnet as the destination, falling back to the first IPv4 address if none is
+    /// found. For IPv6, the selection is based on RFC6724.
     pub fn get_source_address(&self, dst_addr: &IpAddress) -> Option<IpAddress> {
         self.inner.get_source_address(dst_addr)
     }
 
-    /// Get an address from the interface that could be used as source address. This is the first
-    /// IPv4 address from the list of addresses in the interface.
+    /// Get an IPv4 source address based on a destination address. This function tries
+    /// to find the first IPv4 address from the interface that is in the same subnet as
+    /// the destination address. If no such address is found, the first IPv4 address
+    /// from the interface is returned.
     #[cfg(feature = "proto-ipv4")]
     pub fn get_source_address_ipv4(&self, dst_addr: &Ipv4Address) -> Option<Ipv4Address> {
         self.inner.get_source_address_ipv4(dst_addr)

--- a/src/iface/interface/tests/ipv4.rs
+++ b/src/iface/interface/tests/ipv4.rs
@@ -1129,12 +1129,12 @@ fn get_source_address(#[case] medium: Medium) {
     });
 
     // List of addresses we test:
-    //   172.18.1.255 -> 172.18.1.2
+    //   172.18.1.254 -> 172.18.1.2
     //   172.24.24.12 -> 172.24.24.14
-    //   172.24.23.255 -> 172.18.1.2
-    const UNIQUE_LOCAL_ADDR1: Ipv4Address = Ipv4Address::new(172, 18, 1, 255);
+    //   172.24.23.254 -> 172.18.1.2
+    const UNIQUE_LOCAL_ADDR1: Ipv4Address = Ipv4Address::new(172, 18, 1, 254);
     const UNIQUE_LOCAL_ADDR2: Ipv4Address = Ipv4Address::new(172, 24, 24, 12);
-    const UNIQUE_LOCAL_ADDR3: Ipv4Address = Ipv4Address::new(172, 24, 23, 255);
+    const UNIQUE_LOCAL_ADDR3: Ipv4Address = Ipv4Address::new(172, 24, 23, 254);
 
     assert_eq!(
         iface.inner.get_source_address_ipv4(&UNIQUE_LOCAL_ADDR1),
@@ -1162,12 +1162,12 @@ fn get_source_address_empty_interface(#[case] medium: Medium) {
     iface.update_ip_addrs(|ips| ips.clear());
 
     // List of addresses we test:
-    //   172.18.1.255 -> None
+    //   172.18.1.254 -> None
     //   172.24.24.12 -> None
-    //   172.24.23.255 -> None
-    const UNIQUE_LOCAL_ADDR1: Ipv4Address = Ipv4Address::new(172, 18, 1, 255);
+    //   172.24.23.254 -> None
+    const UNIQUE_LOCAL_ADDR1: Ipv4Address = Ipv4Address::new(172, 18, 1, 254);
     const UNIQUE_LOCAL_ADDR2: Ipv4Address = Ipv4Address::new(172, 24, 24, 12);
-    const UNIQUE_LOCAL_ADDR3: Ipv4Address = Ipv4Address::new(172, 24, 23, 255);
+    const UNIQUE_LOCAL_ADDR3: Ipv4Address = Ipv4Address::new(172, 24, 23, 254);
 
     assert_eq!(
         iface.inner.get_source_address_ipv4(&UNIQUE_LOCAL_ADDR1),

--- a/src/iface/interface/tests/ipv6.rs
+++ b/src/iface/interface/tests/ipv6.rs
@@ -989,6 +989,7 @@ fn get_source_address() {
     //   fd00::201:1:1:1:1 -> fd00::201:1:1:1:2
     //   fd01::201:1:1:1:1 -> fd01::201:1:1:1:2
     //   fd02::201:1:1:1:1 -> fd00::201:1:1:1:2 (because first added in the list)
+    //   fd01::201:1:1:1:3 -> fd01::201:1:1:1:2 (because in same subnet)
     //   ff02::1           -> fe80::1 (same scope)
     //   2001:db8:3::2     -> 2001:db8:3::1
     //   2001:db9:3::2     -> 2001:db8:3::1
@@ -996,6 +997,7 @@ fn get_source_address() {
     const UNIQUE_LOCAL_ADDR1: Ipv6Address = Ipv6Address::new(0xfd00, 0, 0, 201, 1, 1, 1, 1);
     const UNIQUE_LOCAL_ADDR2: Ipv6Address = Ipv6Address::new(0xfd01, 0, 0, 201, 1, 1, 1, 1);
     const UNIQUE_LOCAL_ADDR3: Ipv6Address = Ipv6Address::new(0xfd02, 0, 0, 201, 1, 1, 1, 1);
+    const UNIQUE_LOCAL_ADDR4: Ipv6Address = Ipv6Address::new(0xfd01, 0, 0, 201, 1, 1, 1, 3);
     const GLOBAL_UNICAST_ADDR1: Ipv6Address =
         Ipv6Address::new(0x2001, 0x0db8, 0x0003, 0, 0, 0, 0, 2);
     const GLOBAL_UNICAST_ADDR2: Ipv6Address =
@@ -1021,6 +1023,10 @@ fn get_source_address() {
     assert_eq!(
         iface.inner.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR3),
         OWN_UNIQUE_LOCAL_ADDR1
+    );
+    assert_eq!(
+        iface.inner.get_source_address_ipv6(&UNIQUE_LOCAL_ADDR4),
+        OWN_UNIQUE_LOCAL_ADDR2
     );
     assert_eq!(
         iface


### PR DESCRIPTION
## Improve IPv4 source address selection for multi-subnet interfaces

### Problem

When an interface has multiple IPv4 addresses in different subnets, the current implementation always returns the first IPv4 address as the source address, regardless of the destination. This causes issues in multi-homed configurations where the interface serves multiple networks.

I encountered this issue with a setup where I registered an interface like this:
```rust
let first_ip = Ipv4Cidr::new(Ipv4Addr::new(172, 18, 1, 2), 24);
let second_ip = Ipv4Cidr::new(Ipv4Addr::new(172, 24, 24, 14), 24);

let mut interface = Interface::new(interface_config, &mut device, now);
interface.update_ip_addrs(|a| {
    a.push(first_ip.into()).unwrap();
    a.push(second_ip.into()).unwrap();
});
```

When a smoltcp socket attempts to send a packet to a device on the `172.24.24.0/24` network, the initial ARP packets that were sent were being sent with the wrong source IP (`172.18.1.2` instead of `172.24.24.14`). This caused the remote device to ignore the ARP requests since they appeared to come from a different network, causing the packet to never be sent.

### Solution

This PR enhances the IPv4 source address selection algorithm to be subnet-aware. The new implementation:

1. First attempts to find an interface address that is in the same subnet as the destination address
2. Falls back to the first IPv4 address if no matching subnet is found (preserving backward compatibility)

### Changes

- Modified `get_source_address_ipv4()` in `src/iface/interface/ipv4.rs` to iterate through all interface addresses and check if they're in the same subnet as the destination
- Updated documentation to reflect the new subnet-aware behavior
- The change maintains backward compatibility - if no subnet match is found, it returns the first IPv4 address as before

Now when communicating with a device at `172.24.24.100`, the source address will correctly be `172.24.24.14` instead of `172.18.1.2`.