### PR TITLE
iface: Honor any_ip when checking local address

### DIFF
--- a/src/iface/interface/ipv4.rs
+++ b/src/iface/interface/ipv4.rs
@@ -187,12 +187,6 @@ impl InterfaceInner {
             && !self.is_broadcast_v4(ipv4_repr.dst_addr)
         {
             // Ignore IP packets not directed at us, or broadcast, or any of the multicast groups.
-            // If AnyIP is enabled, also check if the packet is routed locally.
-
-            if !self.any_ip {
-                net_trace!("Rejecting IPv4 packet; any_ip=false");
-                return None;
-            }
 
             if !ipv4_repr.dst_addr.x_is_unicast() {
                 net_trace!(
@@ -211,6 +205,9 @@ impl InterfaceInner {
 
                 return None;
             }
+
+            net_trace!("Rejecting IPv4 packet; no assigned address");
+            return None;
         }
 
         #[cfg(feature = "medium-ethernet")]
@@ -272,7 +269,7 @@ impl InterfaceInner {
                 ..
             } => {
                 // Only process ARP packets for us.
-                if !self.has_ip_addr(target_protocol_addr) && !self.any_ip {
+                if !self.has_ip_addr(target_protocol_addr) {
                     return None;
                 }
 

--- a/src/iface/interface/ipv6.rs
+++ b/src/iface/interface/ipv6.rs
@@ -214,11 +214,6 @@ impl InterfaceInner {
             && !self.has_multicast_group(ipv6_repr.dst_addr)
             && !ipv6_repr.dst_addr.is_loopback()
         {
-            if !self.any_ip {
-                net_trace!("Rejecting IPv6 packet; any_ip=false");
-                return None;
-            }
-
             if !ipv6_repr.dst_addr.x_is_unicast() {
                 net_trace!(
                     "Rejecting IPv6 packet; {} is not a unicast address",
@@ -236,6 +231,9 @@ impl InterfaceInner {
 
                 return None;
             }
+
+            net_trace!("Rejecting IPv6 packet; no assigned address");
+            return None;
         }
 
         #[cfg(feature = "socket-raw")]

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -876,7 +876,14 @@ impl InterfaceInner {
     }
 
     /// Check whether the interface has the given IP address assigned.
+    ///
+    /// Always returns true if [`InterfaceInner::any_ip`].
     pub(crate) fn has_ip_addr<T: Into<IpAddress>>(&self, addr: T) -> bool {
+        // If any IP is set to true, we don't bother about checking the IP.
+        if self.any_ip {
+            return true;
+        }
+
         let addr = addr.into();
         self.ip_addrs.iter().any(|probe| probe.address() == addr)
     }


### PR DESCRIPTION
#1113 introduced a fix to discard packets from interfaces with non-matching source addresses.  This is a totally valid behavior in most circumstances.  However, when the `any_ip` feature is enabled, an interface should not bother with checking the source IP addresses, as the feature is described as follows:

> AnyIP allowins packets to be received locally on IP addresses other
> than the interface’s configured ip_addrs.

See #466
See <https://gitlab.torproject.org/tpo/core/onionmasq/-/issues/175>