### PR TITLE
phy: add RxToken::preprocess hook

### DIFF
--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -632,6 +632,8 @@ impl Interface {
             return PollIngressSingleResult::None;
         };
 
+        rx_token.preprocess(sockets);
+
         let rx_meta = rx_token.meta();
         rx_token.consume(|frame| {
             if frame.is_empty() {


### PR DESCRIPTION
## Motivation

When implementing a POSIX-like TCP server with `accept()` semantics in an operating system using smoltcp, we need to pre-allocate TCP sockets when receiving SYN packets, before the packet reaches the protocol stack's normal processing flow.

Currently, there is no clean way to intercept and analyze incoming packets before they are consumed by the Interface. This leads to either:
1. Parsing packets twice (once for preprocessing, once by smoltcp)
2. Implementing complex workarounds that duplicate packet data
3. Maintaining a fork with custom modifications

## Proposed Solution

Add an optional `preprocess` method to the `RxToken` trait that allows users to inspect packet data and access the socket set before packet consumption.

### API Design

```rust
pub trait RxToken {
    fn consume<R, F>(self, f: F) -> R
    where
        F: FnOnce(&[u8]) -> R;

    fn meta(&self) -> PacketMeta {
        PacketMeta::default()
    }

    /// Optional hook called before packet consumption.
    /// 
    /// This method is invoked by `Interface::socket_ingress` after receiving
    /// a packet but before consuming it, allowing users to:
    /// - Inspect packet contents without consuming the token
    /// - Access the socket set to perform preparatory actions
    /// - Implement custom packet handling logic (e.g., pre-allocating sockets)
    /// 
    /// The default implementation does nothing, ensuring zero overhead for
    /// users who don't need this functionality.
    fn preprocess(&self, _sockets: &mut crate::iface::SocketSet<'_>) {}
}
```

###  Use Case: TCP Accept Queue
```rust
impl<'a> phy::RxToken for MyRxToken<'a> {
    fn consume<R, F>(self, f: F) -> R {
        f(self.packet_data)
    }

    fn preprocess(&self, sockets: &mut SocketSet) {
        // Parse the packet to detect TCP SYN
        if is_tcp_syn_packet(self.packet_data) {
            // Pre-create a socket in the accept queue
            prepare_tcp_socket(sockets, ...);
        }
    }
}







