### PR TITLE
ipv4: implement RFC 3514 evil bit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ defmt = ["dep:defmt", "heapless/defmt"]
 
 "proto-ipv4" = []
 "proto-ipv4-fragmentation" = ["proto-ipv4", "_proto-fragmentation"]
+"proto-evil" = ["proto-ipv4"]
 "proto-dhcpv4" = ["proto-ipv4"]
 "proto-ipv6" = []
 "proto-ipv6-hbh" = ["proto-ipv6"]

--- a/src/iface/interface/ipv4.rs
+++ b/src/iface/interface/ipv4.rs
@@ -101,6 +101,13 @@ impl InterfaceInner {
         frag: &'a mut FragmentsBuffer,
     ) -> Option<Packet<'a>> {
         let mut ipv4_repr = check!(Ipv4Repr::parse(ipv4_packet, &self.caps.checksum));
+
+        #[cfg(feature = "proto-evil")]
+        if ipv4_packet.evil() {
+            net_debug!("packet declared evil intent");
+            return None;
+        }
+
         if !self.is_unicast_v4(ipv4_repr.src_addr) && !ipv4_repr.src_addr.is_unspecified() {
             // Discard packets with non-unicast source addresses but allow unspecified
             net_debug!("non-unicast or unspecified source address");

--- a/src/iface/interface/tests/ipv4.rs
+++ b/src/iface/interface/tests/ipv4.rs
@@ -1535,6 +1535,41 @@ fn get_source_address_empty_interface(#[case] medium: Medium) {
     );
 }
 
+#[rstest]
+#[case(Medium::Ip)]
+#[cfg(feature = "medium-ip")]
+#[cfg(feature = "proto-evil")]
+fn test_drop_evil_packet(#[case] medium: Medium) {
+    let (mut iface, mut sockets, _) = setup(medium);
+
+    let repr = IpRepr::Ipv4(Ipv4Repr {
+        src_addr: Ipv4Address::new(0x7f, 0x00, 0x00, 0x01),
+        dst_addr: Ipv4Address::new(192, 168, 1, 1),
+        next_header: IpProtocol::Unknown(0x0c),
+        payload_len: 0,
+        hop_limit: 0x40,
+    });
+
+    let mut bytes = vec![0u8; 54];
+    repr.emit(&mut bytes, &ChecksumCapabilities::default());
+
+    let mut frame = Ipv4Packet::new_unchecked(&mut bytes[..]);
+    frame.set_evil(true);
+    frame.fill_checksum();
+
+    let frame = Ipv4Packet::new_unchecked(&bytes[..]);
+    assert_eq!(
+        iface.inner.process_ipv4(
+            &mut sockets,
+            PacketMeta::default(),
+            HardwareAddress::default(),
+            &frame,
+            &mut iface.fragments
+        ),
+        None
+    );
+}
+
 use crate::wire::ipv4::HEADER_LEN;
 #[rstest]
 #[cfg(all(feature = "medium-ip", feature = "proto-ipv4-fragmentation",))]

--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -293,6 +293,15 @@ impl<T: AsRef<[u8]>> Packet<T> {
         NetworkEndian::read_u16(&data[field::IDENT])
     }
 
+    /// Return the "evil" flag, as defined in RFC 3514.
+    ///
+    /// If set, the packet has been sent with malicious intent.
+    #[inline]
+    pub fn evil(&self) -> bool {
+        let data = self.buffer.as_ref();
+        NetworkEndian::read_u16(&data[field::FLG_OFF]) & 0x8000 != 0
+    }
+
     /// Return the "don't fragment" flag.
     #[inline]
     pub fn dont_frag(&self) -> bool {
@@ -430,6 +439,15 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Packet<T> {
         let data = self.buffer.as_mut();
         let raw = NetworkEndian::read_u16(&data[field::FLG_OFF]);
         let raw = raw & !0xe000;
+        NetworkEndian::write_u16(&mut data[field::FLG_OFF], raw);
+    }
+
+    /// Set the "evil" flag, as defined in RFC 3514.
+    #[inline]
+    pub fn set_evil(&mut self, value: bool) {
+        let data = self.buffer.as_mut();
+        let raw = NetworkEndian::read_u16(&data[field::FLG_OFF]);
+        let raw = if value { raw | 0x8000 } else { raw & !0x8000 };
         NetworkEndian::write_u16(&mut data[field::FLG_OFF], raw);
     }
 
@@ -587,6 +605,7 @@ impl Repr {
         packet.set_total_len(total_len);
         packet.set_ident(0);
         packet.clear_flags();
+        packet.set_evil(false);
         packet.set_more_frags(false);
         packet.set_dont_frag(true);
         packet.set_frag_offset(0);
@@ -632,6 +651,9 @@ impl<T: AsRef<[u8]> + ?Sized> fmt::Display for Packet<&T> {
                     write!(f, " ecn={}", self.ecn())?;
                 }
                 write!(f, " tlen={}", self.total_len())?;
+                if self.evil() {
+                    write!(f, " evil")?;
+                }
                 if self.dont_frag() {
                     write!(f, " df")?;
                 }
@@ -715,7 +737,7 @@ pub(crate) mod test {
     pub(crate) const MOCK_UNSPECIFIED: Address = Address::UNSPECIFIED;
 
     static PACKET_BYTES: [u8; 30] = [
-        0x45, 0x00, 0x00, 0x1e, 0x01, 0x02, 0x62, 0x03, 0x1a, 0x01, 0xd5, 0x6e, 0x11, 0x12, 0x13,
+        0x45, 0x00, 0x00, 0x1e, 0x01, 0x02, 0xe2, 0x03, 0x1a, 0x01, 0x55, 0x6e, 0x11, 0x12, 0x13,
         0x14, 0x21, 0x22, 0x23, 0x24, 0xaa, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff,
     ];
 
@@ -730,12 +752,13 @@ pub(crate) mod test {
         assert_eq!(packet.ecn(), 0);
         assert_eq!(packet.total_len(), 30);
         assert_eq!(packet.ident(), 0x102);
+        assert!(packet.evil());
         assert!(packet.more_frags());
         assert!(packet.dont_frag());
         assert_eq!(packet.frag_offset(), 0x203 * 8);
         assert_eq!(packet.hop_limit(), 0x1a);
         assert_eq!(packet.next_header(), Protocol::Icmp);
-        assert_eq!(packet.checksum(), 0xd56e);
+        assert_eq!(packet.checksum(), 0x556e);
         assert_eq!(packet.src_addr(), Address::new(0x11, 0x12, 0x13, 0x14));
         assert_eq!(packet.dst_addr(), Address::new(0x21, 0x22, 0x23, 0x24));
         assert!(packet.verify_checksum());
@@ -753,6 +776,7 @@ pub(crate) mod test {
         packet.set_ecn(0);
         packet.set_total_len(30);
         packet.set_ident(0x102);
+        packet.set_evil(true);
         packet.set_more_frags(true);
         packet.set_dont_frag(true);
         packet.set_frag_offset(0x203 * 8);

--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -296,6 +296,7 @@ impl<T: AsRef<[u8]>> Packet<T> {
     /// Return the "evil" flag, as defined in RFC 3514.
     ///
     /// If set, the packet has been sent with malicious intent.
+    #[cfg(feature = "proto-evil")]
     #[inline]
     pub fn evil(&self) -> bool {
         let data = self.buffer.as_ref();
@@ -443,6 +444,7 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Packet<T> {
     }
 
     /// Set the "evil" flag, as defined in RFC 3514.
+    #[cfg(feature = "proto-evil")]
     #[inline]
     pub fn set_evil(&mut self, value: bool) {
         let data = self.buffer.as_mut();
@@ -605,6 +607,7 @@ impl Repr {
         packet.set_total_len(total_len);
         packet.set_ident(0);
         packet.clear_flags();
+        #[cfg(feature = "proto-evil")]
         packet.set_evil(false);
         packet.set_more_frags(false);
         packet.set_dont_frag(true);
@@ -651,6 +654,7 @@ impl<T: AsRef<[u8]> + ?Sized> fmt::Display for Packet<&T> {
                     write!(f, " ecn={}", self.ecn())?;
                 }
                 write!(f, " tlen={}", self.total_len())?;
+                #[cfg(feature = "proto-evil")]
                 if self.evil() {
                     write!(f, " evil")?;
                 }
@@ -737,7 +741,7 @@ pub(crate) mod test {
     pub(crate) const MOCK_UNSPECIFIED: Address = Address::UNSPECIFIED;
 
     static PACKET_BYTES: [u8; 30] = [
-        0x45, 0x00, 0x00, 0x1e, 0x01, 0x02, 0xe2, 0x03, 0x1a, 0x01, 0x55, 0x6e, 0x11, 0x12, 0x13,
+        0x45, 0x00, 0x00, 0x1e, 0x01, 0x02, 0x62, 0x03, 0x1a, 0x01, 0xd5, 0x6e, 0x11, 0x12, 0x13,
         0x14, 0x21, 0x22, 0x23, 0x24, 0xaa, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff,
     ];
 
@@ -752,13 +756,12 @@ pub(crate) mod test {
         assert_eq!(packet.ecn(), 0);
         assert_eq!(packet.total_len(), 30);
         assert_eq!(packet.ident(), 0x102);
-        assert!(packet.evil());
         assert!(packet.more_frags());
         assert!(packet.dont_frag());
         assert_eq!(packet.frag_offset(), 0x203 * 8);
         assert_eq!(packet.hop_limit(), 0x1a);
         assert_eq!(packet.next_header(), Protocol::Icmp);
-        assert_eq!(packet.checksum(), 0x556e);
+        assert_eq!(packet.checksum(), 0xd56e);
         assert_eq!(packet.src_addr(), Address::new(0x11, 0x12, 0x13, 0x14));
         assert_eq!(packet.dst_addr(), Address::new(0x21, 0x22, 0x23, 0x24));
         assert!(packet.verify_checksum());
@@ -776,7 +779,6 @@ pub(crate) mod test {
         packet.set_ecn(0);
         packet.set_total_len(30);
         packet.set_ident(0x102);
-        packet.set_evil(true);
         packet.set_more_frags(true);
         packet.set_dont_frag(true);
         packet.set_frag_offset(0x203 * 8);
@@ -867,6 +869,26 @@ pub(crate) mod test {
         repr.emit(&mut packet, &ChecksumCapabilities::default());
         packet.payload_mut().copy_from_slice(&REPR_PAYLOAD_BYTES);
         assert_eq!(&*packet.into_inner(), &REPR_PACKET_BYTES[..]);
+    }
+
+    #[test]
+    #[cfg(feature = "proto-evil")]
+    fn test_evil_bit() {
+        let packet = Packet::new_unchecked(&PACKET_BYTES[..]);
+        assert!(!packet.evil());
+        assert!(packet.dont_frag());
+        assert!(packet.more_frags());
+
+        let mut bytes = [0u8; 30];
+        bytes.copy_from_slice(&PACKET_BYTES[..]);
+        let mut packet: Packet<&mut [u8]> = Packet::new_unchecked(&mut bytes[..]);
+        packet.set_evil(true);
+        assert!(packet.evil());
+        assert!(packet.dont_frag());
+        assert!(packet.more_frags());
+
+        packet.clear_flags();
+        assert!(!packet.evil());
     }
 
     #[test]


### PR DESCRIPTION
This PR implements [RFC 3514](https://datatracker.ietf.org/doc/html/rfc3514) ("The Security Flag in the IPv4 Header"), closing what I can only describe as a critical gap in smoltcp's security posture.

With this great addition, I believe users will finally be able to build significantly more secure and maintainable projects.

Happy April 1st