### PR TITLE
fix: Prevent SACK overflow panic from SeqNumber i32-to-usize sign-extension

### DIFF
--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -4410,6 +4410,40 @@ mod test {
     }
 
     #[test]
+    fn test_established_sack_no_overflow_on_near_max_seqnumber() {
+        let mut s = socket_established();
+        s.remote_has_sack = true;
+        s.remote_seq_no = TcpSeqNumber(-4);
+        s.remote_last_ack = Some(TcpSeqNumber(-4));
+
+        // Send an out-of-order segment 10 bytes past the expected sequence,
+        // creating a 10-byte hole at the front of the assembler.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: TcpSeqNumber(-4 + 10),
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &b"AAAAAAAAAA"[..],
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(TcpSeqNumber(-4)),
+                window_len: 64,
+                sack_ranges: [
+                    Some((
+                        (-4_i32 + 10) as u32,
+                        (-4_i32 + 20) as u32,
+                    )),
+                    None,
+                    None,
+                ],
+                ..RECV_TEMPL
+            })
+        );
+    }
+
+    #[test]
     fn test_established_sliding_window_recv() {
         let mut s = socket_established();
         // Update our scaling parameters for a TCP with a scaled buffer.

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1478,7 +1478,7 @@ impl<'a> Socket<'a> {
             if let Some(last_seg_seq) = self.local_rx_last_seq.map(|s| s.0 as u32) {
                 reply_repr.sack_ranges[0] = self
                     .assembler
-                    .iter_data(reply_repr.ack_number.map(|s| s.0 as usize).unwrap_or(0))
+                    .iter_data(reply_repr.ack_number.map(|s| s.0 as u32 as usize).unwrap_or(0))
                     .map(|(left, right)| (left as u32, right as u32))
                     .find(|(left, right)| *left <= last_seg_seq && *right >= last_seg_seq);
             }
@@ -1493,7 +1493,7 @@ impl<'a> Socket<'a> {
                 // most quickly advance the acknowledgement number.
                 reply_repr.sack_ranges[0] = self
                     .assembler
-                    .iter_data(reply_repr.ack_number.map(|s| s.0 as usize).unwrap_or(0))
+                    .iter_data(reply_repr.ack_number.map(|s| s.0 as u32 as usize).unwrap_or(0))
                     .map(|(left, right)| (left as u32, right as u32))
                     .next();
             }

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -4431,10 +4431,7 @@ mod test {
                 ack_number: Some(TcpSeqNumber(-4)),
                 window_len: 64,
                 sack_ranges: [
-                    Some((
-                        (-4_i32 + 10) as u32,
-                        (-4_i32 + 20) as u32,
-                    )),
+                    Some(((-4_i32 + 10) as u32, (-4_i32 + 20) as u32,)),
                     None,
                     None,
                 ],

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1478,7 +1478,12 @@ impl<'a> Socket<'a> {
             if let Some(last_seg_seq) = self.local_rx_last_seq.map(|s| s.0 as u32) {
                 reply_repr.sack_ranges[0] = self
                     .assembler
-                    .iter_data(reply_repr.ack_number.map(|s| s.0 as u32 as usize).unwrap_or(0))
+                    .iter_data(
+                        reply_repr
+                            .ack_number
+                            .map(|s| s.0 as u32 as usize)
+                            .unwrap_or(0),
+                    )
                     .map(|(left, right)| (left as u32, right as u32))
                     .find(|(left, right)| *left <= last_seg_seq && *right >= last_seg_seq);
             }
@@ -1493,7 +1498,12 @@ impl<'a> Socket<'a> {
                 // most quickly advance the acknowledgement number.
                 reply_repr.sack_ranges[0] = self
                     .assembler
-                    .iter_data(reply_repr.ack_number.map(|s| s.0 as u32 as usize).unwrap_or(0))
+                    .iter_data(
+                        reply_repr
+                            .ack_number
+                            .map(|s| s.0 as u32 as usize)
+                            .unwrap_or(0),
+                    )
                     .map(|(left, right)| (left as u32, right as u32))
                     .next();
             }

--- a/src/storage/assembler.rs
+++ b/src/storage/assembler.rs
@@ -593,6 +593,18 @@ mod test {
     }
 
     #[test]
+    fn test_iter_offset_negative() {
+        let assr = contigs![(100, 10)];
+        let offset: usize = (-5_i32) as usize; // 0xFFFF_FFFF_FFFF_FFFB on 64-bit
+        let segments: Vec<_> = assr.iter_data(offset).collect();
+        assert_eq!(segments.len(), 1);
+        let (left, right) = segments[0];
+        // In u32 space: (100 + 0xFFFFFFFB) = 95, (110 + 0xFFFFFFFB) = 105
+        assert_eq!(left as u32, 95);
+        assert_eq!(right as u32, 105);
+    }
+
+    #[test]
     fn test_iter_one_front() {
         let mut assr = Assembler::new();
         assert_eq!(assr.add(0, 4), Ok(()));

--- a/src/storage/assembler.rs
+++ b/src/storage/assembler.rs
@@ -358,7 +358,10 @@ impl<'a> Iterator for AssemblerIter<'a> {
             self.left += contig.hole_size;
             self.right = self.left + contig.data_size;
             data_range = if self.left < self.right {
-                let data_range = (self.left + self.offset, self.right + self.offset);
+                let data_range = (
+                    self.left.wrapping_add(self.offset),
+                    self.right.wrapping_add(self.offset),
+                );
                 self.left = self.right;
                 Some(data_range)
             } else {


### PR DESCRIPTION
Casting SeqNumber `s.0` (`i32`) directly to `usize` via `as usize` sign-extends negative values on 64-bit platforms, producing near-`usize::MAX` offsets. When the assembler iterator adds these to buffer-relative positions, the result overflows and panics.

Without this fix, any remote peer that completes a TCP handshake with SACK Permitted and an ISN in the upper half of the 32-bit sequence space (~50% of all connections) can cause a crash.  In release builds without overflow checks, the wrap-around silently produces incorrect SACK ranges, degrading TCP performance.

Changes
- `src/socket/tcp.rs` -- Cast through `u32` before widening to `usize` (`s.0 as u32 as usize`) at both `iter_data` call sites in `ack_reply()`, preventing sign-extension.
- `src/storage/assembler.rs` -- Use `wrapping_add` for the offset addition in `AssemblerIter::next()`, which is correct for modular-2^32 TCP sequence number arithmetic and prevents overflow on 32-bit targets.