### PR TITLE
tcp: Reject bytes outside the receive window

### DIFF
--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -6794,6 +6794,74 @@ mod test {
     }
 
     #[test]
+    fn test_recv_out_of_recv_win() {
+        let mut s = socket_established();
+        s.set_ack_delay(Some(ACK_DELAY_DEFAULT));
+        s.remote_mss = 32;
+
+        // No ACKs are sent due to the ACK delay.
+        send!(
+            s,
+            TcpRepr {
+                control: TcpControl::Psh,
+                seq_number: REMOTE_SEQ + 1,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &[0; 32],
+                ..SEND_TEMPL
+            }
+        );
+        recv_nothing!(s);
+
+        // RMSS+1 bytes of data has been received, so ACK is sent without delay.
+        send!(
+            s,
+            TcpRepr {
+                control: TcpControl::Psh,
+                seq_number: REMOTE_SEQ + 33,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &[0; 1],
+                ..SEND_TEMPL
+            }
+        );
+        recv!(
+            s,
+            Ok(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 34),
+                window_len: 31,
+                ..RECV_TEMPL
+            })
+        );
+
+        // This frees up a byte in the receive buffer. However, the remote shouldn't be aware of
+        // this since no ACKs are sent.
+        s.recv_slice(&mut [0; 1]).unwrap();
+        recv_nothing!(s);
+
+        // Now, if the remote wants to send one byte outside of the receive window that we
+        // previously advertised, it should not succeed.
+        send!(
+            s,
+            TcpRepr {
+                control: TcpControl::Psh,
+                seq_number: REMOTE_SEQ + 34,
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &[0; 32],
+                ..SEND_TEMPL
+            }
+        );
+        recv!(
+            s,
+            Ok(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(REMOTE_SEQ + 65),
+                window_len: 1, // The last byte isn't accepted.
+                ..RECV_TEMPL
+            })
+        );
+    }
+
+    #[test]
     fn test_close_wait_no_window_update() {
         let mut s = socket_established();
         send!(

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1677,7 +1677,11 @@ impl<'a> Socket<'a> {
         }
 
         let window_start = self.remote_seq_no + self.rx_buffer.len();
-        let window_end = self.remote_seq_no + self.rx_buffer.capacity();
+        let window_end = if let Some(last_ack) = self.remote_last_ack {
+            last_ack + ((self.remote_last_win as usize) << self.remote_win_shift)
+        } else {
+            window_start
+        };
         let segment_start = repr.seq_number;
         let segment_end = repr.seq_number + repr.payload.len();
 


### PR DESCRIPTION
In the current implementation, we accept incoming bytes as long as there is space in the receive buffer. This occurs even if we never advertise its availability. For example, a previous ACK packet may be delayed due to the ACK delay mechanism.
https://github.com/smoltcp-rs/smoltcp/blob/d2d647090d544b1e7c142571da9d55f7280f664b/src/socket/tcp.rs#L1598-L1599

We may not want to do this because it may mess up our internal states by breaking some invariants, e.g., `last_ack + last_win - next_ack` should always work without overflows/underflows:
https://github.com/smoltcp-rs/smoltcp/blob/d2d647090d544b1e7c142571da9d55f7280f664b/src/socket/tcp.rs#L698

As a PoC, if you test the newly added `test_recv_out_of_recv_win` test in the main branch, you'll see the following:
```
---- socket::tcp::test::test_recv_out_of_recv_win stdout ----
send: TCP src=49500 dst=80 psh seq=4294957296 ack=10001 win=256 len=32
rx buffer: receiving 32 octets at offset 0
rx buffer: enqueueing 32 octets (now 32)
starting delayed ack timer
send: TCP src=49500 dst=80 psh seq=4294957328 ack=10001 win=256 len=1
rx buffer: receiving 1 octets at offset 0
rx buffer: enqueueing 1 octets (now 33)
delayed ack timer already started, forcing expiry
outgoing segment will acknowledge
sending ACK
recv: TCP src=80 dst=49500 seq=10001 ack=4294957329 win=31 len=0
stop delayed ack timer (was force-expired)
rx buffer: dequeueing 1 octets (now 32)
send: TCP src=49500 dst=80 psh seq=4294957329 ack=10001 win=256 len=32
rx buffer: receiving 32 octets at offset 0
rx buffer: enqueueing 32 octets (now 64)
starting delayed ack timer
thread 'socket::tcp::test::test_recv_out_of_recv_win' panicked at src/wire/tcp.rs:81:13:
attempt to subtract sequence numbers with underflow
```

The test will pass after changes in this PR.

I think this is the root cause of #1048 and #1051. So this PR may fix #1048 and fix #1051.