### PR TITLE
wire: use newly stable ip methods from core.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "smoltcp"
 version = "0.12.0"
 edition = "2024"
-rust-version = "1.87"
+rust-version = "1.91"
 authors = ["whitequark <whitequark@whitequark.org>"]
 description = "A TCP/IP stack designed for bare-metal, real-time systems without a heap."
 documentation = "https://docs.rs/smoltcp/"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ include complicated compile-time computations, such as macro or type tricks, eve
 at cost of performance degradation.
 
 _smoltcp_ does not need heap allocation *at all*, is [extensively documented][docs],
-and compiles on stable Rust 1.87 and later.
+and compiles on stable Rust 1.91 and later.
 
 _smoltcp_ achieves [~Gbps of throughput](#examplesbenchmarkrs) when tested against
 the Linux TCP stack in loopback mode.

--- a/build.rs
+++ b/build.rs
@@ -67,27 +67,27 @@ fn main() {
             cfg.seen_env = true;
         }
 
-        if let Some(feature) = var.strip_prefix("CARGO_FEATURE_") {
-            if let Some(i) = feature.rfind('_') {
-                let name = &feature[..i];
-                let value = &feature[i + 1..];
-                if let Some(cfg) = configs.get_mut(name) {
-                    let Ok(value) = value.parse::<usize>() else {
-                        panic!("Invalid value for feature {name}: {value}")
-                    };
+        if let Some(feature) = var.strip_prefix("CARGO_FEATURE_")
+            && let Some(i) = feature.rfind('_')
+        {
+            let name = &feature[..i];
+            let value = &feature[i + 1..];
+            if let Some(cfg) = configs.get_mut(name) {
+                let Ok(value) = value.parse::<usize>() else {
+                    panic!("Invalid value for feature {name}: {value}")
+                };
 
-                    // envvars take priority.
-                    if !cfg.seen_env {
-                        if cfg.seen_feature {
-                            panic!(
-                                "multiple values set for feature {}: {} and {}",
-                                name, cfg.value, value
-                            );
-                        }
-
-                        cfg.value = value;
-                        cfg.seen_feature = true;
+                // envvars take priority.
+                if !cfg.seen_env {
+                    if cfg.seen_feature {
+                        panic!(
+                            "multiple values set for feature {}: {} and {}",
+                            name, cfg.value, value
+                        );
                     }
+
+                    cfg.value = value;
+                    cfg.seen_feature = true;
                 }
             }
         }

--- a/ci.sh
+++ b/ci.sh
@@ -4,7 +4,7 @@ set -eox pipefail
 
 export DEFMT_LOG=trace
 
-MSRV="1.87.0"
+MSRV="1.91.0"
 
 RUSTC_VERSIONS=(
     $MSRV

--- a/src/iface/fragmentation.rs
+++ b/src/iface/fragmentation.rs
@@ -85,10 +85,10 @@ impl<K> PacketAssembler<K> {
 
     /// Set the total size of the packet assembler.
     pub(crate) fn set_total_size(&mut self, size: usize) -> Result<(), AssemblerError> {
-        if let Some(old_size) = self.total_size {
-            if old_size != size {
-                return Err(AssemblerError);
-            }
+        if let Some(old_size) = self.total_size
+            && old_size != size
+        {
+            return Err(AssemblerError);
         }
 
         #[cfg(not(feature = "alloc"))]

--- a/src/iface/interface/ipv4.rs
+++ b/src/iface/interface/ipv4.rs
@@ -18,11 +18,11 @@ impl Interface {
         }
 
         let pkt = &self.fragmenter;
-        if pkt.packet_len > pkt.sent_bytes {
-            if let Some(tx_token) = device.transmit(self.inner.now) {
-                self.inner
-                    .dispatch_ipv4_frag(tx_token, &mut self.fragmenter);
-            }
+        if pkt.packet_len > pkt.sent_bytes
+            && let Some(tx_token) = device.transmit(self.inner.now)
+        {
+            self.inner
+                .dispatch_ipv4_frag(tx_token, &mut self.fragmenter);
         }
     }
 }

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -644,12 +644,10 @@ impl Interface {
                     if let Some(packet) =
                         self.inner
                             .process_ethernet(sockets, rx_meta, frame, &mut self.fragments)
-                    {
-                        if let Err(err) =
+                        && let Err(err) =
                             self.inner.dispatch(tx_token, packet, &mut self.fragmenter)
-                        {
-                            net_debug!("Failed to send response: {:?}", err);
-                        }
+                    {
+                        net_debug!("Failed to send response: {:?}", err);
                     }
                 }
                 #[cfg(feature = "medium-ip")]
@@ -657,15 +655,14 @@ impl Interface {
                     if let Some(packet) =
                         self.inner
                             .process_ip(sockets, rx_meta, frame, &mut self.fragments)
-                    {
-                        if let Err(err) = self.inner.dispatch_ip(
+                        && let Err(err) = self.inner.dispatch_ip(
                             tx_token,
                             PacketMeta::default(),
                             packet,
                             &mut self.fragmenter,
-                        ) {
-                            net_debug!("Failed to send response: {:?}", err);
-                        }
+                        )
+                    {
+                        net_debug!("Failed to send response: {:?}", err);
                     }
                 }
                 #[cfg(feature = "medium-ieee802154")]
@@ -673,15 +670,14 @@ impl Interface {
                     if let Some(packet) =
                         self.inner
                             .process_ieee802154(sockets, rx_meta, frame, &mut self.fragments)
-                    {
-                        if let Err(err) = self.inner.dispatch_ip(
+                        && let Err(err) = self.inner.dispatch_ip(
                             tx_token,
                             PacketMeta::default(),
                             packet,
                             &mut self.fragmenter,
-                        ) {
-                            net_debug!("Failed to send response: {:?}", err);
-                        }
+                        )
+                    {
+                        net_debug!("Failed to send response: {:?}", err);
                     }
                 }
             }

--- a/src/iface/interface/multicast.rs
+++ b/src/iface/interface/multicast.rs
@@ -362,24 +362,24 @@ impl Interface {
                         _ => None,
                     })
                     .collect::<heapless::Vec<_, IFACE_MAX_MULTICAST_GROUP_COUNT>>();
-                if let Some(pkt) = self.inner.mldv2_report_packet(&records) {
-                    if let Some(tx_token) = device.transmit(self.inner.now) {
-                        self.inner
-                            .dispatch_ip(tx_token, PacketMeta::default(), pkt, &mut self.fragmenter)
-                            .unwrap();
-                    };
+                if let Some(pkt) = self.inner.mldv2_report_packet(&records)
+                    && let Some(tx_token) = device.transmit(self.inner.now)
+                {
+                    self.inner
+                        .dispatch_ip(tx_token, PacketMeta::default(), pkt, &mut self.fragmenter)
+                        .unwrap();
                 };
                 self.inner.multicast.mld_report_state = MldReportState::Inactive;
             }
             MldReportState::ToSpecificQuery { group, timeout } if self.inner.now >= timeout => {
                 let record = MldAddressRecordRepr::new(MldRecordType::ModeIsExclude, group);
-                if let Some(pkt) = self.inner.mldv2_report_packet(&[record]) {
-                    if let Some(tx_token) = device.transmit(self.inner.now) {
-                        // NOTE(unwrap): packet destination is multicast, which is always routable and doesn't require neighbor discovery.
-                        self.inner
-                            .dispatch_ip(tx_token, PacketMeta::default(), pkt, &mut self.fragmenter)
-                            .unwrap();
-                    }
+                if let Some(pkt) = self.inner.mldv2_report_packet(&[record])
+                    && let Some(tx_token) = device.transmit(self.inner.now)
+                {
+                    // NOTE(unwrap): packet destination is multicast, which is always routable and doesn't require neighbor discovery.
+                    self.inner
+                        .dispatch_ip(tx_token, PacketMeta::default(), pkt, &mut self.fragmenter)
+                        .unwrap();
                 }
                 self.inner.multicast.mld_report_state = MldReportState::Inactive;
             }

--- a/src/iface/interface/sixlowpan.rs
+++ b/src/iface/interface/sixlowpan.rs
@@ -840,10 +840,10 @@ mod tests {
 
         let mut ip_packet = PacketV6 {
             header: Ipv6Repr {
-                src_addr: Ipv6Address::from_bytes(&[
+                src_addr: Ipv6Address::from_octets([
                     253, 0, 0, 0, 0, 0, 0, 0, 2, 3, 0, 3, 0, 3, 0, 3,
                 ]),
-                dst_addr: Ipv6Address::from_bytes(&[
+                dst_addr: Ipv6Address::from_octets([
                     253, 0, 0, 0, 0, 0, 0, 0, 2, 1, 0, 1, 0, 1, 0, 1,
                 ]),
                 next_header: IpProtocol::Icmpv6,
@@ -860,7 +860,7 @@ mod tests {
                 rpl_instance_id: RplInstanceId::Global(30),
                 expect_ack: false,
                 sequence: 241,
-                dodag_id: Some(Ipv6Address::from_bytes(&[
+                dodag_id: Some(Ipv6Address::from_octets([
                     253, 0, 0, 0, 0, 0, 0, 0, 2, 1, 0, 1, 0, 1, 0, 1,
                 ])),
                 options: &[],
@@ -906,9 +906,9 @@ mod tests {
             src_addr: Some(Ieee802154Address::Extended([0, 3, 0, 3, 0, 3, 0, 3])),
         };
 
-        let addr = Ipv6Address::from_bytes(&[253, 0, 0, 0, 0, 0, 0, 0, 2, 3, 0, 3, 0, 3, 0, 3]);
+        let addr = Ipv6Address::from_octets([253, 0, 0, 0, 0, 0, 0, 0, 2, 3, 0, 3, 0, 3, 0, 3]);
         let parent_address =
-            Ipv6Address::from_bytes(&[253, 0, 0, 0, 0, 0, 0, 0, 2, 1, 0, 1, 0, 1, 0, 1]);
+            Ipv6Address::from_octets([253, 0, 0, 0, 0, 0, 0, 0, 2, 1, 0, 1, 0, 1, 0, 1]);
 
         let mut hbh_options = heapless::Vec::new();
         hbh_options
@@ -941,7 +941,7 @@ mod tests {
                 rpl_instance_id: RplInstanceId::Global(30),
                 expect_ack: false,
                 sequence: 241,
-                dodag_id: Some(Ipv6Address::from_bytes(&[
+                dodag_id: Some(Ipv6Address::from_octets([
                     253, 0, 0, 0, 0, 0, 0, 0, 2, 1, 0, 1, 0, 1, 0, 1,
                 ])),
                 options: &[

--- a/src/iface/interface/sixlowpan.rs
+++ b/src/iface/interface/sixlowpan.rs
@@ -19,11 +19,11 @@ impl Interface {
         }
 
         let pkt = &self.fragmenter;
-        if pkt.packet_len > pkt.sent_bytes {
-            if let Some(tx_token) = device.transmit(self.inner.now) {
-                self.inner
-                    .dispatch_ieee802154_frag(tx_token, &mut self.fragmenter);
-            }
+        if pkt.packet_len > pkt.sent_bytes
+            && let Some(tx_token) = device.transmit(self.inner.now)
+        {
+            self.inner
+                .dispatch_ieee802154_frag(tx_token, &mut self.fragmenter);
         }
     }
 

--- a/src/iface/interface/tests/ipv4.rs
+++ b/src/iface/interface/tests/ipv4.rs
@@ -17,11 +17,11 @@ fn test_any_ip_accept_arp(#[case] medium: Medium) {
             source_hardware_addr: EthernetAddress::from_bytes(&[
                 0x02, 0x02, 0x02, 0x02, 0x02, 0x03,
             ]),
-            source_protocol_addr: Ipv4Address::from_bytes(&[192, 168, 1, 2]),
+            source_protocol_addr: Ipv4Address::from_octets([192, 168, 1, 2]),
             target_hardware_addr: EthernetAddress::from_bytes(&[
                 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
             ]),
-            target_protocol_addr: Ipv4Address::from_bytes(&[192, 168, 1, 3]),
+            target_protocol_addr: Ipv4Address::from_octets([192, 168, 1, 3]),
         };
         let mut frame = EthernetFrame::new_unchecked(&mut buffer[..]);
         ethernet_repr.emit(&mut frame);

--- a/src/iface/neighbor.rs
+++ b/src/iface/neighbor.rs
@@ -73,10 +73,9 @@ impl Cache {
             expires_at,
             hardware_addr,
         }) = self.storage.get_mut(&protocol_addr)
+            && source_hardware_addr == *hardware_addr
         {
-            if source_hardware_addr == *hardware_addr {
-                *expires_at = timestamp + Self::ENTRY_LIFETIME;
-            }
+            *expires_at = timestamp + Self::ENTRY_LIFETIME;
         }
     }
 
@@ -154,10 +153,9 @@ impl Cache {
             expires_at,
             hardware_addr,
         }) = self.storage.get(protocol_addr)
+            && timestamp < expires_at
         {
-            if timestamp < expires_at {
-                return Answer::Found(hardware_addr);
-            }
+            return Answer::Found(hardware_addr);
         }
 
         if timestamp < self.silent_until {

--- a/src/iface/route.rs
+++ b/src/iface/route.rs
@@ -153,10 +153,10 @@ impl Routes {
             .iter()
             // Keep only matching routes
             .filter(|route| {
-                if let Some(expires_at) = route.expires_at {
-                    if timestamp > expires_at {
-                        return false;
-                    }
+                if let Some(expires_at) = route.expires_at
+                    && timestamp > expires_at
+                {
+                    return false;
                 }
                 route.cidr.contains_addr(addr)
             })

--- a/src/iface/slaac.rs
+++ b/src/iface/slaac.rs
@@ -129,10 +129,10 @@ impl Slaac {
             return;
         }
         let prefix_info = PrefixInfo::from_prefix(prefix, now);
-        if let Ok(old_info) = self.prefix.insert(*cidr, prefix_info) {
-            if old_info.is_none() {
-                self.sync_required = true;
-            }
+        if let Ok(old_info) = self.prefix.insert(*cidr, prefix_info)
+            && old_info.is_none()
+        {
+            self.sync_required = true;
         }
     }
 
@@ -188,10 +188,10 @@ impl Slaac {
         prefix: Option<NdiscPrefixInformation>, // prefix info
         now: Instant,
     ) {
-        if let Some(prefix) = prefix {
-            if prefix.is_valid_prefix_info() {
-                self.process_prefix(prefix, now)
-            }
+        if let Some(prefix) = prefix
+            && prefix.is_valid_prefix_info()
+        {
+            self.process_prefix(prefix, now)
         }
 
         if router_lifetime > Duration::ZERO {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 //!
 //! # Minimum Supported Rust Version (MSRV)
 //!
-//! This crate is guaranteed to compile on stable Rust 1.87 and up with any valid set of features.
+//! This crate is guaranteed to compile on stable Rust 1.91 and up with any valid set of features.
 //! It *might* compile on older versions but that may change in any new patch release.
 //!
 //! The exception is when using the `defmt` feature, in which case `defmt`'s MSRV applies, which

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -10,7 +10,7 @@ use core::str::FromStr;
 use crate::wire::EthernetAddress;
 use crate::wire::{IpAddress, IpCidr, IpEndpoint};
 #[cfg(feature = "proto-ipv4")]
-use crate::wire::{Ipv4Address, Ipv4AddressExt, Ipv4Cidr};
+use crate::wire::{Ipv4Address, Ipv4Cidr};
 #[cfg(feature = "proto-ipv6")]
 use crate::wire::{Ipv6Address, Ipv6Cidr};
 
@@ -294,7 +294,7 @@ impl<'a> Parser<'a> {
     #[cfg(feature = "proto-ipv4")]
     fn accept_ipv4(&mut self) -> Result<Ipv4Address> {
         let octets = self.accept_ipv4_octets()?;
-        Ok(Ipv4Address::from_bytes(&octets))
+        Ok(Ipv4Address::from_octets(octets))
     }
 
     fn accept_ip(&mut self) -> Result<IpAddress> {

--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -358,10 +358,10 @@ impl<'a> Socket<'a> {
         );
 
         // Copy over the payload into the receive packet buffer.
-        if let Some(buffer) = self.receive_packet_buffer.as_mut() {
-            if let Some(buffer) = buffer.get_mut(..payload.len()) {
-                buffer.copy_from_slice(payload);
-            }
+        if let Some(buffer) = self.receive_packet_buffer.as_mut()
+            && let Some(buffer) = buffer.get_mut(..payload.len())
+        {
+            buffer.copy_from_slice(payload);
         }
 
         match (&mut self.state, dhcp_repr.message_type) {

--- a/src/wire/arp.rs
+++ b/src/wire/arp.rs
@@ -2,7 +2,7 @@ use byteorder::{ByteOrder, NetworkEndian};
 use core::fmt;
 
 use super::{Error, Result};
-use super::{EthernetAddress, Ipv4Address, Ipv4AddressExt};
+use super::{EthernetAddress, Ipv4Address};
 
 pub use super::EthernetProtocol as Protocol;
 
@@ -281,9 +281,13 @@ impl Repr {
             (Hardware::Ethernet, Protocol::Ipv4, 6, 4) => Ok(Repr::EthernetIpv4 {
                 operation: packet.operation(),
                 source_hardware_addr: EthernetAddress::from_bytes(packet.source_hardware_addr()),
-                source_protocol_addr: Ipv4Address::from_bytes(packet.source_protocol_addr()),
+                source_protocol_addr: Ipv4Address::from_octets(
+                    packet.source_protocol_addr().try_into().unwrap(),
+                ),
                 target_hardware_addr: EthernetAddress::from_bytes(packet.target_hardware_addr()),
-                target_protocol_addr: Ipv4Address::from_bytes(packet.target_protocol_addr()),
+                target_protocol_addr: Ipv4Address::from_octets(
+                    packet.target_protocol_addr().try_into().unwrap(),
+                ),
             }),
             _ => Err(Error),
         }
@@ -434,11 +438,11 @@ mod test {
             source_hardware_addr: EthernetAddress::from_bytes(&[
                 0x11, 0x12, 0x13, 0x14, 0x15, 0x16,
             ]),
-            source_protocol_addr: Ipv4Address::from_bytes(&[0x21, 0x22, 0x23, 0x24]),
+            source_protocol_addr: Ipv4Address::from_octets([0x21, 0x22, 0x23, 0x24]),
             target_hardware_addr: EthernetAddress::from_bytes(&[
                 0x31, 0x32, 0x33, 0x34, 0x35, 0x36,
             ]),
-            target_protocol_addr: Ipv4Address::from_bytes(&[0x41, 0x42, 0x43, 0x44]),
+            target_protocol_addr: Ipv4Address::from_octets([0x41, 0x42, 0x43, 0x44]),
         }
     }
 

--- a/src/wire/dns.rs
+++ b/src/wire/dns.rs
@@ -7,9 +7,9 @@ use core::iter::Iterator;
 
 use super::{Error, Result};
 #[cfg(feature = "proto-ipv4")]
-use crate::wire::{Ipv4Address, Ipv4AddressExt};
+use crate::wire::Ipv4Address;
 #[cfg(feature = "proto-ipv6")]
-use crate::wire::{Ipv6Address, Ipv6AddressExt};
+use crate::wire::Ipv6Address;
 
 enum_with_unknown! {
     /// DNS OpCodes
@@ -338,19 +338,13 @@ impl<'a> RecordData<'a> {
     pub fn parse(type_: Type, data: &'a [u8]) -> Result<RecordData<'a>> {
         match type_ {
             #[cfg(feature = "proto-ipv4")]
-            Type::A => {
-                if data.len() != 4 {
-                    return Err(Error);
-                }
-                Ok(RecordData::A(Ipv4Address::from_bytes(data)))
-            }
+            Type::A => Ok(RecordData::A(Ipv4Address::from_octets(
+                data.try_into().map_err(|_| Error)?,
+            ))),
             #[cfg(feature = "proto-ipv6")]
-            Type::Aaaa => {
-                if data.len() != 16 {
-                    return Err(Error);
-                }
-                Ok(RecordData::Aaaa(Ipv6Address::from_bytes(data)))
-            }
+            Type::Aaaa => Ok(RecordData::Aaaa(Ipv6Address::from_octets(
+                data.try_into().map_err(|_| Error)?,
+            ))),
             Type::Cname => Ok(RecordData::Cname(data)),
             x => Ok(RecordData::Other(x, data)),
         }

--- a/src/wire/ieee802154.rs
+++ b/src/wire/ieee802154.rs
@@ -3,7 +3,7 @@ use core::fmt;
 use byteorder::{ByteOrder, LittleEndian};
 
 use super::{Error, Result};
-use crate::wire::{Ipv6Address, Ipv6AddressExt};
+use crate::wire::Ipv6Address;
 
 enum_with_unknown! {
     /// IEEE 802.15.4 frame type.
@@ -196,7 +196,7 @@ impl Address {
         bytes[1] = 0x80;
         bytes[8..].copy_from_slice(&self.as_eui_64()?);
 
-        Some(Ipv6Address::from_bytes(&bytes))
+        Some(Ipv6Address::from_octets(bytes))
     }
 }
 

--- a/src/wire/igmp.rs
+++ b/src/wire/igmp.rs
@@ -5,7 +5,7 @@ use super::{Error, Result};
 use crate::time::Duration;
 use crate::wire::ip::checksum;
 
-use crate::wire::{Ipv4Address, Ipv4AddressExt};
+use crate::wire::Ipv4Address;
 
 enum_with_unknown! {
     /// Internet Group Management Protocol v1/v2 message version/type.
@@ -112,7 +112,7 @@ impl<T: AsRef<[u8]>> Packet<T> {
     #[inline]
     pub fn group_addr(&self) -> Ipv4Address {
         let data = self.buffer.as_ref();
-        Ipv4Address::from_bytes(&data[field::GROUP_ADDRESS])
+        Ipv4Address::from_octets(data[field::GROUP_ADDRESS].try_into().unwrap())
     }
 
     /// Validate the header checksum.
@@ -387,7 +387,7 @@ mod test {
         assert_eq!(packet.checksum(), 0x269);
         assert_eq!(
             packet.group_addr(),
-            Ipv4Address::from_bytes(&[224, 0, 6, 150])
+            Ipv4Address::from_octets([224, 0, 6, 150])
         );
         assert!(packet.verify_checksum());
     }
@@ -400,7 +400,7 @@ mod test {
         assert_eq!(packet.checksum(), 0x08da);
         assert_eq!(
             packet.group_addr(),
-            Ipv4Address::from_bytes(&[225, 0, 0, 37])
+            Ipv4Address::from_octets([225, 0, 0, 37])
         );
         assert!(packet.verify_checksum());
     }
@@ -411,7 +411,7 @@ mod test {
         let mut packet = Packet::new_unchecked(&mut bytes);
         packet.set_msg_type(Message::LeaveGroup);
         packet.set_max_resp_code(0);
-        packet.set_group_address(Ipv4Address::from_bytes(&[224, 0, 6, 150]));
+        packet.set_group_address(Ipv4Address::from_octets([224, 0, 6, 150]));
         packet.fill_checksum();
         assert_eq!(&*packet.into_inner(), &LEAVE_PACKET_BYTES[..]);
     }
@@ -422,7 +422,7 @@ mod test {
         let mut packet = Packet::new_unchecked(&mut bytes);
         packet.set_msg_type(Message::MembershipReportV2);
         packet.set_max_resp_code(0);
-        packet.set_group_address(Ipv4Address::from_bytes(&[225, 0, 0, 37]));
+        packet.set_group_address(Ipv4Address::from_octets([225, 0, 0, 37]));
         packet.fill_checksum();
         assert_eq!(&*packet.into_inner(), &REPORT_PACKET_BYTES[..]);
     }

--- a/src/wire/ipv6.rs
+++ b/src/wire/ipv6.rs
@@ -101,13 +101,6 @@ pub(crate) trait AddressExt {
     /// [link-local]: https://tools.ietf.org/html/rfc4291#section-2.5.6
     fn is_link_local(&self) -> bool;
 
-    /// Query whether the IPv6 address is a [Unique Local Address] (ULA).
-    ///
-    /// [Unique Local Address]: https://tools.ietf.org/html/rfc4193
-    ///
-    /// `x_` prefix is to avoid a collision with the still-unstable method in `core::ip`.
-    fn x_is_unique_local(&self) -> bool;
-
     /// Helper function used to mask an address given a prefix.
     ///
     /// # Panics
@@ -166,10 +159,6 @@ impl AddressExt for Address {
         self.octets()[0..8] == [0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
     }
 
-    fn x_is_unique_local(&self) -> bool {
-        (self.octets()[0] & 0b1111_1110) == 0xfc
-    }
-
     fn mask(&self, mask: u8) -> [u8; ADDR_SIZE] {
         assert!(mask <= 128);
         let mut bytes = [0u8; ADDR_SIZE];
@@ -201,7 +190,7 @@ impl AddressExt for Address {
 
         if self.is_link_local() {
             MulticastScope::LinkLocal
-        } else if self.x_is_unique_local() || self.is_global_unicast() {
+        } else if self.is_unique_local() || self.is_global_unicast() {
             // ULA are considered global scope
             // https://www.rfc-editor.org/rfc/rfc6724#section-3.1
             MulticastScope::Global
@@ -727,14 +716,14 @@ pub(crate) mod test {
         assert!(LINK_LOCAL_ALL_ROUTERS.is_multicast());
         assert!(!LINK_LOCAL_ALL_ROUTERS.is_link_local());
         assert!(!LINK_LOCAL_ALL_ROUTERS.is_loopback());
-        assert!(!LINK_LOCAL_ALL_ROUTERS.x_is_unique_local());
+        assert!(!LINK_LOCAL_ALL_ROUTERS.is_unique_local());
         assert!(!LINK_LOCAL_ALL_ROUTERS.is_global_unicast());
         assert!(!LINK_LOCAL_ALL_ROUTERS.is_solicited_node_multicast());
         assert!(!LINK_LOCAL_ALL_NODES.is_unspecified());
         assert!(LINK_LOCAL_ALL_NODES.is_multicast());
         assert!(!LINK_LOCAL_ALL_NODES.is_link_local());
         assert!(!LINK_LOCAL_ALL_NODES.is_loopback());
-        assert!(!LINK_LOCAL_ALL_NODES.x_is_unique_local());
+        assert!(!LINK_LOCAL_ALL_NODES.is_unique_local());
         assert!(!LINK_LOCAL_ALL_NODES.is_global_unicast());
         assert!(!LINK_LOCAL_ALL_NODES.is_solicited_node_multicast());
     }
@@ -745,7 +734,7 @@ pub(crate) mod test {
         assert!(!LINK_LOCAL_ADDR.is_multicast());
         assert!(LINK_LOCAL_ADDR.is_link_local());
         assert!(!LINK_LOCAL_ADDR.is_loopback());
-        assert!(!LINK_LOCAL_ADDR.x_is_unique_local());
+        assert!(!LINK_LOCAL_ADDR.is_unique_local());
         assert!(!LINK_LOCAL_ADDR.is_global_unicast());
         assert!(!LINK_LOCAL_ADDR.is_solicited_node_multicast());
     }
@@ -756,7 +745,7 @@ pub(crate) mod test {
         assert!(!Address::LOCALHOST.is_multicast());
         assert!(!Address::LOCALHOST.is_link_local());
         assert!(Address::LOCALHOST.is_loopback());
-        assert!(!Address::LOCALHOST.x_is_unique_local());
+        assert!(!Address::LOCALHOST.is_unique_local());
         assert!(!Address::LOCALHOST.is_global_unicast());
         assert!(!Address::LOCALHOST.is_solicited_node_multicast());
     }
@@ -767,7 +756,7 @@ pub(crate) mod test {
         assert!(!UNIQUE_LOCAL_ADDR.is_multicast());
         assert!(!UNIQUE_LOCAL_ADDR.is_link_local());
         assert!(!UNIQUE_LOCAL_ADDR.is_loopback());
-        assert!(UNIQUE_LOCAL_ADDR.x_is_unique_local());
+        assert!(UNIQUE_LOCAL_ADDR.is_unique_local());
         assert!(!UNIQUE_LOCAL_ADDR.is_global_unicast());
         assert!(!UNIQUE_LOCAL_ADDR.is_solicited_node_multicast());
     }
@@ -778,7 +767,7 @@ pub(crate) mod test {
         assert!(!GLOBAL_UNICAST_ADDR.is_multicast());
         assert!(!GLOBAL_UNICAST_ADDR.is_link_local());
         assert!(!GLOBAL_UNICAST_ADDR.is_loopback());
-        assert!(!GLOBAL_UNICAST_ADDR.x_is_unique_local());
+        assert!(!GLOBAL_UNICAST_ADDR.is_unique_local());
         assert!(GLOBAL_UNICAST_ADDR.is_global_unicast());
         assert!(!GLOBAL_UNICAST_ADDR.is_solicited_node_multicast());
     }
@@ -789,7 +778,7 @@ pub(crate) mod test {
         assert!(TEST_SOL_NODE_MCAST_ADDR.is_multicast());
         assert!(!TEST_SOL_NODE_MCAST_ADDR.is_link_local());
         assert!(!TEST_SOL_NODE_MCAST_ADDR.is_loopback());
-        assert!(!TEST_SOL_NODE_MCAST_ADDR.x_is_unique_local());
+        assert!(!TEST_SOL_NODE_MCAST_ADDR.is_unique_local());
         assert!(!TEST_SOL_NODE_MCAST_ADDR.is_global_unicast());
         assert!(TEST_SOL_NODE_MCAST_ADDR.is_solicited_node_multicast());
     }

--- a/src/wire/ipv6routing.rs
+++ b/src/wire/ipv6routing.rs
@@ -1,7 +1,7 @@
 use super::{Error, Result};
 use core::fmt;
 
-use crate::wire::{Ipv6Address as Address, Ipv6AddressExt};
+use crate::wire::Ipv6Address as Address;
 
 enum_with_unknown! {
     /// IPv6 Extension Routing Header Routing Type
@@ -191,7 +191,7 @@ impl<T: AsRef<[u8]>> Header<T> {
     /// This function may panic if this header is not the Type2 Routing Header routing type.
     pub fn home_address(&self) -> Address {
         let data = self.buffer.as_ref();
-        Address::from_bytes(&data[field::HOME_ADDRESS])
+        Address::from_octets(data[field::HOME_ADDRESS].try_into().unwrap())
     }
 }
 

--- a/src/wire/mld.rs
+++ b/src/wire/mld.rs
@@ -7,8 +7,8 @@
 use byteorder::{ByteOrder, NetworkEndian};
 
 use super::{Error, Result};
+use crate::wire::Ipv6Address;
 use crate::wire::icmpv6::{Message, Packet, field};
-use crate::wire::{Ipv6Address, Ipv6AddressExt};
 
 enum_with_unknown! {
     /// MLDv2 Multicast Listener Report Record Type. See [RFC 3810 § 5.2.12] for
@@ -49,7 +49,7 @@ impl<T: AsRef<[u8]>> Packet<T> {
     #[inline]
     pub fn mcast_addr(&self) -> Ipv6Address {
         let data = self.buffer.as_ref();
-        Ipv6Address::from_bytes(&data[field::QUERY_MCAST_ADDR])
+        Ipv6Address::from_octets(data[field::QUERY_MCAST_ADDR].try_into().unwrap())
     }
 
     /// Return the Suppress Router-Side Processing flag.
@@ -234,7 +234,7 @@ impl<T: AsRef<[u8]>> AddressRecord<T> {
     #[inline]
     pub fn mcast_addr(&self) -> Ipv6Address {
         let data = self.buffer.as_ref();
-        Ipv6Address::from_bytes(&data[field::RECORD_MCAST_ADDR])
+        Ipv6Address::from_octets(data[field::RECORD_MCAST_ADDR].try_into().unwrap())
     }
 }
 
@@ -519,7 +519,7 @@ mod test {
         assert_eq!(packet.qqic(), 0x12);
         assert_eq!(packet.num_srcs(), 0x01);
         assert_eq!(
-            Ipv6Address::from_bytes(packet.payload()),
+            Ipv6Address::from_octets(packet.payload().try_into().unwrap()),
             IPV6_LINK_LOCAL_ALL_ROUTERS
         );
     }
@@ -557,7 +557,7 @@ mod test {
         assert_eq!(addr_rcrd.num_srcs(), 0x01);
         assert_eq!(addr_rcrd.mcast_addr(), IPV6_LINK_LOCAL_ALL_NODES);
         assert_eq!(
-            Ipv6Address::from_bytes(addr_rcrd.payload()),
+            Ipv6Address::from_octets(addr_rcrd.payload().try_into().unwrap()),
             IPV6_LINK_LOCAL_ALL_ROUTERS
         );
     }

--- a/src/wire/ndisc.rs
+++ b/src/wire/ndisc.rs
@@ -3,9 +3,9 @@ use byteorder::{ByteOrder, NetworkEndian};
 
 use super::{Error, Result};
 use crate::time::Duration;
+use crate::wire::Ipv6Address;
 use crate::wire::RawHardwareAddress;
 use crate::wire::icmpv6::{Message, Packet, field};
-use crate::wire::{Ipv6Address, Ipv6AddressExt};
 use crate::wire::{NdiscOption, NdiscOptionRepr};
 use crate::wire::{NdiscPrefixInformation, NdiscRedirectedHeader};
 
@@ -78,7 +78,7 @@ impl<T: AsRef<[u8]>> Packet<T> {
     #[inline]
     pub fn target_addr(&self) -> Ipv6Address {
         let data = self.buffer.as_ref();
-        Ipv6Address::from_bytes(&data[field::TARGET_ADDR])
+        Ipv6Address::from_octets(data[field::TARGET_ADDR].try_into().unwrap())
     }
 }
 
@@ -104,7 +104,7 @@ impl<T: AsRef<[u8]>> Packet<T> {
     #[inline]
     pub fn dest_addr(&self) -> Ipv6Address {
         let data = self.buffer.as_ref();
-        Ipv6Address::from_bytes(&data[field::DEST_ADDR])
+        Ipv6Address::from_octets(data[field::DEST_ADDR].try_into().unwrap())
     }
 }
 

--- a/src/wire/ndiscoption.rs
+++ b/src/wire/ndiscoption.rs
@@ -266,7 +266,7 @@ impl<T: AsRef<[u8]>> NdiscOption<T> {
     #[inline]
     pub fn prefix(&self) -> Ipv6Address {
         let data = self.buffer.as_ref();
-        Ipv6Address::from_bytes(&data[field::PREFIX])
+        Ipv6Address::from_octets(data[field::PREFIX].try_into().unwrap())
     }
 }
 

--- a/src/wire/rpl.rs
+++ b/src/wire/rpl.rs
@@ -377,11 +377,10 @@ impl<T: AsRef<[u8]>> Packet<T> {
     /// Return the DODAG id, which is an IPv6 address.
     #[inline]
     pub fn dio_dodag_id(&self) -> Address {
-        get!(
-            self.buffer,
-            into: Address,
-            fun: from_bytes,
-            field: field::DIO_DODAG_ID
+        Address::from_octets(
+            self.buffer.as_ref()[field::DIO_DODAG_ID]
+                .try_into()
+                .unwrap(),
         )
     }
 }
@@ -474,8 +473,10 @@ impl<T: AsRef<[u8]>> Packet<T> {
     #[inline]
     pub fn dao_dodag_id(&self) -> Option<Address> {
         if self.dao_dodag_id_present() {
-            Some(Address::from_bytes(
-                &self.buffer.as_ref()[field::DAO_DODAG_ID],
+            Some(Address::from_octets(
+                self.buffer.as_ref()[field::DAO_DODAG_ID]
+                    .try_into()
+                    .unwrap(),
             ))
         } else {
             None
@@ -560,8 +561,10 @@ impl<T: AsRef<[u8]>> Packet<T> {
     #[inline]
     pub fn dao_ack_dodag_id(&self) -> Option<Address> {
         if self.dao_ack_dodag_id_present() {
-            Some(Address::from_bytes(
-                &self.buffer.as_ref()[field::DAO_ACK_DODAG_ID],
+            Some(Address::from_octets(
+                self.buffer.as_ref()[field::DAO_ACK_DODAG_ID]
+                    .try_into()
+                    .unwrap(),
             ))
         } else {
             None
@@ -1445,8 +1448,10 @@ pub mod options {
         #[inline]
         pub fn parent_address(&self) -> Option<Address> {
             if self.option_length() > 5 {
-                Some(Address::from_bytes(
-                    &self.buffer.as_ref()[field::TRANSIT_INFO_PARENT_ADDRESS],
+                Some(Address::from_octets(
+                    self.buffer.as_ref()[field::TRANSIT_INFO_PARENT_ADDRESS]
+                        .try_into()
+                        .unwrap(),
                 ))
             } else {
                 None
@@ -1566,11 +1571,10 @@ pub mod options {
         /// Return the DODAG ID field.
         #[inline]
         pub fn dodag_id(&self) -> Address {
-            get!(
-                self.buffer,
-                into: Address,
-                fun: from_bytes,
-                field: field::SOLICITED_INFO_DODAG_ID
+            Address::from_octets(
+                self.buffer.as_ref()[field::SOLICITED_INFO_DODAG_ID]
+                    .try_into()
+                    .unwrap(),
             )
         }
 
@@ -2055,7 +2059,9 @@ pub mod options {
                 }),
                 OptionType::RplTarget => Ok(Repr::RplTarget {
                     prefix_length: packet.target_prefix_length(),
-                    prefix: crate::wire::Ipv6Address::from_bytes(packet.target_prefix()),
+                    prefix: crate::wire::Ipv6Address::from_octets(
+                        packet.target_prefix().try_into().unwrap(),
+                    ),
                 }),
                 OptionType::TransitInformation => Ok(Repr::TransitInformation {
                     external: packet.is_external(),
@@ -2457,7 +2463,7 @@ mod tests {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ];
 
-        let addr = Address::from_bytes(&[
+        let addr = Address::from_octets([
             0xfd, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x01, 0x00, 0x01, 0x00, 0x01,
             0x00, 0x01,
         ]);
@@ -2584,7 +2590,7 @@ mod tests {
             0x00, 0x02,
         ];
 
-        let parent_addr = Address::from_bytes(&[
+        let parent_addr = Address::from_octets([
             0xfd, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x01, 0x00, 0x01, 0x00, 0x01,
             0x00, 0x01,
         ]);

--- a/src/wire/sixlowpan/nhc.rs
+++ b/src/wire/sixlowpan/nhc.rs
@@ -715,10 +715,10 @@ impl<'a> UdpNhcRepr {
                 checksum::data(packet.payload()),
             ]);
 
-            if let Some(checksum) = packet.checksum() {
-                if chk_sum != checksum {
-                    return Err(Error);
-                }
+            if let Some(checksum) = packet.checksum()
+                && chk_sum != checksum
+            {
+                return Err(Error);
             }
         }
 

--- a/src/wire/tcp.rs
+++ b/src/wire/tcp.rs
@@ -983,7 +983,7 @@ impl<'a> Repr<'a> {
         if sack_range_len > 0 {
             length += sack_range_len + 2;
         }
-        if length % 4 != 0 {
+        if !length.is_multiple_of(4) {
             length += 4 - length % 4;
         }
         length


### PR DESCRIPTION
- **Bump MSRV to 1.91**
- **wire: use Ipv[46]Address::from_octets from core.**
- **wire: use Ipv6Addr::is_unique_local() from core.**
