### PR TITLE
Resolve #1091 Require default feature for ICMP echo request auto reply

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,8 +97,8 @@ defmt = ["dep:defmt", "heapless/defmt"]
 
 "async" = []
 
-# Leave all responses up to the user and do not automatically reply to any message.
-"no-auto-response" = []
+# Automatically reply on an ICMP echo request
+"auto-icmp-echo-reply" = []
 
 default = [
   "std", "log", # needed for `cargo test --no-default-features --features default` :/
@@ -107,7 +107,7 @@ default = [
   "proto-ipv4",  "proto-dhcpv4", "proto-ipv6", "proto-dns",
   "proto-ipv4-fragmentation", "proto-sixlowpan-fragmentation",
   "socket-raw", "socket-icmp", "socket-udp", "socket-tcp", "socket-dhcpv4", "socket-dns", "socket-mdns",
-  "packetmeta-id", "async", "multicast"
+  "packetmeta-id", "async", "multicast", "auto-icmp-echo-reply"
 ]
 
 # Private features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,9 @@ defmt = ["dep:defmt", "heapless/defmt"]
 
 "async" = []
 
+# Leave all responses up to the user and do not automatically reply to any message.
+"no-auto-response" = []
+
 default = [
   "std", "log", # needed for `cargo test --no-default-features --features default` :/
   "medium-ethernet", "medium-ip", "medium-ieee802154",

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The IGMPv1 and IGMPv2 protocols are supported, and IPv4 multicast is available.
 The ICMPv4 protocol is supported, and ICMP sockets are available.
 
   * ICMPv4 header checksum is supported.
-  * ICMPv4 echo replies are generated in response to echo requests.
+  * ICMPv4 echo replies are generated in response to echo requests by default.
   * ICMP sockets can listen to ICMPv4 Port Unreachable messages, or any ICMPv4 messages with
     a given IPv4 identifier field.
   * ICMPv4 protocol unreachable messages are **not** passed to higher layers when received.
@@ -97,7 +97,7 @@ The ICMPv4 protocol is supported, and ICMP sockets are available.
 The ICMPv6 protocol is supported, and ICMP sockets are available.
 
   * ICMPv6 header checksum is supported.
-  * ICMPv6 echo replies are generated in response to echo requests.
+  * ICMPv6 echo replies are generated in response to echo requests by default.
   * ICMPv6 protocol unreachable messages are **not** passed to higher layers when received.
 
 #### NDISC

--- a/ci.sh
+++ b/ci.sh
@@ -15,24 +15,23 @@ RUSTC_VERSIONS=(
 FEATURES_TEST=(
     "default"
     "std,proto-ipv4"
-    "std,proto-ipv4,no-auto-response"
     "std,medium-ethernet,phy-raw_socket,proto-ipv6,socket-udp,socket-dns"
     "std,medium-ethernet,phy-tuntap_interface,proto-ipv6,socket-udp"
     "std,medium-ethernet,proto-ipv4,proto-ipv4-fragmentation,socket-raw,socket-dns"
     "std,medium-ethernet,proto-ipv4,multicast,socket-raw,socket-dns"
     "std,medium-ethernet,proto-ipv4,socket-udp,socket-tcp,socket-dns"
     "std,medium-ethernet,proto-ipv4,proto-dhcpv4,socket-udp"
-    "std,medium-ethernet,medium-ip,medium-ieee802154,proto-ipv6,multicast,proto-rpl,socket-udp,socket-dns"
+    "std,medium-ethernet,medium-ip,medium-ieee802154,proto-ipv6,multicast,proto-rpl,socket-udp,socket-dns,auto-icmp-echo-reply"
     "std,medium-ethernet,proto-ipv6,socket-tcp"
     "std,medium-ethernet,medium-ip,proto-ipv4,socket-icmp,socket-tcp"
     "std,medium-ip,proto-ipv6,socket-icmp,socket-tcp"
-    "std,medium-ieee802154,proto-sixlowpan,socket-udp"
-    "std,medium-ieee802154,proto-sixlowpan,proto-sixlowpan-fragmentation,socket-udp"
-    "std,medium-ieee802154,proto-rpl,proto-sixlowpan,proto-sixlowpan-fragmentation,socket-udp"
+    "std,medium-ieee802154,proto-sixlowpan,socket-udp,auto-icmp-echo-reply"
+    "std,medium-ieee802154,proto-sixlowpan,proto-sixlowpan-fragmentation,socket-udp,auto-icmp-echo-reply"
+    "std,medium-ieee802154,proto-rpl,proto-sixlowpan,proto-sixlowpan-fragmentation,socket-udp,auto-icmp-echo-reply"
     "std,medium-ip,proto-ipv4,proto-ipv6,socket-tcp,socket-udp"
-    "std,medium-ethernet,medium-ip,medium-ieee802154,proto-ipv4,proto-ipv6,multicast,proto-rpl,socket-raw,socket-udp,socket-tcp,socket-icmp,socket-dns,async"
+    "std,medium-ethernet,medium-ip,medium-ieee802154,proto-ipv4,proto-ipv6,multicast,proto-rpl,socket-raw,socket-udp,socket-tcp,socket-icmp,socket-dns,async,auto-icmp-echo-reply"
     "std,medium-ip,proto-ipv4,proto-ipv6,multicast,socket-raw,socket-udp,socket-tcp,socket-icmp,socket-dns,async"
-    "std,medium-ieee802154,medium-ip,proto-ipv4,socket-raw"
+    "std,medium-ieee802154,medium-ip,proto-ipv4,socket-raw,auto-icmp-echo-reply"
     "std,medium-ethernet,proto-ipv4,proto-ipsec,socket-raw"
 )
 
@@ -44,7 +43,7 @@ FEATURES_CHECK=(
     "medium-ip,medium-ethernet,medium-ieee802154,proto-ipv6,proto-ipv6,multicast,proto-dhcpv4,proto-ipsec,socket-raw,socket-udp,socket-tcp,socket-icmp,socket-dns,async"
     "defmt,medium-ip,medium-ethernet,proto-ipv6,proto-ipv6,multicast,proto-dhcpv4,socket-raw,socket-udp,socket-tcp,socket-icmp,socket-dns,async"
     "defmt,alloc,medium-ip,medium-ethernet,proto-ipv6,proto-ipv6,multicast,proto-dhcpv4,socket-raw,socket-udp,socket-tcp,socket-icmp,socket-dns,async"
-    "medium-ieee802154,proto-sixlowpan,socket-dns"
+    "medium-ieee802154,proto-sixlowpan,socket-dns,auto-icmp-echo-reply"
 )
 
 test() {

--- a/ci.sh
+++ b/ci.sh
@@ -15,6 +15,7 @@ RUSTC_VERSIONS=(
 FEATURES_TEST=(
     "default"
     "std,proto-ipv4"
+    "std,proto-ipv4,no-auto-response"
     "std,medium-ethernet,phy-raw_socket,proto-ipv6,socket-udp,socket-dns"
     "std,medium-ethernet,phy-tuntap_interface,proto-ipv6,socket-udp"
     "std,medium-ethernet,proto-ipv4,proto-ipv4-fragmentation,socket-raw,socket-dns"

--- a/src/iface/interface/ipv4.rs
+++ b/src/iface/interface/ipv4.rs
@@ -345,7 +345,7 @@ impl InterfaceInner {
 
         match icmp_repr {
             // Respond to echo requests.
-            #[cfg(all(feature = "proto-ipv4", not(feature = "no-auto-response")))]
+            #[cfg(all(feature = "proto-ipv4", feature = "auto-icmp-echo-reply"))]
             Icmpv4Repr::EchoRequest {
                 ident,
                 seq_no,
@@ -358,7 +358,7 @@ impl InterfaceInner {
                 };
                 self.icmpv4_reply(ip_repr, icmp_reply_repr)
             }
-            #[cfg(all(feature = "proto-ipv4", feature = "no-auto-response"))]
+            #[cfg(all(feature = "proto-ipv4", not(feature = "auto-icmp-echo-reply")))]
             Icmpv4Repr::EchoRequest {
                 ident: _,
                 seq_no: _,

--- a/src/iface/interface/ipv4.rs
+++ b/src/iface/interface/ipv4.rs
@@ -345,7 +345,7 @@ impl InterfaceInner {
 
         match icmp_repr {
             // Respond to echo requests.
-            #[cfg(feature = "proto-ipv4")]
+            #[cfg(all(feature = "proto-ipv4", not(feature = "no-auto-response")))]
             Icmpv4Repr::EchoRequest {
                 ident,
                 seq_no,
@@ -358,6 +358,8 @@ impl InterfaceInner {
                 };
                 self.icmpv4_reply(ip_repr, icmp_reply_repr)
             }
+            #[cfg(all(feature = "proto-ipv4", feature = "no-auto-response"))]
+            Icmpv4Repr::EchoRequest { ident: _, seq_no: _, data: _ } => None,
 
             // Ignore any echo replies.
             Icmpv4Repr::EchoReply { .. } => None,

--- a/src/iface/interface/ipv4.rs
+++ b/src/iface/interface/ipv4.rs
@@ -358,12 +358,6 @@ impl InterfaceInner {
                 };
                 self.icmpv4_reply(ip_repr, icmp_reply_repr)
             }
-            #[cfg(all(feature = "proto-ipv4", not(feature = "auto-icmp-echo-reply")))]
-            Icmpv4Repr::EchoRequest {
-                ident: _,
-                seq_no: _,
-                data: _,
-            } => None,
 
             // Ignore any echo replies.
             Icmpv4Repr::EchoReply { .. } => None,
@@ -374,6 +368,7 @@ impl InterfaceInner {
             _ if handled_by_icmp_socket => None,
 
             // FIXME: do something correct here?
+            // By doing nothing, this arm handles the case when auto echo replies are disabled.
             _ => None,
         }
     }

--- a/src/iface/interface/ipv4.rs
+++ b/src/iface/interface/ipv4.rs
@@ -359,7 +359,11 @@ impl InterfaceInner {
                 self.icmpv4_reply(ip_repr, icmp_reply_repr)
             }
             #[cfg(all(feature = "proto-ipv4", feature = "no-auto-response"))]
-            Icmpv4Repr::EchoRequest { ident: _, seq_no: _, data: _ } => None,
+            Icmpv4Repr::EchoRequest {
+                ident: _,
+                seq_no: _,
+                data: _,
+            } => None,
 
             // Ignore any echo replies.
             Icmpv4Repr::EchoReply { .. } => None,

--- a/src/iface/interface/ipv6.rs
+++ b/src/iface/interface/ipv6.rs
@@ -410,9 +410,13 @@ impl InterfaceInner {
                     data,
                 };
                 self.icmpv6_reply(ip_repr, icmp_reply_repr)
-            },
+            }
             #[cfg(feature = "no-auto-response")]
-            Icmpv6Repr::EchoRequest { ident: _, seq_no: _, data: _, } => { None },
+            Icmpv6Repr::EchoRequest {
+                ident: _,
+                seq_no: _,
+                data: _,
+            } => None,
 
             // Ignore any echo replies.
             Icmpv6Repr::EchoReply { .. } => None,

--- a/src/iface/interface/ipv6.rs
+++ b/src/iface/interface/ipv6.rs
@@ -411,12 +411,6 @@ impl InterfaceInner {
                 };
                 self.icmpv6_reply(ip_repr, icmp_reply_repr)
             }
-            #[cfg(not(feature = "auto-icmp-echo-reply"))]
-            Icmpv6Repr::EchoRequest {
-                ident: _,
-                seq_no: _,
-                data: _,
-            } => None,
 
             // Ignore any echo replies.
             Icmpv6Repr::EchoReply { .. } => None,
@@ -448,6 +442,7 @@ impl InterfaceInner {
             _ if handled_by_icmp_socket => None,
 
             // FIXME: do something correct here?
+            // By doing nothing, this arm handles the case when auto echo replies are disabled.
             _ => None,
         }
     }

--- a/src/iface/interface/ipv6.rs
+++ b/src/iface/interface/ipv6.rs
@@ -398,6 +398,7 @@ impl InterfaceInner {
 
         match icmp_repr {
             // Respond to echo requests.
+            #[cfg(not(feature = "no-auto-response"))]
             Icmpv6Repr::EchoRequest {
                 ident,
                 seq_no,
@@ -409,7 +410,9 @@ impl InterfaceInner {
                     data,
                 };
                 self.icmpv6_reply(ip_repr, icmp_reply_repr)
-            }
+            },
+            #[cfg(feature = "no-auto-response")]
+            Icmpv6Repr::EchoRequest { ident: _, seq_no: _, data: _, } => { None },
 
             // Ignore any echo replies.
             Icmpv6Repr::EchoReply { .. } => None,

--- a/src/iface/interface/ipv6.rs
+++ b/src/iface/interface/ipv6.rs
@@ -398,7 +398,7 @@ impl InterfaceInner {
 
         match icmp_repr {
             // Respond to echo requests.
-            #[cfg(not(feature = "no-auto-response"))]
+            #[cfg(feature = "auto-icmp-echo-reply")]
             Icmpv6Repr::EchoRequest {
                 ident,
                 seq_no,
@@ -411,7 +411,7 @@ impl InterfaceInner {
                 };
                 self.icmpv6_reply(ip_repr, icmp_reply_repr)
             }
-            #[cfg(feature = "no-auto-response")]
+            #[cfg(not(feature = "auto-icmp-echo-reply"))]
             Icmpv6Repr::EchoRequest {
                 ident: _,
                 seq_no: _,

--- a/src/iface/interface/tests/ipv4.rs
+++ b/src/iface/interface/tests/ipv4.rs
@@ -381,9 +381,9 @@ fn test_icmp_error_port_unreachable(#[case] medium: Medium) {
 
 #[rstest]
 #[case(Medium::Ip)]
-#[cfg(feature = "medium-ip")]
+#[cfg(all(feature = "medium-ip", not(feature = "no-auto-response")))]
 #[case(Medium::Ethernet)]
-#[cfg(feature = "medium-ethernet")]
+#[cfg(all(feature = "medium-ethernet", not(feature = "no-auto-response")))]
 fn test_handle_ipv4_broadcast(#[case] medium: Medium) {
     use crate::wire::{Icmpv4Packet, Icmpv4Repr};
 
@@ -626,9 +626,9 @@ fn test_arp_flush_after_update_ip(#[case] medium: Medium) {
 
 #[rstest]
 #[case(Medium::Ip)]
-#[cfg(all(feature = "socket-icmp", feature = "medium-ip"))]
+#[cfg(all(feature = "socket-icmp", feature = "medium-ip", not(feature = "no-auto-response")))]
 #[case(Medium::Ethernet)]
-#[cfg(all(feature = "socket-icmp", feature = "medium-ethernet"))]
+#[cfg(all(feature = "socket-icmp", feature = "medium-ethernet", not(feature = "no-auto-response")))]
 fn test_icmpv4_socket(#[case] medium: Medium) {
     use crate::wire::Icmpv4Packet;
 

--- a/src/iface/interface/tests/ipv4.rs
+++ b/src/iface/interface/tests/ipv4.rs
@@ -381,9 +381,9 @@ fn test_icmp_error_port_unreachable(#[case] medium: Medium) {
 
 #[rstest]
 #[case(Medium::Ip)]
-#[cfg(all(feature = "medium-ip", not(feature = "no-auto-response")))]
+#[cfg(all(feature = "medium-ip", feature = "auto-icmp-echo-reply"))]
 #[case(Medium::Ethernet)]
-#[cfg(all(feature = "medium-ethernet", not(feature = "no-auto-response")))]
+#[cfg(all(feature = "medium-ethernet", feature = "auto-icmp-echo-reply"))]
 fn test_handle_ipv4_broadcast(#[case] medium: Medium) {
     use crate::wire::{Icmpv4Packet, Icmpv4Repr};
 
@@ -629,13 +629,13 @@ fn test_arp_flush_after_update_ip(#[case] medium: Medium) {
 #[cfg(all(
     feature = "socket-icmp",
     feature = "medium-ip",
-    not(feature = "no-auto-response")
+    feature = "auto-icmp-echo-reply",
 ))]
 #[case(Medium::Ethernet)]
 #[cfg(all(
     feature = "socket-icmp",
     feature = "medium-ethernet",
-    not(feature = "no-auto-response")
+    feature = "auto-icmp-echo-reply",
 ))]
 fn test_icmpv4_socket(#[case] medium: Medium) {
     use crate::wire::Icmpv4Packet;

--- a/src/iface/interface/tests/ipv4.rs
+++ b/src/iface/interface/tests/ipv4.rs
@@ -626,9 +626,17 @@ fn test_arp_flush_after_update_ip(#[case] medium: Medium) {
 
 #[rstest]
 #[case(Medium::Ip)]
-#[cfg(all(feature = "socket-icmp", feature = "medium-ip", not(feature = "no-auto-response")))]
+#[cfg(all(
+    feature = "socket-icmp",
+    feature = "medium-ip",
+    not(feature = "no-auto-response")
+))]
 #[case(Medium::Ethernet)]
-#[cfg(all(feature = "socket-icmp", feature = "medium-ethernet", not(feature = "no-auto-response")))]
+#[cfg(all(
+    feature = "socket-icmp",
+    feature = "medium-ethernet",
+    not(feature = "no-auto-response")
+))]
 fn test_icmpv4_socket(#[case] medium: Medium) {
     use crate::wire::Icmpv4Packet;
 


### PR DESCRIPTION
This PR changes the auto reply for an ICMP echo request message (ping) to require a feature at compile time. The new feature is added to the default set, so no behavior change will occur for the default case.

To disable the auto reply, the user must either compile without default features or remove the feature from the default set. 

The README is also updated.

Resolves https://github.com/smoltcp-rs/smoltcp/issues/1091.