### PR TITLE
Rely on TCP SYN retransmission to handle a larger number of incoming connections than the number of available sockets

### DIFF
--- a/src/iface/interface/tcp.rs
+++ b/src/iface/interface/tcp.rs
@@ -39,6 +39,19 @@ impl InterfaceInner {
             // Never send a TCP RST packet with unspecified addresses.
             // Never send a TCP RST when packet has been handled by raw socket.
             None
+        } else if tcp_repr.control == TcpControl::Syn {
+            // The packet is trying to open a new connection, but we don't have a socket listening on the
+            // destination port. In this case, we should just ignore the packet instead of sending a TCP RST packet.
+            //
+            // The idea is to keep the other peer re-sending the SYN packet until eventually we get a new socket
+            // listening on the destination port, at which point the connection can be established.
+            //
+            // This allows for emulating a SYN backlog, without actually having to allocate any resources for it.
+            // A typical example would be an HTTP server that is operating off from a limited number of sockets
+            // and is currently busy in that all sockets are handling requests, but the server would _still_ want
+            //  to allow new connections to be established as soon as a socket becomes available, rather than
+            // those being dropped on the floor because the SYN packet was responded to with a TCP RST packet.
+            None
         } else {
             // The packet wasn't handled by a socket, send a TCP RST packet.
             let (ip, tcp) = tcp::Socket::rst_reply(&ip_repr, &tcp_repr);


### PR DESCRIPTION
`smoltcp` (and `embassy-net`) often operate with just a handful of TCP sockets due to memory constraints.

This poses a problem when implementing something like [an HTTP server on top](https://github.com/sysgrok/edge-net/tree/master/edge-http) in that - typically - there would be only a few allocated sockets and - most often than not - **all** these sockets might be busy serving already accepted HTTP connections.

In that hypothetical scenario, what happens when a new TCP SYN packet arrives is that it is immediately refused with a TCP RST request, so the other peer (a browser, or curl or whatever) ends up with an error.

However, this is not ideal because there is a high likelihood that the "busy" sockets will - sooner rather than later - become available again for accepting new incoming connections.

One way to resolve this issue is to just have much more sockets than HTTP connection handlers, but this does not come free in terms of resources, as each socket needs a TX + RX buffer (granted, these could be small-ish, but still!). I.e. maintaining a user-level SYN acceptance queue of sorts.

Another way - which is what this PR does is to just **not** answer the incoming SYN request **at all** and rely on the other peer to re-transmit (with a back-off!) the SYN request. Where the assumption is that _eventually_ some of the busy sockets will become free during the retransmission, and the SYN packet would get accepted.

So in a way, we emulate a SYN acceptance queue by (ab)using TCP retransmission logic.

This specifically solves this issue in edge-http: https://github.com/sysgrok/edge-net/issues/80