### PR TITLE
doc: fix cargo doc url complaints

### DIFF
--- a/src/phy/sys/bpf.rs
+++ b/src/phy/sys/bpf.rs
@@ -42,9 +42,9 @@ const SIZEOF_BPF_HDR: usize = 18;
 #[cfg(any(target_os = "openbsd", target_os = "freebsd"))]
 const SIZEOF_BPF_HDR: usize = 24;
 /// The actual header length may be larger than the bpf_hdr struct due to aligning
-/// see https://github.com/openbsd/src/blob/37ecb4d066e5566411cc16b362d3960c93b1d0be/sys/net/bpf.c#L1649
-/// and https://github.com/apple/darwin-xnu/blob/8f02f2a044b9bb1ad951987ef5bab20ec9486310/bsd/net/bpf.c#L3580
-/// and https://github.com/NetBSD/src/blob/13d937d9ba3db87c9a898a40a8ed9d2aab2b1b95/sys/net/bpf.c#L1988
+/// see <https://github.com/openbsd/src/blob/37ecb4d066e5566411cc16b362d3960c93b1d0be/sys/net/bpf.c#L1649>
+/// and <https://github.com/apple/darwin-xnu/blob/8f02f2a044b9bb1ad951987ef5bab20ec9486310/bsd/net/bpf.c#L3580>
+/// and <https://github.com/NetBSD/src/blob/13d937d9ba3db87c9a898a40a8ed9d2aab2b1b95/sys/net/bpf.c#L1988>
 /// for FreeBSD, core::mem::size_of::<libc::bpf_hdr>() = 32 when run on a FreeBSD system.
 #[cfg(any(
     target_os = "macos",

--- a/src/wire/ipv6routing.rs
+++ b/src/wire/ipv6routing.rs
@@ -8,25 +8,25 @@ enum_with_unknown! {
     pub enum Type(u8) {
         /// Source Route (DEPRECATED)
         ///
-        /// See https://tools.ietf.org/html/rfc5095 for details.
+        /// See <https://tools.ietf.org/html/rfc5095> for details.
         Type0 = 0,
         /// Nimrod (DEPRECATED 2009-05-06)
         Nimrod = 1,
         /// Type 2 Routing Header for Mobile IPv6
         ///
-        /// See https://tools.ietf.org/html/rfc6275#section-6.4 for details.
+        /// See <https://tools.ietf.org/html/rfc6275#section-6.4> for details.
         Type2 = 2,
         /// RPL Source Routing Header
         ///
-        /// See https://tools.ietf.org/html/rfc6554 for details.
+        /// See <https://tools.ietf.org/html/rfc6554> for details.
         Rpl = 3,
         /// RFC3692-style Experiment 1
         ///
-        /// See https://tools.ietf.org/html/rfc4727 for details.
+        /// See <https://tools.ietf.org/html/rfc4727> for details.
         Experiment1 = 253,
         /// RFC3692-style Experiment 2
         ///
-        /// See https://tools.ietf.org/html/rfc4727 for details.
+        /// See <https://tools.ietf.org/html/rfc4727> for details.
         Experiment2 = 254,
         /// Reserved for future use
         Reserved = 252

--- a/src/wire/ndiscoption.rs
+++ b/src/wire/ndiscoption.rs
@@ -404,7 +404,7 @@ pub struct PrefixInformation {
 
 impl PrefixInformation {
     /// Validates the prefix information option against check a, b, c in
-    /// https://www.rfc-editor.org/rfc/rfc4862#section-5.5.3
+    /// <https://www.rfc-editor.org/rfc/rfc4862#section-5.5.3>
     pub fn is_valid_prefix_info(&self) -> bool {
         self.flags.contains(PrefixInfoFlags::ADDRCONF)
             && !self.prefix.is_link_local()


### PR DESCRIPTION
This PR fixes all rustdoc "this URL is not a hyperlink" complaints I could find.