### PR TITLE
feat: add slaac_updated_at method

### DIFF
--- a/src/iface/interface/ipv6.rs
+++ b/src/iface/interface/ipv6.rs
@@ -697,8 +697,14 @@ impl Interface {
                 }
             });
         }
-
+        self.inner.slaac_updated = timestamp;
         self.inner.slaac.update_slaac_state(timestamp);
+    }
+
+    /// Retrieve the timestamp at which the slaac state was last updated.
+    #[cfg(feature = "proto-ipv6-slaac")]
+    pub fn slaac_updated_at(&self) -> Instant {
+        self.inner.slaac_updated
     }
 
     /// Emit a router solicitation when required by the interface's slaac state machine.

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -150,6 +150,8 @@ pub struct InterfaceInner {
     slaac_enabled: bool,
     #[cfg(feature = "proto-ipv6-slaac")]
     slaac: Slaac,
+    #[cfg(feature = "proto-ipv6-slaac")]
+    slaac_updated: Instant,
     routes: Routes,
     #[cfg(feature = "multicast")]
     multicast: multicast::State,
@@ -280,6 +282,8 @@ impl Interface {
                 slaac_enabled: config.slaac,
                 #[cfg(feature = "proto-ipv6-slaac")]
                 slaac: Slaac::new(),
+                #[cfg(feature = "proto-ipv6-slaac")]
+                slaac_updated: Instant::from_millis(0),
                 rand,
             },
         }


### PR DESCRIPTION
This adds a bit of functionality to know when / if the slaac state was last changed.

I'm open to alternative ways to detect if the address and route state was changed, this is the best I could come up with over the weekend. 