### PR TITLE
feat: convert Enpoint into SocketAddr

### DIFF
--- a/src/wire/ip.rs
+++ b/src/wire/ip.rs
@@ -394,6 +394,12 @@ impl From<::core::net::SocketAddrV6> for Endpoint {
     }
 }
 
+impl From<Endpoint> for ::core::net::SocketAddr {
+    fn from(x: Endpoint) -> ::core::net::SocketAddr {
+        ::core::net::SocketAddr::new(x.addr.into(), x.port)
+    }
+}
+
 impl fmt::Display for Endpoint {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}:{}", self.addr, self.port)


### PR DESCRIPTION
## Motivation

`smoltcp::wire::Endpoint` already supports conversion from `core::net::SocketAddr` (and v4/v6 variants), but there is no reverse conversion back to `SocketAddr`.

In real integrations, this causes small but repeated friction when interacting with APIs or logging paths that use standard Rust socket address types:
- Rewriting the same manual conversion logic in multiple places
- Reduced ergonomics when bridging smoltcp types with `core/std`-based code
- Asymmetric conversion API (`SocketAddr -> Endpoint` exists, reverse does not)

## Proposed Solution

A direct conversion from `Endpoint` to `core::net::SocketAddr` should be added. This makes conversion support symmetrical and removes boilerplate when interoperating with the Rust networking ecosystem.

## API Design

```rust
impl From<Endpoint> for ::core::net::SocketAddr {
    fn from(x: Endpoint) -> ::core::net::SocketAddr {
        ::core::net::SocketAddr::new(x.addr.into(), x.port)
    }
}
```