### PR TITLE
iface: check silent_until expiry in Meta::poll_at

### DIFF
--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -588,10 +588,11 @@ impl Interface {
             .items()
             .filter_map(|item| {
                 let socket_poll_at = item.socket.poll_at(&mut self.inner);
-                match item
-                    .meta
-                    .poll_at(socket_poll_at, |ip_addr| self.inner.has_neighbor(&ip_addr))
-                {
+                match item.meta.poll_at(
+                    socket_poll_at,
+                    |ip_addr| self.inner.has_neighbor(&ip_addr),
+                    timestamp,
+                ) {
                     PollAt::Ingress => None,
                     PollAt::Time(instant) => Some(instant),
                     PollAt::Now => Some(Instant::from_millis(0)),

--- a/src/iface/socket_meta.rs
+++ b/src/iface/socket_meta.rs
@@ -45,13 +45,21 @@ impl Meta {
     /// See also `iface::NeighborCache::SILENT_TIME`.
     pub(crate) const DISCOVERY_SILENT_TIME: Duration = Duration::from_millis(1_000);
 
-    pub(crate) fn poll_at<F>(&self, socket_poll_at: PollAt, has_neighbor: F) -> PollAt
+    pub(crate) fn poll_at<F>(
+        &self,
+        socket_poll_at: PollAt,
+        has_neighbor: F,
+        timestamp: Instant,
+    ) -> PollAt
     where
         F: Fn(IpAddress) -> bool,
     {
         match self.neighbor_state {
             NeighborState::Active => socket_poll_at,
             NeighborState::Waiting { neighbor, .. } if has_neighbor(neighbor) => socket_poll_at,
+            NeighborState::Waiting { silent_until, .. } if timestamp >= silent_until => {
+                socket_poll_at
+            }
             NeighborState::Waiting { silent_until, .. } => PollAt::Time(silent_until),
         }
     }
@@ -99,5 +107,124 @@ impl Meta {
             neighbor,
             silent_until: timestamp + Self::DISCOVERY_SILENT_TIME,
         };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "proto-ipv4")]
+    const NEIGHBOR: IpAddress = IpAddress::v4(192, 168, 1, 1);
+    #[cfg(not(feature = "proto-ipv4"))]
+    const NEIGHBOR: IpAddress = IpAddress::v6(0xfe80, 0, 0, 0, 0, 0, 0, 1);
+
+    fn meta() -> Meta {
+        Meta {
+            handle: SocketHandle::default(),
+            neighbor_state: NeighborState::Active,
+        }
+    }
+
+    #[test]
+    fn poll_at_active_passes_through() {
+        let m = meta();
+        let t = Instant::from_millis(1000);
+
+        assert_eq!(m.poll_at(PollAt::Ingress, |_| false, t), PollAt::Ingress);
+        assert_eq!(m.poll_at(PollAt::Now, |_| false, t), PollAt::Now);
+        let future = Instant::from_millis(2000);
+        assert_eq!(
+            m.poll_at(PollAt::Time(future), |_| false, t),
+            PollAt::Time(future),
+        );
+    }
+
+    #[test]
+    fn poll_at_waiting_neighbor_found() {
+        let mut m = meta();
+        m.neighbor_missing(Instant::from_millis(1000), NEIGHBOR);
+
+        assert_eq!(
+            m.poll_at(PollAt::Now, |_| true, Instant::from_millis(1000)),
+            PollAt::Now,
+        );
+        assert_eq!(
+            m.poll_at(PollAt::Ingress, |_| true, Instant::from_millis(1000)),
+            PollAt::Ingress,
+        );
+    }
+
+    #[test]
+    fn poll_at_waiting_before_silent_until() {
+        let mut m = meta();
+        let t0 = Instant::from_millis(1000);
+        m.neighbor_missing(t0, NEIGHBOR);
+        let silent_until = t0 + Meta::DISCOVERY_SILENT_TIME;
+
+        let t_before = Instant::from_millis(1500);
+        assert!(t_before < silent_until);
+
+        assert_eq!(
+            m.poll_at(PollAt::Ingress, |_| false, t_before),
+            PollAt::Time(silent_until),
+        );
+        assert_eq!(
+            m.poll_at(PollAt::Now, |_| false, t_before),
+            PollAt::Time(silent_until),
+        );
+    }
+
+    #[test]
+    fn poll_at_waiting_after_silent_until_returns_socket_poll_at() {
+        let mut m = meta();
+        let t0 = Instant::from_millis(1000);
+        m.neighbor_missing(t0, NEIGHBOR);
+        let silent_until = t0 + Meta::DISCOVERY_SILENT_TIME;
+
+        let t_after = Instant::from_millis(2500);
+        assert!(t_after >= silent_until);
+
+        assert_eq!(
+            m.poll_at(PollAt::Ingress, |_| false, t_after),
+            PollAt::Ingress,
+        );
+        assert_eq!(m.poll_at(PollAt::Now, |_| false, t_after), PollAt::Now);
+        let future = Instant::from_millis(5000);
+        assert_eq!(
+            m.poll_at(PollAt::Time(future), |_| false, t_after),
+            PollAt::Time(future),
+        );
+    }
+
+    #[test]
+    fn poll_at_waiting_at_exact_silent_until() {
+        let mut m = meta();
+        let t0 = Instant::from_millis(1000);
+        m.neighbor_missing(t0, NEIGHBOR);
+        let silent_until = t0 + Meta::DISCOVERY_SILENT_TIME;
+
+        assert_eq!(
+            m.poll_at(PollAt::Ingress, |_| false, silent_until),
+            PollAt::Ingress,
+        );
+    }
+
+    #[test]
+    fn egress_permitted_consistent_with_poll_at() {
+        let mut m = meta();
+        let t0 = Instant::from_millis(1000);
+        m.neighbor_missing(t0, NEIGHBOR);
+        let silent_until = t0 + Meta::DISCOVERY_SILENT_TIME;
+
+        let t_before = Instant::from_millis(1500);
+        assert!(!m.egress_permitted(t_before, |_| false));
+        assert_eq!(
+            m.poll_at(PollAt::Ingress, |_| false, t_before),
+            PollAt::Time(silent_until),
+        );
+
+        let t_after = Instant::from_millis(2500);
+        assert!(m.egress_permitted(t_after, |_| false));
     }
 }


### PR DESCRIPTION
When a DNS query times out and the neighbor (gateway) is unresolved, Meta::poll_at returns PollAt::Time(silent_until) even after the silence period has passed. Since the DNS socket has no pending queries, its dispatch returns Ok without calling neighbor_missing, so silent_until is never refreshed. The stale past timestamp causes poll_at to return immediately on every call, spinning the event loop at 100% CPU.

Add a timestamp parameter to Meta::poll_at and check whether silent_until has expired. When it has, fall through to socket_poll_at instead of returning the stale value. This is consistent with the existing expiry check in egress_permitted.

Fixes #1096