### PR TITLE
Fix panic in raw socket fragmentation when payload buffer exceeds packet size

### DIFF
--- a/src/iface/packet.rs
+++ b/src/iface/packet.rs
@@ -130,7 +130,10 @@ impl<'p> Packet<'p> {
             }
 
             #[cfg(feature = "socket-raw")]
-            IpPayload::Raw(raw_packet) => payload.copy_from_slice(raw_packet),
+            IpPayload::Raw(raw_packet) => {
+                let len = raw_packet.len();
+                payload[..len].copy_from_slice(raw_packet)
+            }
             #[cfg(any(feature = "socket-udp", feature = "socket-dns"))]
             IpPayload::Udp(udp_repr, inner_payload) => udp_repr.emit(
                 &mut UdpPacket::new_unchecked(payload),


### PR DESCRIPTION
## Summary

This PR fixes a panic that occurs when fragmenting raw socket packets. The panic happens when the packet that is being sent is larger than the MTU, and is not exactly the same size as the fragmentation buffer, causing `copy_from_slice` to fail with mismatched slice lengths.

## Bug Details

When a raw socket packet requires fragmentation (packet size > MTU), the following sequence occurs:

1. In `InterfaceInner::dispatch_ip()`, the fragmentation path is entered when `total_ip_len > self.caps.ip_mtu()`

https://github.com/smoltcp-rs/smoltcp/blob/a54589cd9596bd23884ccddc529dfbcdae188c96/src/iface/interface/mod.rs#L1212-L1281

2. The code calls `emit_ip(&ip_repr, &mut frag.buffer)` to emit the packet into the fragmentation buffer

https://github.com/smoltcp-rs/smoltcp/blob/a54589cd9596bd23884ccddc529dfbcdae188c96/src/iface/interface/mod.rs#L1251

4. Inside `emit_ip`, after emitting the IP header, it passes the remaining fragmentation buffer to `emit_payload`:

https://github.com/smoltcp-rs/smoltcp/blob/a54589cd9596bd23884ccddc529dfbcdae188c96/src/iface/interface/mod.rs#L1200-L1205

5. For raw sockets, `emit_payload` attempts to copy the entire raw packet into the fragmentation buffer "payload":

https://github.com/smoltcp-rs/smoltcp/blob/a54589cd9596bd23884ccddc529dfbcdae188c96/src/iface/packet.rs#L132-L133

The issue is that `raw_packet` can be much smaller than `payload`, since the payload is the fragmentation buffer . For example:
- Fragmentation buffer size: 8192 bytes
- IP header size: 20 bytes  
- Resulting payload buffer: 8172 bytes
- Packet size: 4136 bytes (or any amount greater than the MTU and not equal to the fragmentation buffer size)

This mismatch causes `copy_from_slice` to panic with:
```
copy_from_slice: source slice length (4136) does not match destination slice length (8172)
```

## Fix

The fix ensures we only write to the portion of the destination buffer that matches the source size:
```rust
IpPayload::Raw(raw_packet) => {
    let len = raw_packet.len();
    payload[..len].copy_from_slice(raw_packet)
}
```

This prevents the panic while maintaining the same behavior - the raw packet data is copied to the beginning of the payload buffer, and any remaining buffer space is left untouched.

## Testing

This fix has been tested with raw socket packets that require fragmentation and no longer causes panics when the fragmentation buffer is larger than the packet payload.