### PR TITLE
feat: add default gateway check and retrieval functions

### DIFF
--- a/src/iface/route.rs
+++ b/src/iface/route.rs
@@ -124,6 +124,18 @@ impl Routes {
         Ok(old)
     }
 
+    /// Returns the ipv4 default route if there is one in the route table.
+    #[cfg(feature = "proto-ipv4")]
+    pub fn get_default_ipv4_route(&self) -> Option<Route> {
+        self.storage.iter().find(|r| r.is_ipv4_gateway()).copied()
+    }
+
+    /// Returns the ipv6 default route if there is one in the route table.
+    #[cfg(feature = "proto-ipv6")]
+    pub fn get_default_ipv6_route(&self) -> Option<Route> {
+        self.storage.iter().find(|r| r.is_ipv6_gateway()).copied()
+    }
+
     /// Remove the default ipv4 gateway
     ///
     /// On success, returns the previous default route, if any.

--- a/src/iface/route.rs
+++ b/src/iface/route.rs
@@ -61,6 +61,18 @@ impl Route {
             expires_at: None,
         }
     }
+
+    /// Returns `true` if the route is a default route for IPv6.
+    #[cfg(feature = "proto-ipv6")]
+    pub fn is_ipv6_gateway(&self) -> bool {
+        self.cidr == IPV6_DEFAULT
+    }
+
+    /// Returns `true` if the route is a default route for IPv4.
+    #[cfg(feature = "proto-ipv4")]
+    pub fn is_ipv4_gateway(&self) -> bool {
+        self.cidr == IPV4_DEFAULT
+    }
 }
 
 /// A routing table.
@@ -121,7 +133,7 @@ impl Routes {
             .storage
             .iter()
             .enumerate()
-            .find(|(_, r)| r.cidr == IPV4_DEFAULT)
+            .find(|(_, r)| r.is_ipv4_gateway())
         {
             Some(self.storage.remove(i))
         } else {
@@ -138,7 +150,7 @@ impl Routes {
             .storage
             .iter()
             .enumerate()
-            .find(|(_, r)| r.cidr == IPV6_DEFAULT)
+            .find(|(_, r)| r.is_ipv6_gateway())
         {
             Some(self.storage.remove(i))
         } else {


### PR DESCRIPTION
This extends:
- The route with methods to check if the route is a default route.
- The routing table with methods to get the default route if one is in the table. 