### PR TITLE
ipv4: check IPv4 IHL to be at least 20 bytes

### DIFF
--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -27,6 +27,10 @@ pub const MULTICAST_ALL_SYSTEMS: Address = Address::new(224, 0, 0, 1);
 /// All multicast-capable routers
 pub const MULTICAST_ALL_ROUTERS: Address = Address::new(224, 0, 0, 2);
 
+/// Minimum IHL length 5x32 bit words or 20 bytes
+/// [RFC 791 § 3.1]: https://tools.ietf.org/html/rfc791#section-3.1
+const MINIMUM_IHL_BYTES: u8 = 20;
+
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Key {
@@ -226,6 +230,7 @@ impl<T: AsRef<[u8]>> Packet<T> {
     /// Returns `Err(Error)` if the buffer is too short.
     /// Returns `Err(Error)` if the header length is greater
     /// than total length.
+    /// Returns `Err(Error)` if the header length is less than minimum allowed IHL
     ///
     /// The result of this check is invalidated by calling [set_header_len]
     /// and [set_total_len].
@@ -242,6 +247,8 @@ impl<T: AsRef<[u8]>> Packet<T> {
         } else if self.header_len() as u16 > self.total_len() {
             Err(Error)
         } else if len < self.total_len() as usize {
+            Err(Error)
+        } else if self.header_len() < MINIMUM_IHL_BYTES {
             Err(Error)
         } else {
             Ok(())
@@ -832,6 +839,16 @@ pub(crate) mod test {
     fn test_parse_total_len_less_than_header_len() {
         let mut bytes = vec![0; 40];
         bytes[0] = 0x09;
+        assert_eq!(Packet::new_checked(&mut bytes), Err(Error));
+    }
+
+    #[test]
+    fn test_parse_small_ihl() {
+        let mut bytes = vec![0; 24];
+        bytes.copy_from_slice(&REPR_PACKET_BYTES[..]);
+        let mut packet = Packet::new_unchecked(&mut bytes);
+        packet.set_header_len(16);
+
         assert_eq!(Packet::new_checked(&mut bytes), Err(Error));
     }
 


### PR DESCRIPTION
IPv4 specification requires IHL to be at least 20 bytes (or 5 x 32 bit words)

https://www.rfc-editor.org/rfc/rfc760.html#section-3.1

```
  IHL:  4 bits

    Internet Header Length is the length of the internet header in 32
    bit words, and thus points to the beginning of the data.  Note that
    the minimum value for a correct header is 5.
```

Currently IPv4 parser does not enforce minimum IHL length, this leads to situation where invalid IPv4 packet with technically overlapping L3 and L4 header will pass all length and checksum validation and reach all the way to the application.

Adding a missing IHL check.