### PR TITLE
Upgrade to heap data structures if needed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ bitflags = { version = "1.0", default-features = false }
 defmt = { version = "0.3.8", optional = true, features = ["ip_in_core"] }
 cfg-if = "1.0.0"
 heapless = "0.9"
+smallvec = { version = "2.0.0-alpha.12", optional = true }
 
 [dev-dependencies]
 env_logger = "0.10"
@@ -44,6 +45,8 @@ std = ["managed/std", "alloc"]
 alloc = ["managed/alloc", "defmt?/alloc"]
 verbose = []
 defmt = ["dep:defmt", "heapless/defmt"]
+smallvec = ["dep:smallvec", "alloc"]
+smallmap = ["alloc"]
 "medium-ethernet" = ["socket"]
 "medium-ip" = ["socket"]
 "medium-ieee802154" = ["socket", "proto-sixlowpan"]

--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -1,0 +1,15 @@
+#[cfg(feature = "smallmap")]
+pub use smallmap::SmallMap as LinearMap;
+#[cfg(feature = "smallvec")]
+pub use smallvec::Vec;
+
+#[cfg(not(feature = "smallmap"))]
+pub use heapless::LinearMap;
+#[cfg(not(feature = "smallvec"))]
+pub use heapless::Vec;
+
+#[cfg(feature = "smallvec")]
+pub mod smallvec;
+
+#[cfg(feature = "smallmap")]
+pub mod smallmap;

--- a/src/data_structure/smallmap.rs
+++ b/src/data_structure/smallmap.rs
@@ -1,0 +1,201 @@
+use alloc::collections::BTreeMap;
+use core::{iter::FromIterator, mem::replace};
+use heapless::LinearMap;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SmallMap<K: Eq + Ord + Clone, V: Clone, const N: usize> {
+    Inline(LinearMap<K, V, N>),
+    Heap(BTreeMap<K, V>),
+}
+
+impl<K: Eq + Ord + Clone, V: Clone, const N: usize> SmallMap<K, V, N> {
+    pub const fn new() -> Self {
+        Self::Inline(LinearMap::new())
+    }
+
+    #[inline]
+    pub fn iter(&self) -> SmallMapIter<'_, K, V, N> {
+        match self {
+            Self::Inline(map) => SmallMapIter::Inline(map.iter()),
+            Self::Heap(map) => SmallMapIter::Heap(map.iter()),
+        }
+    }
+
+    #[inline]
+    pub fn iter_mut(&mut self) -> SmallMapIterMut<'_, K, V, N> {
+        match self {
+            Self::Inline(map) => SmallMapIterMut::Inline(map.iter_mut()),
+            Self::Heap(map) => SmallMapIterMut::Heap(map.iter_mut()),
+        }
+    }
+
+    #[inline]
+    pub fn keys(&self) -> impl Iterator<Item = &K> {
+        self.iter().map(|(k, _)| k)
+    }
+
+    #[inline]
+    pub fn values(&self) -> impl Iterator<Item = &V> {
+        self.iter().map(|(_, v)| v)
+    }
+
+    #[inline]
+    pub fn get(&self, key: &K) -> Option<&V> {
+        match self {
+            Self::Inline(map) => map.get(key),
+            Self::Heap(map) => map.get(key),
+        }
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        match self {
+            Self::Inline(map) => map.get_mut(key),
+            Self::Heap(map) => map.get_mut(key),
+        }
+    }
+
+    #[inline]
+    pub fn remove(&mut self, key: &K) -> Option<V> {
+        match self {
+            Self::Inline(map) => map.remove(key),
+            Self::Heap(map) => map.remove(key),
+        }
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        match self {
+            Self::Inline(map) => map.clear(),
+            Self::Heap(map) => map.clear(),
+        }
+    }
+
+    #[inline]
+    pub fn insert(&mut self, key: K, value: V) -> Result<Option<V>, (K, V)> {
+        match self {
+            Self::Inline(map) => match map.insert(key, value) {
+                Ok(old_val) => Ok(old_val),
+                Err((k, v)) => {
+                    if let Self::Inline(old_map) = replace(self, Self::Heap(BTreeMap::new())) {
+                        let mut heap_map: BTreeMap<K, V> = old_map.into_iter().collect();
+                        let res = heap_map.insert(k, v);
+                        *self = Self::Heap(heap_map);
+                        Ok(res)
+                    } else {
+                        Err((k, v))
+                    }
+                }
+            },
+            Self::Heap(map) => Ok(map.insert(key, value)),
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Inline(map) => map.len(),
+            Self::Heap(map) => map.len(),
+        }
+    }
+}
+
+pub enum SmallMapIter<'a, K: 'a, V: 'a, const N: usize> {
+    Inline(heapless::linear_map::Iter<'a, K, V>),
+    Heap(alloc::collections::btree_map::Iter<'a, K, V>),
+}
+
+impl<'a, K, V, const N: usize> Iterator for SmallMapIter<'a, K, V, N> {
+    type Item = (&'a K, &'a V);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Inline(i) => i.next(),
+            Self::Heap(i) => i.next(),
+        }
+    }
+}
+
+pub enum SmallMapIterMut<'a, K: 'a, V: 'a, const N: usize> {
+    Inline(heapless::linear_map::IterMut<'a, K, V>),
+    Heap(alloc::collections::btree_map::IterMut<'a, K, V>),
+}
+
+impl<'a, K, V, const N: usize> Iterator for SmallMapIterMut<'a, K, V, N> {
+    type Item = (&'a K, &'a mut V);
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Inline(i) => i.next(),
+            Self::Heap(i) => i.next(),
+        }
+    }
+}
+
+pub enum SmallMapIntoIter<K: Eq + Ord + Clone, V: Clone, const N: usize> {
+    Inline(heapless::linear_map::IntoIter<K, V, N>),
+    Heap(alloc::collections::btree_map::IntoIter<K, V>),
+}
+
+impl<K: Eq + Ord + Clone, V: Clone, const N: usize> Iterator for SmallMapIntoIter<K, V, N> {
+    type Item = (K, V);
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Inline(i) => i.next(),
+            Self::Heap(i) => i.next(),
+        }
+    }
+}
+
+impl<K: Eq + Ord + Clone, V: Clone, const N: usize> IntoIterator for SmallMap<K, V, N> {
+    type Item = (K, V);
+    type IntoIter = SmallMapIntoIter<K, V, N>;
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            Self::Inline(map) => SmallMapIntoIter::Inline(map.into_iter()),
+            Self::Heap(map) => SmallMapIntoIter::Heap(map.into_iter()),
+        }
+    }
+}
+
+impl<'a, K: Eq + Ord + Clone, V: Clone, const N: usize> IntoIterator for &'a SmallMap<K, V, N> {
+    type Item = (&'a K, &'a V);
+    type IntoIter = SmallMapIter<'a, K, V, N>;
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, K: Eq + Ord + Clone, V: Clone, const N: usize> IntoIterator for &'a mut SmallMap<K, V, N> {
+    type Item = (&'a K, &'a mut V);
+    type IntoIter = SmallMapIterMut<'a, K, V, N>;
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+impl<K: Eq + Ord + Clone, V: Clone, const N: usize> FromIterator<(K, V)> for SmallMap<K, V, N> {
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
+        let mut iter = iter.into_iter();
+        let mut map = LinearMap::new();
+
+        for (k, v) in iter.by_ref() {
+            if let Err((k, v)) = map.insert(k, v) {
+                return Self::Heap(
+                    map.into_iter()
+                        .chain(core::iter::once((k, v)))
+                        .chain(iter)
+                        .collect(),
+                );
+            }
+        }
+
+        Self::Inline(map)
+    }
+}

--- a/src/data_structure/smallvec.rs
+++ b/src/data_structure/smallvec.rs
@@ -1,0 +1,93 @@
+use core::{
+    iter::FromIterator,
+    ops::{Deref, DerefMut},
+    slice::{Iter, IterMut},
+};
+
+use smallvec::{IntoIter, SmallVec};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct Vec<T, const N: usize>(pub SmallVec<T, N>);
+
+impl<T, const N: usize> Vec<T, N> {
+    pub const fn new() -> Self {
+        Self(SmallVec::new())
+    }
+}
+
+impl<T: Clone, const N: usize> Vec<T, N> {
+    #[inline(always)]
+    pub fn from_slice(slice: &[T]) -> Result<Self, ()> {
+        let mut v = Self::new();
+        v.extend_from_slice(slice)?;
+        Ok(v)
+    }
+
+    #[inline(always)]
+    pub fn extend_from_slice(&mut self, slice: &[T]) -> Result<(), ()> {
+        self.0.extend_from_slice(slice);
+        Ok(())
+    }
+}
+
+impl<T, const N: usize> Deref for Vec<T, N> {
+    type Target = SmallVec<T, N>;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T, const N: usize> DerefMut for Vec<T, N> {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T, const N: usize> Vec<T, N> {
+    #[inline(always)]
+    pub fn push(&mut self, value: T) -> Result<(), T> {
+        self.0.push(value);
+        Ok(())
+    }
+}
+
+impl<T, const N: usize> FromIterator<T> for Vec<T, N> {
+    #[inline(always)]
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self(SmallVec::from_iter(iter))
+    }
+}
+
+impl<T, const N: usize> IntoIterator for Vec<T, N> {
+    type Item = T;
+    type IntoIter = IntoIter<T, N>;
+
+    #[inline(always)]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a, T, const N: usize> IntoIterator for &'a Vec<T, N> {
+    type Item = &'a T;
+    type IntoIter = Iter<'a, T>;
+
+    #[inline(always)]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<'a, T, const N: usize> IntoIterator for &'a mut Vec<T, N> {
+    type Item = &'a mut T;
+    type IntoIter = IterMut<'a, T>;
+
+    #[inline(always)]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
+    }
+}

--- a/src/data_structure/smallvec.rs
+++ b/src/data_structure/smallvec.rs
@@ -1,4 +1,5 @@
 use core::{
+    convert::Infallible,
     iter::FromIterator,
     ops::{Deref, DerefMut},
     slice::{Iter, IterMut},
@@ -18,14 +19,14 @@ impl<T, const N: usize> Vec<T, N> {
 
 impl<T: Clone, const N: usize> Vec<T, N> {
     #[inline(always)]
-    pub fn from_slice(slice: &[T]) -> Result<Self, ()> {
+    pub fn from_slice(slice: &[T]) -> Result<Self, Infallible> {
         let mut v = Self::new();
         v.extend_from_slice(slice)?;
         Ok(v)
     }
 
     #[inline(always)]
-    pub fn extend_from_slice(&mut self, slice: &[T]) -> Result<(), ()> {
+    pub fn extend_from_slice(&mut self, slice: &[T]) -> Result<(), Infallible> {
         self.0.extend_from_slice(slice);
         Ok(())
     }
@@ -49,7 +50,7 @@ impl<T, const N: usize> DerefMut for Vec<T, N> {
 
 impl<T, const N: usize> Vec<T, N> {
     #[inline(always)]
-    pub fn push(&mut self, value: T) -> Result<(), T> {
+    pub fn push(&mut self, value: T) -> Result<(), Infallible> {
         self.0.push(value);
         Ok(())
     }

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -26,8 +26,8 @@ mod udp;
 
 use super::packet::*;
 
+use crate::data_structure::Vec;
 use core::result::Result;
-use heapless::Vec;
 
 #[cfg(feature = "_proto-fragmentation")]
 use super::fragmentation::FragKey;

--- a/src/iface/interface/multicast.rs
+++ b/src/iface/interface/multicast.rs
@@ -1,5 +1,5 @@
+use crate::data_structure::{LinearMap, Vec};
 use core::result::Result;
-use heapless::{LinearMap, Vec};
 
 use super::{Interface, InterfaceInner};
 #[cfg(any(feature = "proto-ipv4", feature = "proto-ipv6"))]
@@ -361,7 +361,7 @@ impl Interface {
                         #[allow(unreachable_patterns)]
                         _ => None,
                     })
-                    .collect::<heapless::Vec<_, IFACE_MAX_MULTICAST_GROUP_COUNT>>();
+                    .collect::<crate::data_structure::Vec<_, IFACE_MAX_MULTICAST_GROUP_COUNT>>();
                 if let Some(pkt) = self.inner.mldv2_report_packet(&records)
                     && let Some(tx_token) = device.transmit(self.inner.now)
                 {

--- a/src/iface/interface/sixlowpan.rs
+++ b/src/iface/interface/sixlowpan.rs
@@ -910,7 +910,7 @@ mod tests {
         let parent_address =
             Ipv6Address::from_octets([253, 0, 0, 0, 0, 0, 0, 0, 2, 1, 0, 1, 0, 1, 0, 1]);
 
-        let mut hbh_options = heapless::Vec::new();
+        let mut hbh_options = crate::data_structure::Vec::new();
         hbh_options
             .push(Ipv6OptionRepr::Rpl(RplHopByHopRepr {
                 down: false,

--- a/src/iface/interface/tests/ipv6.rs
+++ b/src/iface/interface/tests/ipv6.rs
@@ -1099,7 +1099,7 @@ fn test_router_advertisement(#[case] medium: Medium) {
 #[cfg(feature = "medium-ieee802154")]
 fn test_solicited_node_addrs(#[case] medium: Medium) {
     let (mut iface, _, _) = setup(medium);
-    let mut new_addrs = heapless::Vec::<IpCidr, IFACE_MAX_ADDR_COUNT>::new();
+    let mut new_addrs = crate::data_structure::Vec::<IpCidr, IFACE_MAX_ADDR_COUNT>::new();
     new_addrs
         .push(IpCidr::new(IpAddress::v6(0xfe80, 0, 0, 0, 1, 2, 0, 2), 64))
         .unwrap();

--- a/src/iface/neighbor.rs
+++ b/src/iface/neighbor.rs
@@ -1,7 +1,7 @@
 // Heads up! Before working on this file you should read, at least,
 // the parts of RFC 1122 that discuss ARP.
 
-use heapless::LinearMap;
+use crate::data_structure::LinearMap;
 
 use crate::config::IFACE_NEIGHBOR_CACHE_COUNT;
 use crate::time::{Duration, Instant};

--- a/src/iface/route.rs
+++ b/src/iface/route.rs
@@ -1,4 +1,4 @@
-use heapless::Vec;
+use crate::data_structure::Vec;
 
 use crate::config::IFACE_MAX_ROUTE_COUNT;
 use crate::time::Instant;

--- a/src/iface/rpl/parents.rs
+++ b/src/iface/rpl/parents.rs
@@ -1,7 +1,7 @@
+use crate::wire::Ipv6Address;
+
 use super::{lollipop::SequenceCounter, rank::Rank};
 use crate::config::RPL_PARENTS_BUFFER_COUNT;
-use crate::data_structure::LinearMap;
-use crate::wire::Ipv6Address;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct Parent {
@@ -35,7 +35,7 @@ impl Parent {
 
 #[derive(Debug, Default)]
 pub(crate) struct ParentSet {
-    parents: LinearMap<Ipv6Address, Parent, { RPL_PARENTS_BUFFER_COUNT }>,
+    parents: crate::data_structure::LinearMap<Ipv6Address, Parent, { RPL_PARENTS_BUFFER_COUNT }>,
 }
 
 impl ParentSet {

--- a/src/iface/rpl/parents.rs
+++ b/src/iface/rpl/parents.rs
@@ -1,7 +1,7 @@
-use crate::wire::Ipv6Address;
-
 use super::{lollipop::SequenceCounter, rank::Rank};
 use crate::config::RPL_PARENTS_BUFFER_COUNT;
+use crate::data_structure::LinearMap;
+use crate::wire::Ipv6Address;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct Parent {
@@ -35,7 +35,7 @@ impl Parent {
 
 #[derive(Debug, Default)]
 pub(crate) struct ParentSet {
-    parents: heapless::LinearMap<Ipv6Address, Parent, { RPL_PARENTS_BUFFER_COUNT }>,
+    parents: LinearMap<Ipv6Address, Parent, { RPL_PARENTS_BUFFER_COUNT }>,
 }
 
 impl ParentSet {

--- a/src/iface/rpl/relations.rs
+++ b/src/iface/rpl/relations.rs
@@ -1,7 +1,7 @@
+use crate::config::RPL_RELATIONS_BUFFER_COUNT;
+use crate::data_structure::Vec;
 use crate::time::Instant;
 use crate::wire::Ipv6Address;
-
-use crate::config::RPL_RELATIONS_BUFFER_COUNT;
 
 #[derive(Debug)]
 pub struct Relation {
@@ -12,7 +12,7 @@ pub struct Relation {
 
 #[derive(Default, Debug)]
 pub struct Relations {
-    relations: heapless::Vec<Relation, { RPL_RELATIONS_BUFFER_COUNT }>,
+    relations: Vec<Relation, { RPL_RELATIONS_BUFFER_COUNT }>,
 }
 
 impl Relations {

--- a/src/iface/rpl/relations.rs
+++ b/src/iface/rpl/relations.rs
@@ -1,7 +1,7 @@
-use crate::config::RPL_RELATIONS_BUFFER_COUNT;
-use crate::data_structure::Vec;
 use crate::time::Instant;
 use crate::wire::Ipv6Address;
+
+use crate::config::RPL_RELATIONS_BUFFER_COUNT;
 
 #[derive(Debug)]
 pub struct Relation {
@@ -12,7 +12,7 @@ pub struct Relation {
 
 #[derive(Default, Debug)]
 pub struct Relations {
-    relations: Vec<Relation, { RPL_RELATIONS_BUFFER_COUNT }>,
+    relations: crate::data_structure::Vec<Relation, { RPL_RELATIONS_BUFFER_COUNT }>,
 }
 
 impl Relations {

--- a/src/iface/slaac.rs
+++ b/src/iface/slaac.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs)]
-use heapless::{LinearMap, Vec};
+use crate::data_structure::{LinearMap, Vec};
 
 use crate::config::{IFACE_MAX_PREFIX_COUNT, IFACE_MAX_ROUTE_COUNT};
 use crate::time::{Duration, Instant};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,3 +193,5 @@ pub mod wire;
     )
 ))]
 mod tests;
+
+pub mod data_structure;

--- a/src/socket/dhcpv4.rs
+++ b/src/socket/dhcpv4.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "async")]
 use core::task::Waker;
 
+use crate::data_structure::Vec;
 use crate::iface::Context;
 use crate::time::{Duration, Instant};
 use crate::wire::dhcpv4::field as dhcpv4_field;
@@ -10,7 +11,6 @@ use crate::wire::{
     UDP_HEADER_LEN, UdpRepr,
 };
 use crate::wire::{DhcpOption, HardwareAddress};
-use heapless::Vec;
 
 #[cfg(feature = "async")]
 use super::WakerRegistration;

--- a/src/socket/dns.rs
+++ b/src/socket/dns.rs
@@ -2,7 +2,7 @@ use core::cmp::min;
 #[cfg(feature = "async")]
 use core::task::Waker;
 
-use heapless::Vec;
+use crate::data_structure::Vec;
 use managed::ManagedSlice;
 
 use crate::config::{DNS_MAX_NAME_SIZE, DNS_MAX_RESULT_COUNT, DNS_MAX_SERVER_COUNT};

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -8937,6 +8937,7 @@ mod test {
 
     #[test]
     fn test_established_close_on_src_ip_change() {
+        use crate::data_structure::Vec;
         let mut s = socket_established();
 
         // Verify socket is working normally
@@ -8953,7 +8954,7 @@ mod test {
 
         // Simulate interface IP change - remove the socket's source IP
         // and add a different one.
-        let mut new_addrs = heapless::Vec::<IpCidr, IFACE_MAX_ADDR_COUNT>::new();
+        let mut new_addrs = Vec::<IpCidr, IFACE_MAX_ADDR_COUNT>::new();
         new_addrs.push(IpCidr::new(OTHER_ADDR.into(), 24)).unwrap();
         s.cx.set_ip_addrs(new_addrs);
 

--- a/src/wire/dhcpv4.rs
+++ b/src/wire/dhcpv4.rs
@@ -1,9 +1,9 @@
 // See https://tools.ietf.org/html/rfc2131 for the DHCP specification.
 
+use crate::data_structure::Vec;
 use bitflags::bitflags;
 use byteorder::{ByteOrder, NetworkEndian};
 use core::iter;
-use heapless::Vec;
 
 use super::{Error, Result};
 use crate::wire::arp::Hardware;

--- a/src/wire/ipv6hbh.rs
+++ b/src/wire/ipv6hbh.rs
@@ -1,7 +1,7 @@
 use super::{Error, Ipv6Option, Ipv6OptionRepr, Ipv6OptionsIterator, Result};
 use crate::config;
+use crate::data_structure::Vec;
 use crate::wire::ipv6option::RouterAlert;
-use heapless::Vec;
 
 /// A read/write wrapper around an IPv6 Hop-by-Hop Header buffer.
 pub struct Header<T: AsRef<[u8]>> {


### PR DESCRIPTION
This PR adds a small but slightly noticable change in how the data structures works. 

Before this PR, some of the data structures are using compile time configuration settings for predetermined storage sizes for certain data objects, for example, `IFACE_MAX_ADDR_COUNT` or `IFACE_MAX_ROUTE_COUNT`.

Now this PR is an attempt to lift this restriction, however this is still in a WIP status, and may need some debate whether this is useful.

# Why?

I'm using this for a private VPN library I wrote and somehow I come forward to notice I cannot add more than certain number of routes, then I noticed the compile time constraints limits the options of my network interface HARD. 

Since I'm not using this on an embedded environment, having heap allocation is fine.

# How to use it?

Enable "smallvec" and/or "smallmap" feature in your smoltcp crate. By default this is disabled, and the use of type alias will make it fallback to `heapless::LinearMap` and `heapless::Vec`. Therefore by default, you still have the original behavior, that the maximum size cap during compile time still stay as relevant.

# However

If you enable "smallvec" or "smallmap", then the semantic of the `Vec` and `LinearMap` changes. 

Notably, for "smallvec" feature, the structure now changes from a flat, fixed hard capacity, into still having inlined stack content initially, but if you have more than N items, it will spill over to heap. Previously this will just return the overflown item, but now that means every push will succeed. Space and time complexity is still O(n), but the data storage will transfer from stack to heap. This could potentially be a problem for real time service.

And for "smallmap", the changes may get a little more drastic, for heapless linear map, this is the original description.
> A fixed capacity map/dictionary that performs lookups via linear search.
> 
> Note that as this map doesn't use hashing so most operations are O(n) instead of O(1).

The design of "smallmap" still contains the heapless linear map at first (that means still stored in stack for the first N items), but now all the content of the original linear map will spill over to a new `alloc::collections::BTreeMap`. This changes the semantic nature of the "linear map" a little bit more different. Specifically, (self balanced) BST maps maintains O(log n) time complexity for both amortized and worst case, rather than having O(n) for the linear map.

I've chosen to use BST because I noticed the data nature of the what is using the linear map actually has numeric partial orders, despite we should technically use hash tables.  

Therefore after some consideration, I've decided to make this opt-in and tries to keep the original behavior as much as possible, only to extend it when it really needs to upgrade to heap, as this is the "best" of both world. You still get to keep your original heapless data structure behavior if you don't want heap. 

And if you do need it, you need to explicitly enable it yourself, and be heads up about the semantic change after heap upgrade because you don't know down the line whether this will have some different implications for the characteristic of the TCP/IP stack.

Both feature implies `alloc`. This means a global heap allocator is required.

ABI change: almost untouched. Only if you have `Vec` or `LinearMap` in the public functions, then we do have a little bit of ABI breakage. But the code is intentionally implemented to mimck existing use case of `heapless::LinearMap` as much as possible, despite some specific optimizations can be employed (~~for example, return Result<(), ()> rather than Result<(), T> to save the storage, since push is always going to succeed, I don't think we can use Infalliable for this?~~ Indeed!).

But in exchange, all the `IFACE_MAX_ADDR_COUNT` or `IFACE_MAX_ROUTE_COUNT` now becomes the stack cache count before spilling over to heap. This theoretically means all the restrictions about the max counts are lifted, but in some places of the code there are still manual checks for the max count and needs some more treatment. For example, some of the struct is using patterns like `[T; MAX_COUNT]`, so these will need refactors too.

Fail cases:
```
❯ cargo nextest run --all  --no-fail-fast --features smallvec,smallmap
────────────
     Summary [   0.637s] 654 tests run: 652 passed, 2 failed, 0 skipped
        FAIL [   0.008s] smoltcp iface::neighbor::test::test_evict
        FAIL [   0.005s] smoltcp wire::dhcpv4::test::test_parse_ack_dns_servers
```

*The name of the `LinearMap` type is still intentionally kept to keep the patchset minimal, unless it is agreed for a full mod rename  refactor.