### PR TITLE
tcp: fix sack sequence number overflow.

### DIFF
--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1475,12 +1475,15 @@ impl<'a> Socket<'a> {
             // Acknowledgment Number field in the header.
             reply_repr.sack_ranges[0] = None;
 
-            if let Some(last_seg_seq) = self.local_rx_last_seq.map(|s| s.0 as u32) {
+            let ack = reply_repr.ack_number.unwrap_or(TcpSeqNumber(0));
+
+            if let Some(last_seg_seq) = self.local_rx_last_seq {
                 reply_repr.sack_ranges[0] = self
                     .assembler
-                    .iter_data(reply_repr.ack_number.map(|s| s.0 as usize).unwrap_or(0))
-                    .map(|(left, right)| (left as u32, right as u32))
-                    .find(|(left, right)| *left <= last_seg_seq && *right >= last_seg_seq);
+                    .iter_data()
+                    .map(|(left, right)| (ack + left, ack + right))
+                    .find(|&(left, right)| left <= last_seg_seq && right >= last_seg_seq)
+                    .map(|(left, right)| (left.0 as u32, right.0 as u32));
             }
 
             if reply_repr.sack_ranges[0].is_none() {
@@ -1493,9 +1496,10 @@ impl<'a> Socket<'a> {
                 // most quickly advance the acknowledgement number.
                 reply_repr.sack_ranges[0] = self
                     .assembler
-                    .iter_data(reply_repr.ack_number.map(|s| s.0 as usize).unwrap_or(0))
-                    .map(|(left, right)| (left as u32, right as u32))
-                    .next();
+                    .iter_data()
+                    .map(|(left, right)| (ack + left, ack + right))
+                    .next()
+                    .map(|(left, right)| (left.0 as u32, right.0 as u32));
             }
         }
 
@@ -4397,6 +4401,37 @@ mod test {
                 })
             );
         }
+    }
+
+    #[test]
+    fn test_established_sack_no_overflow_on_near_max_seqnumber() {
+        let mut s = socket_established();
+        s.remote_has_sack = true;
+        s.remote_seq_no = TcpSeqNumber(-4);
+        s.remote_last_ack = Some(TcpSeqNumber(-4));
+
+        // Send an out-of-order segment 10 bytes past the expected sequence,
+        // creating a 10-byte hole at the front of the assembler.
+        send!(
+            s,
+            TcpRepr {
+                seq_number: TcpSeqNumber(-4 + 10),
+                ack_number: Some(LOCAL_SEQ + 1),
+                payload: &b"AAAAAAAAAA"[..],
+                ..SEND_TEMPL
+            },
+            Some(TcpRepr {
+                seq_number: LOCAL_SEQ + 1,
+                ack_number: Some(TcpSeqNumber(-4)),
+                window_len: 64,
+                sack_ranges: [
+                    Some(((-4_i32 + 10) as u32, (-4_i32 + 20) as u32,)),
+                    None,
+                    None,
+                ],
+                ..RECV_TEMPL
+            })
+        );
     }
 
     #[test]

--- a/src/storage/assembler.rs
+++ b/src/storage/assembler.rs
@@ -316,57 +316,26 @@ impl Assembler {
 
     /// Iterate over all of the contiguous data ranges.
     ///
-    /// This is used in calculating what data ranges have been received. The offset indicates the
-    /// number of bytes of contiguous data received before the beginnings of this Assembler.
+    /// Returns `(offset, size)` tuples for each contiguous data range, where
+    /// offset is relative to the start of the assembler.
     ///
     ///    Data        Hole        Data
     /// |--- 100 ---|--- 200 ---|--- 100 ---|
     ///
-    /// An offset of 1500 would return the ranges: ``(1500, 1600), (1800, 1900)``
-    pub fn iter_data(&self, first_offset: usize) -> AssemblerIter<'_> {
-        AssemblerIter::new(self, first_offset)
-    }
-}
-
-pub struct AssemblerIter<'a> {
-    assembler: &'a Assembler,
-    offset: usize,
-    index: usize,
-    left: usize,
-    right: usize,
-}
-
-impl<'a> AssemblerIter<'a> {
-    fn new(assembler: &'a Assembler, offset: usize) -> AssemblerIter<'a> {
-        AssemblerIter {
-            assembler,
-            offset,
-            index: 0,
-            left: 0,
-            right: 0,
-        }
-    }
-}
-
-impl<'a> Iterator for AssemblerIter<'a> {
-    type Item = (usize, usize);
-
-    fn next(&mut self) -> Option<(usize, usize)> {
-        let mut data_range = None;
-        while data_range.is_none() && self.index < self.assembler.contigs.len() {
-            let contig = self.assembler.contigs[self.index];
-            self.left += contig.hole_size;
-            self.right = self.left + contig.data_size;
-            data_range = if self.left < self.right {
-                let data_range = (self.left + self.offset, self.right + self.offset);
-                self.left = self.right;
-                Some(data_range)
+    /// Would return the ranges: ``(0, 100), (300, 400)``
+    pub fn iter_data(&self) -> impl Iterator<Item = (usize, usize)> + '_ {
+        let mut offset = 0;
+        self.contigs.iter().filter_map(move |contig| {
+            offset += contig.hole_size;
+            let left = offset;
+            offset += contig.data_size;
+            let right = offset;
+            if left < right {
+                Some((left, right))
             } else {
                 None
-            };
-            self.index += 1;
-        }
-        data_range
+            }
+        })
     }
 }
 
@@ -569,7 +538,7 @@ mod test {
     #[test]
     fn test_iter_empty() {
         let assr = Assembler::new();
-        let segments: Vec<_> = assr.iter_data(10).collect();
+        let segments: Vec<_> = assr.iter_data().collect();
         assert_eq!(segments, vec![]);
     }
 
@@ -577,61 +546,53 @@ mod test {
     fn test_iter_full() {
         let mut assr = Assembler::new();
         assert_eq!(assr.add(0, 16), Ok(()));
-        let segments: Vec<_> = assr.iter_data(10).collect();
-        assert_eq!(segments, vec![(10, 26)]);
-    }
-
-    #[test]
-    fn test_iter_offset() {
-        let mut assr = Assembler::new();
-        assert_eq!(assr.add(0, 16), Ok(()));
-        let segments: Vec<_> = assr.iter_data(100).collect();
-        assert_eq!(segments, vec![(100, 116)]);
+        let segments: Vec<_> = assr.iter_data().collect();
+        assert_eq!(segments, vec![(0, 16)]);
     }
 
     #[test]
     fn test_iter_one_front() {
         let mut assr = Assembler::new();
         assert_eq!(assr.add(0, 4), Ok(()));
-        let segments: Vec<_> = assr.iter_data(10).collect();
-        assert_eq!(segments, vec![(10, 14)]);
+        let segments: Vec<_> = assr.iter_data().collect();
+        assert_eq!(segments, vec![(0, 4)]);
     }
 
     #[test]
     fn test_iter_one_back() {
         let mut assr = Assembler::new();
         assert_eq!(assr.add(12, 4), Ok(()));
-        let segments: Vec<_> = assr.iter_data(10).collect();
-        assert_eq!(segments, vec![(22, 26)]);
+        let segments: Vec<_> = assr.iter_data().collect();
+        assert_eq!(segments, vec![(12, 16)]);
     }
 
     #[test]
     fn test_iter_one_mid() {
         let mut assr = Assembler::new();
         assert_eq!(assr.add(4, 8), Ok(()));
-        let segments: Vec<_> = assr.iter_data(10).collect();
-        assert_eq!(segments, vec![(14, 22)]);
+        let segments: Vec<_> = assr.iter_data().collect();
+        assert_eq!(segments, vec![(4, 12)]);
     }
 
     #[test]
     fn test_iter_one_trailing_gap() {
         let assr = contigs![(4, 8)];
-        let segments: Vec<_> = assr.iter_data(100).collect();
-        assert_eq!(segments, vec![(104, 112)]);
+        let segments: Vec<_> = assr.iter_data().collect();
+        assert_eq!(segments, vec![(4, 12)]);
     }
 
     #[test]
     fn test_iter_two_split() {
         let assr = contigs![(2, 6), (4, 1)];
-        let segments: Vec<_> = assr.iter_data(100).collect();
-        assert_eq!(segments, vec![(102, 108), (112, 113)]);
+        let segments: Vec<_> = assr.iter_data().collect();
+        assert_eq!(segments, vec![(2, 8), (12, 13)]);
     }
 
     #[test]
     fn test_iter_three_split() {
         let assr = contigs![(2, 6), (2, 1), (2, 2)];
-        let segments: Vec<_> = assr.iter_data(100).collect();
-        assert_eq!(segments, vec![(102, 108), (110, 111), (113, 115)]);
+        let segments: Vec<_> = assr.iter_data().collect();
+        assert_eq!(segments, vec![(2, 8), (10, 11), (13, 15)]);
     }
 
     #[test]


### PR DESCRIPTION
The Assembler is supposed to deal only with offsets and lengths, never with sequence numbers modulo 2^32. It's logically a sequence of "hole, data, hole, data..." where the start of the first hole lines up with the start of the rx buffer (ie the next byte the application is supposed to recv). The numbers here can't get larger than 2^32 as long as the tcp socket buffer size doesn't exceed 2^32 which is a reasonable assumption.

The assembler `iter_data` takes a `first_offset: usize` to add to the returned tuples. The problem is it's *supposed* to be an offset, but the TCP code passes a sequence number, expecting the assembler to do sequence number math, instead of integer math.

This removes `first_offset` and does the addition in the TCP code. This way the assembler stays free of sequence number math.

Thanks to @eddo26 for finding the bug. #1136