### PR TITLE
Add raw Ethernet socket support and example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ defmt = ["dep:defmt", "heapless/defmt"]
 
 "socket" = []
 "socket-raw" = ["socket"]
+"socket-raw-ethernet" = ["socket", "medium-ethernet"]
 "socket-udp" = ["socket"]
 "socket-tcp" = ["socket"]
 "socket-tcp-pause-synack" = ["socket-tcp"]
@@ -107,7 +108,7 @@ default = [
   "phy-raw_socket", "phy-tuntap_interface",
   "proto-ipv4",  "proto-dhcpv4", "proto-ipv6", "proto-ipv6-slaac", "proto-dns",
   "proto-ipv4-fragmentation", "proto-sixlowpan-fragmentation",
-  "socket-raw", "socket-icmp", "socket-udp", "socket-tcp", "socket-dhcpv4", "socket-dns", "socket-mdns",
+  "socket-raw", "socket-raw-ethernet", "socket-icmp", "socket-udp", "socket-tcp", "socket-dhcpv4", "socket-dns", "socket-mdns",
   "packetmeta-id", "async", "multicast", "auto-icmp-echo-reply"
 ]
 
@@ -307,6 +308,10 @@ required-features = ["std", "medium-ethernet", "medium-ip", "phy-tuntap_interfac
 [[example]]
 name = "ping"
 required-features = ["std", "medium-ethernet", "medium-ip", "phy-tuntap_interface", "proto-ipv4", "proto-ipv6", "socket-icmp"]
+
+[[example]]
+name = "raw_ethernet"
+required-features = ["std", "medium-ethernet", "phy-tuntap_interface", "proto-ipv4", "socket-raw-ethernet"]
 
 [[example]]
 name = "server"

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Enable `smoltcp::phy::RawSocket` and `smoltcp::phy::TunTapInterface`, respective
 
 These features are enabled by default.
 
-### Features `socket-raw`, `socket-udp`, `socket-tcp`, `socket-icmp`, `socket-dhcpv4`, `socket-dns`
+### Features `socket-raw`, `socket-raw-ethernet`, `socket-udp`, `socket-tcp`, `socket-icmp`, `socket-dhcpv4`, `socket-dns`
 
 Enable the corresponding socket type.
 

--- a/examples/raw_ethernet.rs
+++ b/examples/raw_ethernet.rs
@@ -1,0 +1,218 @@
+//! Raw Ethernet example
+//!
+//! This example opens a raw Ethernet socket on a TAP interface and:
+//! - sends one Ethernet II frame per second;
+//! - receives frames matching a selected EtherType filter.
+//!
+//! Quick start:
+//!
+//! ```sh
+//! sudo ip tuntap add dev tap0 mode tap user "$USER"
+//! sudo ip link set dev tap0 up
+//! cargo run --example raw_ethernet -- --tap tap0 --ethertype 0x88b5
+//! ```
+//!
+//! Important:
+//! - A single TAP endpoint does not loop packets back to itself.
+//! - To observe `recv`, use two TAP interfaces bridged together and run this example on both.
+//!
+//! Two-endpoint setup:
+//!
+//! ```sh
+//! sudo ip tuntap add dev tap0 mode tap user "$USER"
+//! sudo ip tuntap add dev tap1 mode tap user "$USER"
+//! sudo ip link add br0 type bridge
+//! sudo ip link set br0 up
+//! sudo ip link set tap0 master br0
+//! sudo ip link set tap1 master br0
+//! sudo ip link set tap0 up
+//! sudo ip link set tap1 up
+//! ```
+//!
+//! Then run in two terminals:
+//!
+//! ```sh
+//! cargo run --example raw_ethernet -- --tap tap0 --ethertype 0x88b5
+//! cargo run --example raw_ethernet -- --tap tap1 --ethertype 0x88b5
+//! ```
+//!
+//! Optional flags:
+//! - `--src aa:bb:cc:dd:ee:ff`
+//! - `--dst aa:bb:cc:dd:ee:ff`
+//! - `--payload "text"`
+//!
+mod utils;
+
+use std::os::unix::io::AsRawFd;
+
+use smoltcp::iface::{Config, Interface, SocketSet};
+use smoltcp::phy::wait as phy_wait;
+use smoltcp::socket::raw_ethernet;
+use smoltcp::time::{Duration, Instant};
+use smoltcp::wire::{EthernetAddress, EthernetFrame, EthernetProtocol, EthernetRepr};
+
+fn parse_ethertype(input: &str) -> Result<u16, String> {
+    let s = input
+        .strip_prefix("0x")
+        .or_else(|| input.strip_prefix("0X"))
+        .unwrap_or(input);
+    u16::from_str_radix(s, 16).map_err(|_| format!("invalid ethertype: {input}"))
+}
+
+fn parse_mac(input: &str) -> Result<EthernetAddress, String> {
+    let mut out = [0u8; 6];
+    let mut count = 0usize;
+
+    for part in input.split(':') {
+        if count >= 6 {
+            return Err(format!("invalid MAC address: {input}"));
+        }
+        if part.len() != 2 {
+            return Err(format!("invalid MAC address: {input}"));
+        }
+        out[count] = u8::from_str_radix(part, 16)
+            .map_err(|_| format!("invalid MAC address octet '{part}' in {input}"))?;
+        count += 1;
+    }
+
+    if count != 6 {
+        return Err(format!("invalid MAC address: {input}"));
+    }
+
+    Ok(EthernetAddress(out))
+}
+
+fn main() {
+    utils::setup_logging("info");
+
+    let (mut opts, mut free) = utils::create_options();
+    utils::add_tuntap_options(&mut opts, &mut free);
+    utils::add_middleware_options(&mut opts, &mut free);
+
+    opts.optopt(
+        "",
+        "ethertype",
+        "EtherType in hex (for filter and emitted frame), default 0x88b5",
+        "HEX",
+    );
+    opts.optopt(
+        "",
+        "dst",
+        "Destination MAC as aa:bb:cc:dd:ee:ff, default ff:ff:ff:ff:ff:ff",
+        "MAC",
+    );
+    opts.optopt(
+        "",
+        "src",
+        "Source MAC as aa:bb:cc:dd:ee:ff, default 02:00:00:00:00:01",
+        "MAC",
+    );
+    opts.optopt(
+        "",
+        "payload",
+        "ASCII payload to emit periodically, default 'smoltcp raw ethernet'",
+        "TEXT",
+    );
+
+    let mut matches = utils::parse_options(&opts, free);
+    let device = utils::parse_tuntap_options(&mut matches);
+    let fd = device.as_raw_fd();
+    let mut device =
+        utils::parse_middleware_options(&mut matches, device, /*loopback=*/ false);
+
+    let ethertype = matches
+        .opt_str("ethertype")
+        .as_deref()
+        .map(parse_ethertype)
+        .transpose()
+        .expect("invalid --ethertype")
+        .unwrap_or(0x88b5);
+    let dst = matches
+        .opt_str("dst")
+        .as_deref()
+        .map(parse_mac)
+        .transpose()
+        .expect("invalid --dst")
+        .unwrap_or(EthernetAddress::BROADCAST);
+    let src = matches
+        .opt_str("src")
+        .as_deref()
+        .map(parse_mac)
+        .transpose()
+        .expect("invalid --src")
+        .unwrap_or(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]));
+
+    let payload = matches
+        .opt_str("payload")
+        .unwrap_or_else(|| "smoltcp raw ethernet".to_string())
+        .into_bytes();
+
+    let mut config = Config::new(src.into());
+    config.random_seed = rand::random();
+    let mut iface = Interface::new(config, &mut device, Instant::now());
+
+    let rx_buffer = raw_ethernet::PacketBuffer::new(
+        vec![raw_ethernet::PacketMetadata::EMPTY; 8],
+        vec![0; 1536 * 8],
+    );
+    let tx_buffer = raw_ethernet::PacketBuffer::new(
+        vec![raw_ethernet::PacketMetadata::EMPTY; 8],
+        vec![0; 1536 * 8],
+    );
+    let raw_socket = raw_ethernet::Socket::new(
+        Some(EthernetProtocol::Unknown(ethertype)),
+        rx_buffer,
+        tx_buffer,
+    );
+
+    let mut sockets = SocketSet::new(vec![]);
+    let raw_handle = sockets.add(raw_socket);
+
+    let mut next_tx_at = Instant::from_millis(0);
+
+    println!("raw ethernet example started: ethertype=0x{ethertype:04x}, src={src}, dst={dst}");
+
+    loop {
+        let timestamp = Instant::now();
+        iface.poll(timestamp, &mut device, &mut sockets);
+
+        {
+            let socket = sockets.get_mut::<raw_ethernet::Socket>(raw_handle);
+
+            if socket.can_send() && timestamp >= next_tx_at {
+                let frame_len = EthernetFrame::<&[u8]>::header_len() + payload.len();
+                let frame_buf = socket.send(frame_len).expect("send buffer full");
+                let mut frame = EthernetFrame::new_unchecked(frame_buf);
+
+                EthernetRepr {
+                    src_addr: src,
+                    dst_addr: dst,
+                    ethertype: EthernetProtocol::Unknown(ethertype),
+                }
+                .emit(&mut frame);
+                frame.payload_mut().copy_from_slice(&payload);
+
+                println!("sent {} bytes", frame_len);
+                next_tx_at = timestamp + Duration::from_secs(1);
+            }
+
+            while socket.can_recv() {
+                let data = socket.recv().expect("recv should succeed");
+                let frame = EthernetFrame::new_checked(data).expect("malformed frame from socket");
+                println!(
+                    "recv {} bytes: src={} dst={} ethertype={} payload={:x?}",
+                    data.len(),
+                    frame.src_addr(),
+                    frame.dst_addr(),
+                    frame.ethertype(),
+                    frame.payload()
+                );
+            }
+        }
+
+        let delay = iface
+            .poll_delay(timestamp, &sockets)
+            .unwrap_or(Duration::from_millis(100));
+        phy_wait(fd, Some(delay)).expect("wait error");
+    }
+}

--- a/src/iface/interface/ethernet.rs
+++ b/src/iface/interface/ethernet.rs
@@ -18,6 +18,10 @@ impl InterfaceInner {
             return None;
         }
 
+        #[cfg(feature = "socket-raw-ethernet")]
+        let _handled_by_raw_ethernet_socket =
+            self.raw_ethernet_socket_filter(sockets, &eth_frame, frame);
+
         match eth_frame.ethertype() {
             #[cfg(feature = "proto-ipv4")]
             EthernetProtocol::Arp => self.process_arp(self.now, &eth_frame),

--- a/src/iface/interface/tests/ethernet.rs
+++ b/src/iface/interface/tests/ethernet.rs
@@ -1,0 +1,113 @@
+use super::*;
+
+#[cfg(feature = "socket-raw-ethernet")]
+use crate::socket::raw_ethernet;
+
+#[cfg(feature = "socket-raw-ethernet")]
+fn make_frame(ethertype: EthernetProtocol) -> [u8; 18] {
+    let mut bytes = [0u8; 18];
+    let mut frame = EthernetFrame::new_unchecked(&mut bytes[..]);
+    EthernetRepr {
+        src_addr: EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]),
+        dst_addr: EthernetAddress([0x02, 0x02, 0x02, 0x02, 0x02, 0x02]),
+        ethertype,
+    }
+    .emit(&mut frame);
+    frame
+        .payload_mut()
+        .copy_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+    bytes
+}
+
+#[test]
+#[cfg(all(feature = "medium-ethernet", feature = "socket-raw-ethernet"))]
+fn test_raw_ethernet_socket_captures_unknown_ethertype() {
+    let (mut iface, mut sockets, _) = setup(Medium::Ethernet);
+
+    let rx_buffer =
+        raw_ethernet::PacketBuffer::new(vec![raw_ethernet::PacketMetadata::EMPTY], vec![0; 64]);
+    let tx_buffer =
+        raw_ethernet::PacketBuffer::new(vec![raw_ethernet::PacketMetadata::EMPTY], vec![0; 64]);
+    let handle = sockets.add(raw_ethernet::Socket::new(None, rx_buffer, tx_buffer));
+
+    let frame = make_frame(EthernetProtocol::Unknown(0x88b5));
+
+    assert_eq!(
+        iface.inner.process_ethernet(
+            &mut sockets,
+            PacketMeta::default(),
+            &frame,
+            &mut iface.fragments,
+        ),
+        None
+    );
+
+    let socket = sockets.get_mut::<raw_ethernet::Socket>(handle);
+    assert!(socket.can_recv());
+    assert_eq!(socket.recv(), Ok(&frame[..]));
+}
+
+#[test]
+#[cfg(all(feature = "medium-ethernet", feature = "socket-raw-ethernet"))]
+fn test_raw_ethernet_socket_ethertype_filter() {
+    let (mut iface, mut sockets, _) = setup(Medium::Ethernet);
+
+    let rx_buffer =
+        raw_ethernet::PacketBuffer::new(vec![raw_ethernet::PacketMetadata::EMPTY], vec![0; 64]);
+    let tx_buffer =
+        raw_ethernet::PacketBuffer::new(vec![raw_ethernet::PacketMetadata::EMPTY], vec![0; 64]);
+    let handle = sockets.add(raw_ethernet::Socket::new(
+        Some(EthernetProtocol::Unknown(0x88b5)),
+        rx_buffer,
+        tx_buffer,
+    ));
+
+    let accepted = make_frame(EthernetProtocol::Unknown(0x88b5));
+    let rejected = make_frame(EthernetProtocol::Unknown(0x88b6));
+
+    let _ = iface.inner.process_ethernet(
+        &mut sockets,
+        PacketMeta::default(),
+        &accepted,
+        &mut iface.fragments,
+    );
+    let _ = iface.inner.process_ethernet(
+        &mut sockets,
+        PacketMeta::default(),
+        &rejected,
+        &mut iface.fragments,
+    );
+
+    let socket = sockets.get_mut::<raw_ethernet::Socket>(handle);
+    assert!(socket.can_recv());
+    assert_eq!(socket.recv(), Ok(&accepted[..]));
+    assert!(!socket.can_recv());
+}
+
+#[test]
+#[cfg(all(feature = "medium-ethernet", feature = "socket-raw-ethernet"))]
+fn test_raw_ethernet_socket_egress_transmits_verbatim_frame() {
+    use crate::time::Instant;
+
+    let (mut iface, mut sockets, mut device) = setup(Medium::Ethernet);
+
+    let rx_buffer =
+        raw_ethernet::PacketBuffer::new(vec![raw_ethernet::PacketMetadata::EMPTY], vec![0; 64]);
+    let tx_buffer =
+        raw_ethernet::PacketBuffer::new(vec![raw_ethernet::PacketMetadata::EMPTY], vec![0; 64]);
+    let handle = sockets.add(raw_ethernet::Socket::new(None, rx_buffer, tx_buffer));
+
+    let frame = make_frame(EthernetProtocol::Unknown(0x88b5));
+    {
+        let socket = sockets.get_mut::<raw_ethernet::Socket>(handle);
+        assert_eq!(socket.send_slice(&frame), Ok(()));
+    }
+
+    assert_eq!(
+        iface.poll(Instant::from_millis(0), &mut device, &mut sockets),
+        PollResult::SocketStateChanged
+    );
+
+    let transmitted: Vec<Vec<u8>> = device.tx_queue.drain(..).collect();
+    assert!(transmitted.iter().any(|pkt| pkt.as_slice() == frame));
+}

--- a/src/iface/interface/tests/mod.rs
+++ b/src/iface/interface/tests/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "medium-ethernet")]
+mod ethernet;
 #[cfg(feature = "proto-ipv4")]
 mod ipv4;
 #[cfg(feature = "proto-ipv6")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,7 @@ compile_error!(
     feature = "socket",
     not(any(
         feature = "socket-raw",
+        feature = "socket-raw-ethernet",
         feature = "socket-udp",
         feature = "socket-tcp",
         feature = "socket-icmp",
@@ -112,7 +113,7 @@ compile_error!(
     ))
 ))]
 compile_error!(
-    "If you enable the socket feature, you must enable at least one of the following features: socket-raw, socket-udp, socket-tcp, socket-icmp, socket-dhcpv4, socket-dns"
+    "If you enable the socket feature, you must enable at least one of the following features: socket-raw, socket-raw-ethernet, socket-udp, socket-tcp, socket-icmp, socket-dhcpv4, socket-dns"
 );
 
 #[cfg(all(

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -22,6 +22,8 @@ pub mod dns;
 pub mod icmp;
 #[cfg(feature = "socket-raw")]
 pub mod raw;
+#[cfg(feature = "socket-raw-ethernet")]
+pub mod raw_ethernet;
 #[cfg(feature = "socket-tcp")]
 pub mod tcp;
 #[cfg(feature = "socket-udp")]
@@ -60,6 +62,8 @@ pub(crate) enum PollAt {
 pub enum Socket<'a> {
     #[cfg(feature = "socket-raw")]
     Raw(raw::Socket<'a>),
+    #[cfg(feature = "socket-raw-ethernet")]
+    RawEthernet(raw_ethernet::Socket<'a>),
     #[cfg(feature = "socket-icmp")]
     Icmp(icmp::Socket<'a>),
     #[cfg(feature = "socket-udp")]
@@ -77,6 +81,8 @@ impl<'a> Socket<'a> {
         match self {
             #[cfg(feature = "socket-raw")]
             Socket::Raw(s) => s.poll_at(cx),
+            #[cfg(feature = "socket-raw-ethernet")]
+            Socket::RawEthernet(s) => s.poll_at(cx),
             #[cfg(feature = "socket-icmp")]
             Socket::Icmp(s) => s.poll_at(cx),
             #[cfg(feature = "socket-udp")]
@@ -153,6 +159,8 @@ macro_rules! from_socket {
 
 #[cfg(feature = "socket-raw")]
 from_socket!(raw::Socket<'a>, Raw);
+#[cfg(feature = "socket-raw-ethernet")]
+from_socket!(raw_ethernet::Socket<'a>, RawEthernet);
 #[cfg(feature = "socket-icmp")]
 from_socket!(icmp::Socket<'a>, Icmp);
 #[cfg(feature = "socket-udp")]

--- a/src/socket/raw_ethernet.rs
+++ b/src/socket/raw_ethernet.rs
@@ -1,0 +1,407 @@
+use core::cmp::min;
+#[cfg(feature = "async")]
+use core::task::Waker;
+
+use crate::iface::Context;
+use crate::socket::PollAt;
+#[cfg(feature = "async")]
+use crate::socket::WakerRegistration;
+
+use crate::storage::Empty;
+use crate::wire::{EthernetFrame, EthernetProtocol};
+
+/// Error returned by [`Socket::send`]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum SendError {
+    BufferFull,
+}
+
+impl core::fmt::Display for SendError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self {
+            SendError::BufferFull => write!(f, "buffer full"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for SendError {}
+
+/// Error returned by [`Socket::recv`]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum RecvError {
+    Exhausted,
+    Truncated,
+}
+
+impl core::fmt::Display for RecvError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self {
+            RecvError::Exhausted => write!(f, "exhausted"),
+            RecvError::Truncated => write!(f, "truncated"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for RecvError {}
+
+/// An Ethernet packet metadata.
+pub type PacketMetadata = crate::storage::PacketMetadata<()>;
+
+/// An Ethernet packet ring buffer.
+pub type PacketBuffer<'a> = crate::storage::PacketBuffer<'a, ()>;
+
+/// A raw Ethernet socket.
+///
+/// A raw Ethernet socket can be optionally filtered by EtherType,
+/// and owns transmit and receive packet buffers.
+#[derive(Debug)]
+pub struct Socket<'a> {
+    ethertype: Option<EthernetProtocol>,
+    rx_buffer: PacketBuffer<'a>,
+    tx_buffer: PacketBuffer<'a>,
+    #[cfg(feature = "async")]
+    rx_waker: WakerRegistration,
+    #[cfg(feature = "async")]
+    tx_waker: WakerRegistration,
+}
+
+impl<'a> Socket<'a> {
+    /// Create a raw Ethernet socket bound to the given EtherType, with the given buffers.
+    pub fn new(
+        ethertype: Option<EthernetProtocol>,
+        rx_buffer: PacketBuffer<'a>,
+        tx_buffer: PacketBuffer<'a>,
+    ) -> Socket<'a> {
+        Socket {
+            ethertype,
+            rx_buffer,
+            tx_buffer,
+            #[cfg(feature = "async")]
+            rx_waker: WakerRegistration::new(),
+            #[cfg(feature = "async")]
+            tx_waker: WakerRegistration::new(),
+        }
+    }
+
+    /// Register a waker for receive operations.
+    #[cfg(feature = "async")]
+    pub fn register_recv_waker(&mut self, waker: &Waker) {
+        self.rx_waker.register(waker)
+    }
+
+    /// Register a waker for send operations.
+    #[cfg(feature = "async")]
+    pub fn register_send_waker(&mut self, waker: &Waker) {
+        self.tx_waker.register(waker)
+    }
+
+    /// Return the EtherType the socket is bound to.
+    #[inline]
+    pub fn ethertype(&self) -> Option<EthernetProtocol> {
+        self.ethertype
+    }
+
+    /// Check whether the transmit buffer is full.
+    #[inline]
+    pub fn can_send(&self) -> bool {
+        !self.tx_buffer.is_full()
+    }
+
+    /// Check whether the receive buffer is not empty.
+    #[inline]
+    pub fn can_recv(&self) -> bool {
+        !self.rx_buffer.is_empty()
+    }
+
+    /// Return the maximum number packets the socket can receive.
+    #[inline]
+    pub fn packet_recv_capacity(&self) -> usize {
+        self.rx_buffer.packet_capacity()
+    }
+
+    /// Return the maximum number packets the socket can transmit.
+    #[inline]
+    pub fn packet_send_capacity(&self) -> usize {
+        self.tx_buffer.packet_capacity()
+    }
+
+    /// Return the maximum number of bytes inside the recv buffer.
+    #[inline]
+    pub fn payload_recv_capacity(&self) -> usize {
+        self.rx_buffer.payload_capacity()
+    }
+
+    /// Return the maximum number of bytes inside the transmit buffer.
+    #[inline]
+    pub fn payload_send_capacity(&self) -> usize {
+        self.tx_buffer.payload_capacity()
+    }
+
+    /// Enqueue a frame to send, and return a pointer to its bytes.
+    pub fn send(&mut self, size: usize) -> Result<&mut [u8], SendError> {
+        let frame_buf = self
+            .tx_buffer
+            .enqueue(size, ())
+            .map_err(|_| SendError::BufferFull)?;
+
+        net_trace!(
+            "raw-eth:{:?}: buffer to send {} octets",
+            self.ethertype,
+            frame_buf.len()
+        );
+        Ok(frame_buf)
+    }
+
+    /// Enqueue a frame to be sent and pass the buffer to the provided closure.
+    pub fn send_with<F>(&mut self, max_size: usize, f: F) -> Result<usize, SendError>
+    where
+        F: FnOnce(&mut [u8]) -> usize,
+    {
+        let size = self
+            .tx_buffer
+            .enqueue_with_infallible(max_size, (), f)
+            .map_err(|_| SendError::BufferFull)?;
+
+        net_trace!(
+            "raw-eth:{:?}: buffer to send {} octets",
+            self.ethertype,
+            size
+        );
+
+        Ok(size)
+    }
+
+    /// Enqueue a frame to send, and fill it from a slice.
+    pub fn send_slice(&mut self, data: &[u8]) -> Result<(), SendError> {
+        self.send(data.len())?.copy_from_slice(data);
+        Ok(())
+    }
+
+    /// Dequeue a frame and return a pointer to its bytes.
+    pub fn recv(&mut self) -> Result<&[u8], RecvError> {
+        let ((), frame_buf) = self.rx_buffer.dequeue().map_err(|_| RecvError::Exhausted)?;
+
+        net_trace!(
+            "raw-eth:{:?}: receive {} buffered octets",
+            self.ethertype,
+            frame_buf.len()
+        );
+        Ok(frame_buf)
+    }
+
+    /// Dequeue a frame and copy the frame bytes into the given slice.
+    pub fn recv_slice(&mut self, data: &mut [u8]) -> Result<usize, RecvError> {
+        let buffer = self.recv()?;
+        if data.len() < buffer.len() {
+            return Err(RecvError::Truncated);
+        }
+
+        let length = min(data.len(), buffer.len());
+        data[..length].copy_from_slice(&buffer[..length]);
+        Ok(length)
+    }
+
+    /// Peek at a frame in the receive buffer without removing it.
+    pub fn peek(&mut self) -> Result<&[u8], RecvError> {
+        let ((), frame_buf) = self.rx_buffer.peek().map_err(|_| RecvError::Exhausted)?;
+
+        net_trace!(
+            "raw-eth:{:?}: receive {} buffered octets",
+            self.ethertype,
+            frame_buf.len()
+        );
+
+        Ok(frame_buf)
+    }
+
+    /// Peek at a frame in the receive buffer and copy it into the given slice.
+    pub fn peek_slice(&mut self, data: &mut [u8]) -> Result<usize, RecvError> {
+        let buffer = self.peek()?;
+        if data.len() < buffer.len() {
+            return Err(RecvError::Truncated);
+        }
+
+        let length = min(data.len(), buffer.len());
+        data[..length].copy_from_slice(&buffer[..length]);
+        Ok(length)
+    }
+
+    /// Return the amount of octets queued in the transmit buffer.
+    pub fn send_queue(&self) -> usize {
+        self.tx_buffer.payload_bytes_count()
+    }
+
+    /// Return the amount of octets queued in the receive buffer.
+    pub fn recv_queue(&self) -> usize {
+        self.rx_buffer.payload_bytes_count()
+    }
+
+    pub(crate) fn accepts(&self, frame: &EthernetFrame<&[u8]>) -> bool {
+        if self
+            .ethertype
+            .is_some_and(|ethertype| ethertype != frame.ethertype())
+        {
+            return false;
+        }
+
+        true
+    }
+
+    pub(crate) fn process(&mut self, _cx: &mut Context, frame: &[u8]) {
+        net_trace!(
+            "raw-eth:{:?}: receiving {} octets",
+            self.ethertype,
+            frame.len()
+        );
+
+        match self.rx_buffer.enqueue(frame.len(), ()) {
+            Ok(buf) => buf.copy_from_slice(frame),
+            Err(_) => net_trace!(
+                "raw-eth:{:?}: buffer full, dropped incoming frame",
+                self.ethertype
+            ),
+        }
+
+        #[cfg(feature = "async")]
+        self.rx_waker.wake();
+    }
+
+    pub(crate) fn dispatch<F, E>(&mut self, _cx: &mut Context, emit: F) -> Result<(), E>
+    where
+        F: FnOnce(&mut Context, &[u8]) -> Result<(), E>,
+    {
+        let ethertype = self.ethertype;
+        let res = self.tx_buffer.dequeue_with(|&mut (), buffer| {
+            let frame = match EthernetFrame::new_checked(&*buffer) {
+                Ok(x) => x,
+                Err(_) => {
+                    net_trace!("raw-eth: malformed frame in queue, dropping.");
+                    return Ok(());
+                }
+            };
+
+            if ethertype.is_some_and(|bound| bound != frame.ethertype()) {
+                net_trace!("raw-eth: sent frame with wrong ethertype, dropping.");
+                return Ok(());
+            }
+
+            net_trace!("raw-eth:{:?}: sending", ethertype);
+            emit(_cx, buffer)
+        });
+
+        match res {
+            Err(Empty) => Ok(()),
+            Ok(Err(e)) => Err(e),
+            Ok(Ok(())) => {
+                #[cfg(feature = "async")]
+                self.tx_waker.wake();
+                Ok(())
+            }
+        }
+    }
+
+    pub(crate) fn poll_at(&self, _cx: &mut Context) -> PollAt {
+        if self.tx_buffer.is_empty() {
+            PollAt::Ingress
+        } else {
+            PollAt::Now
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::phy::Medium;
+    use crate::tests::setup;
+    use rstest::*;
+
+    use super::*;
+    use crate::wire::{EthernetAddress, EthernetFrame, EthernetProtocol, EthernetRepr};
+
+    fn buffer(packets: usize) -> PacketBuffer<'static> {
+        PacketBuffer::new(vec![PacketMetadata::EMPTY; packets], vec![0; 64 * packets])
+    }
+
+    fn frame_bytes(ethertype: EthernetProtocol) -> [u8; 18] {
+        let mut bytes = [0u8; 18];
+        let mut frame = EthernetFrame::new_unchecked(&mut bytes[..]);
+        EthernetRepr {
+            src_addr: EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]),
+            dst_addr: EthernetAddress::BROADCAST,
+            ethertype,
+        }
+        .emit(&mut frame);
+        frame
+            .payload_mut()
+            .copy_from_slice(&[0xaa, 0xbb, 0xcc, 0xdd]);
+        bytes
+    }
+
+    #[rstest]
+    #[case::ethernet(Medium::Ethernet)]
+    #[cfg(feature = "medium-ethernet")]
+    fn test_send_dispatch(#[case] medium: Medium) {
+        let (mut iface, _, _) = setup(medium);
+        let cx = iface.context();
+        let mut socket = Socket::new(Some(EthernetProtocol::Ipv4), buffer(0), buffer(1));
+
+        let tx = frame_bytes(EthernetProtocol::Ipv4);
+        assert_eq!(socket.send_slice(&tx), Ok(()));
+
+        assert_eq!(
+            socket.dispatch(cx, |_, data| {
+                assert_eq!(data, &tx);
+                Ok::<_, ()>(())
+            }),
+            Ok(())
+        );
+    }
+
+    #[rstest]
+    #[case::ethernet(Medium::Ethernet)]
+    #[cfg(feature = "medium-ethernet")]
+    fn test_send_wrong_ethertype_dropped(#[case] medium: Medium) {
+        let (mut iface, _, _) = setup(medium);
+        let cx = iface.context();
+        let mut socket = Socket::new(Some(EthernetProtocol::Ipv6), buffer(0), buffer(1));
+
+        let tx = frame_bytes(EthernetProtocol::Ipv4);
+        assert_eq!(socket.send_slice(&tx), Ok(()));
+
+        assert_eq!(socket.dispatch(cx, |_, _| unreachable!()), Ok::<_, ()>(()));
+    }
+
+    #[rstest]
+    #[case::ethernet(Medium::Ethernet)]
+    #[cfg(feature = "medium-ethernet")]
+    fn test_recv_process(#[case] medium: Medium) {
+        let (mut iface, _, _) = setup(medium);
+        let cx = iface.context();
+        let mut socket = Socket::new(Some(EthernetProtocol::Ipv4), buffer(1), buffer(0));
+
+        let rx = frame_bytes(EthernetProtocol::Ipv4);
+        let frame = EthernetFrame::new_checked(&rx[..]).unwrap();
+
+        assert!(socket.accepts(&frame));
+        socket.process(cx, &rx);
+
+        assert_eq!(socket.recv(), Ok(&rx[..]));
+    }
+
+    #[test]
+    fn test_accepts_filter() {
+        let socket = Socket::new(Some(EthernetProtocol::Arp), buffer(1), buffer(1));
+        let ipv4 = frame_bytes(EthernetProtocol::Ipv4);
+        let arp = frame_bytes(EthernetProtocol::Arp);
+
+        let ipv4_frame = EthernetFrame::new_checked(&ipv4[..]).unwrap();
+        let arp_frame = EthernetFrame::new_checked(&arp[..]).unwrap();
+
+        assert!(!socket.accepts(&ipv4_frame));
+        assert!(socket.accepts(&arp_frame));
+    }
+}


### PR DESCRIPTION
Introduce a new raw Ethernet socket type behind the socket-raw-ethernet feature, with EtherType filtering and verbatim Ethernet II frame RX/TX.

Integrate raw Ethernet sockets into interface ingress/egress paths, add Ethernet-focused tests, update feature documentation, and include a TAP-based raw_ethernet example with usage guidance.