### PR TITLE
iface: make neighbor discovery silent time configurable

### DIFF
--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -155,6 +155,8 @@ pub struct InterfaceInner {
     routes: Routes,
     #[cfg(feature = "multicast")]
     multicast: multicast::State,
+
+    discovery_silent_time: Duration,
 }
 
 /// Configuration structure used for creating a network interface.
@@ -183,9 +185,14 @@ pub struct Config {
     /// Enable stateless address autoconfiguration on the interface.
     #[cfg(feature = "proto-ipv6")]
     pub slaac: bool,
+
+    /// Minimum delay between neighbor discovery requests for the interface.
+    pub discovery_silent_time: Duration,
 }
 
 impl Config {
+    pub(crate) const DEFAULT_DISCOVERY_SILENT_TIME: Duration = Duration::from_millis(1_000);
+
     pub fn new(hardware_addr: HardwareAddress) -> Self {
         Config {
             random_seed: 0,
@@ -194,6 +201,7 @@ impl Config {
             pan_id: None,
             #[cfg(feature = "proto-ipv6")]
             slaac: false,
+            discovery_silent_time: Self::DEFAULT_DISCOVERY_SILENT_TIME,
         }
     }
 }
@@ -285,6 +293,7 @@ impl Interface {
                 #[cfg(feature = "proto-ipv6-slaac")]
                 slaac_updated: Instant::from_millis(0),
                 rand,
+                discovery_silent_time: config.discovery_silent_time,
             },
         }
     }
@@ -807,6 +816,7 @@ impl Interface {
                     item.meta.neighbor_missing(
                         self.inner.now,
                         neighbor_addr.expect("non-IP response packet"),
+                        self.inner.discovery_silent_time,
                     );
                 }
                 Ok(()) => {}
@@ -1181,7 +1191,8 @@ impl InterfaceInner {
         }
 
         // The request got dispatched, limit the rate on the cache.
-        self.neighbor_cache.limit_rate(self.now);
+        self.neighbor_cache
+            .limit_rate(self.now, self.discovery_silent_time);
         Err(DispatchError::NeighborPending)
     }
 

--- a/src/iface/neighbor.rs
+++ b/src/iface/neighbor.rs
@@ -49,9 +49,6 @@ pub struct Cache {
 }
 
 impl Cache {
-    /// Minimum delay between discovery requests, in milliseconds.
-    pub(crate) const SILENT_TIME: Duration = Duration::from_millis(1_000);
-
     /// Neighbor entry lifetime, in milliseconds.
     pub(crate) const ENTRY_LIFETIME: Duration = Duration::from_millis(60_000);
 
@@ -165,8 +162,8 @@ impl Cache {
         }
     }
 
-    pub(crate) fn limit_rate(&mut self, timestamp: Instant) {
-        self.silent_until = timestamp + Self::SILENT_TIME;
+    pub(crate) fn limit_rate(&mut self, timestamp: Instant, delay: Duration) {
+        self.silent_until = timestamp + delay;
     }
 
     pub(crate) fn flush(&mut self) {
@@ -305,7 +302,7 @@ mod test {
             Answer::NotFound
         );
 
-        cache.limit_rate(Instant::from_millis(0));
+        cache.limit_rate(Instant::from_millis(0), Duration::from_millis(1000));
         assert_eq!(
             cache.lookup(&MOCK_IP_ADDR_1.into(), Instant::from_millis(100)),
             Answer::RateLimited

--- a/src/iface/socket_meta.rs
+++ b/src/iface/socket_meta.rs
@@ -39,12 +39,6 @@ pub(crate) struct Meta {
 }
 
 impl Meta {
-    /// Minimum delay between neighbor discovery requests for this particular
-    /// socket, in milliseconds.
-    ///
-    /// See also `iface::NeighborCache::SILENT_TIME`.
-    pub(crate) const DISCOVERY_SILENT_TIME: Duration = Duration::from_millis(1_000);
-
     pub(crate) fn poll_at<F>(
         &self,
         socket_poll_at: PollAt,
@@ -96,16 +90,21 @@ impl Meta {
         }
     }
 
-    pub(crate) fn neighbor_missing(&mut self, timestamp: Instant, neighbor: IpAddress) {
+    pub(crate) fn neighbor_missing(
+        &mut self,
+        timestamp: Instant,
+        neighbor: IpAddress,
+        delay: Duration,
+    ) {
         net_trace!(
             "{}: neighbor {} missing, silencing until t+{}",
             self.handle,
             neighbor,
-            Self::DISCOVERY_SILENT_TIME
+            delay
         );
         self.neighbor_state = NeighborState::Waiting {
             neighbor,
-            silent_until: timestamp + Self::DISCOVERY_SILENT_TIME,
+            silent_until: timestamp + delay,
         };
     }
 }
@@ -143,7 +142,11 @@ mod tests {
     #[test]
     fn poll_at_waiting_neighbor_found() {
         let mut m = meta();
-        m.neighbor_missing(Instant::from_millis(1000), NEIGHBOR);
+        m.neighbor_missing(
+            Instant::from_millis(1000),
+            NEIGHBOR,
+            Duration::from_millis(1000),
+        );
 
         assert_eq!(
             m.poll_at(PollAt::Now, |_| true, Instant::from_millis(1000)),
@@ -159,8 +162,8 @@ mod tests {
     fn poll_at_waiting_before_silent_until() {
         let mut m = meta();
         let t0 = Instant::from_millis(1000);
-        m.neighbor_missing(t0, NEIGHBOR);
-        let silent_until = t0 + Meta::DISCOVERY_SILENT_TIME;
+        m.neighbor_missing(t0, NEIGHBOR, Duration::from_millis(1000));
+        let silent_until = t0 + Duration::from_millis(1000);
 
         let t_before = Instant::from_millis(1500);
         assert!(t_before < silent_until);
@@ -179,8 +182,8 @@ mod tests {
     fn poll_at_waiting_after_silent_until_returns_socket_poll_at() {
         let mut m = meta();
         let t0 = Instant::from_millis(1000);
-        m.neighbor_missing(t0, NEIGHBOR);
-        let silent_until = t0 + Meta::DISCOVERY_SILENT_TIME;
+        m.neighbor_missing(t0, NEIGHBOR, Duration::from_millis(1000));
+        let silent_until = t0 + Duration::from_millis(1000);
 
         let t_after = Instant::from_millis(2500);
         assert!(t_after >= silent_until);
@@ -201,8 +204,8 @@ mod tests {
     fn poll_at_waiting_at_exact_silent_until() {
         let mut m = meta();
         let t0 = Instant::from_millis(1000);
-        m.neighbor_missing(t0, NEIGHBOR);
-        let silent_until = t0 + Meta::DISCOVERY_SILENT_TIME;
+        m.neighbor_missing(t0, NEIGHBOR, Duration::from_millis(1000));
+        let silent_until = t0 + Duration::from_millis(1000);
 
         assert_eq!(
             m.poll_at(PollAt::Ingress, |_| false, silent_until),
@@ -214,8 +217,8 @@ mod tests {
     fn egress_permitted_consistent_with_poll_at() {
         let mut m = meta();
         let t0 = Instant::from_millis(1000);
-        m.neighbor_missing(t0, NEIGHBOR);
-        let silent_until = t0 + Meta::DISCOVERY_SILENT_TIME;
+        m.neighbor_missing(t0, NEIGHBOR, Duration::from_millis(1000));
+        let silent_until = t0 + Duration::from_millis(1000);
 
         let t_before = Instant::from_millis(1500);
         assert!(!m.egress_permitted(t_before, |_| false));


### PR DESCRIPTION
At the moment ARP requests are throttled to one/sec. In many situations this is too slow.

Allow the "discovery silent time" delay to be configurable per interface, with the default remaining at 1000ms.