### PR TITLE
Avoid immediate repoll loops when no transmit tokens are available

### DIFF
--- a/src/iface/interface/ipv4.rs
+++ b/src/iface/interface/ipv4.rs
@@ -18,11 +18,14 @@ impl Interface {
         }
 
         let pkt = &self.fragmenter;
-        if pkt.packet_len > pkt.sent_bytes
-            && let Some(tx_token) = device.transmit(self.inner.now)
-        {
-            self.inner
-                .dispatch_ipv4_frag(tx_token, &mut self.fragmenter);
+        if pkt.packet_len > pkt.sent_bytes {
+            if let Some(tx_token) = device.transmit(self.inner.now) {
+                self.inner
+                    .dispatch_ipv4_frag(tx_token, &mut self.fragmenter);
+                self.inner.clear_device_exhausted();
+            } else {
+                self.inner.mark_device_exhausted();
+            }
         }
     }
 }

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -155,6 +155,10 @@ pub struct InterfaceInner {
     routes: Routes,
     #[cfg(feature = "multicast")]
     multicast: multicast::State,
+    /// Deadline before which `poll_at` should avoid returning an immediate
+    /// deadline, because the device was recently unable to transmit.
+    device_exhausted_until: Instant,
+    device_exhausted_this_poll: bool,
 }
 
 /// Configuration structure used for creating a network interface.
@@ -285,6 +289,8 @@ impl Interface {
                 #[cfg(feature = "proto-ipv6-slaac")]
                 slaac_updated: Instant::from_millis(0),
                 rand,
+                device_exhausted_until: Instant::ZERO,
+                device_exhausted_this_poll: false,
             },
         }
     }
@@ -510,6 +516,7 @@ impl Interface {
         sockets: &mut SocketSet<'_>,
     ) -> PollResult {
         self.inner.now = timestamp;
+        self.inner.device_exhausted_this_poll = false;
 
         match self.inner.caps.medium {
             #[cfg(feature = "medium-ieee802154")]
@@ -584,7 +591,7 @@ impl Interface {
 
         #[cfg(feature = "_proto-fragmentation")]
         if !self.fragmenter.is_empty() {
-            return Some(Instant::from_millis(0));
+            return Some(self.inner.poll_at_immediate());
         }
 
         #[allow(unused_mut)]
@@ -599,7 +606,7 @@ impl Interface {
                 ) {
                     PollAt::Ingress => None,
                     PollAt::Time(instant) => Some(instant),
-                    PollAt::Now => Some(Instant::from_millis(0)),
+                    PollAt::Now => Some(self.inner.poll_at_immediate()),
                 }
             })
             .min();
@@ -725,6 +732,7 @@ impl Interface {
                     net_debug!("failed to transmit IP: device exhausted");
                     EgressError::Exhausted
                 })?;
+                inner.clear_device_exhausted();
 
                 inner
                     .dispatch_ip(t, meta, response, &mut self.fragmenter)
@@ -798,7 +806,10 @@ impl Interface {
             };
 
             match result {
-                Err(EgressError::Exhausted) => break, // Device buffer full.
+                Err(EgressError::Exhausted) => {
+                    self.inner.mark_device_exhausted();
+                    break;
+                }
                 Err(EgressError::Dispatch) => {
                     // `NeighborCache` already takes care of rate limiting the neighbor discovery
                     // requests from the socket. However, without an additional rate limiting
@@ -817,6 +828,36 @@ impl Interface {
 }
 
 impl InterfaceInner {
+    const DEVICE_EXHAUST_SILENT_TIME: Duration = Duration::from_millis(10);
+
+    pub(crate) fn mark_device_exhausted(&mut self) {
+        if !self.device_exhausted_this_poll {
+            self.device_exhausted_this_poll = true;
+
+            self.device_exhausted_until = if self.device_exhausted_until == Instant::ZERO {
+                // Allow one immediate re-poll.
+                self.now
+            } else {
+                // Wait a bit to avoid spinning on a continuously exhausted device.
+                self.now + Self::DEVICE_EXHAUST_SILENT_TIME
+            };
+        }
+    }
+
+    pub(crate) fn clear_device_exhausted(&mut self) {
+        // One or two immediate re-polls are not a big deal, we don't have to reset the
+        // device_exhausted_this_poll flag.
+        self.device_exhausted_until = Instant::ZERO;
+    }
+
+    /// Returns the instant to use for "immediate" poll deadlines, accounting
+    /// for device exhaustion back-off.
+    fn poll_at_immediate(&self) -> Instant {
+        // Either the timeout has expired in which case we return an Instant in the past,
+        // or we're still in the back-off period, in which case we return the back-off deadline.
+        self.device_exhausted_until
+    }
+
     #[allow(unused)] // unused depending on which sockets are enabled
     pub(crate) fn now(&self) -> Instant {
         self.now

--- a/src/iface/interface/sixlowpan.rs
+++ b/src/iface/interface/sixlowpan.rs
@@ -19,11 +19,14 @@ impl Interface {
         }
 
         let pkt = &self.fragmenter;
-        if pkt.packet_len > pkt.sent_bytes
-            && let Some(tx_token) = device.transmit(self.inner.now)
-        {
-            self.inner
-                .dispatch_ieee802154_frag(tx_token, &mut self.fragmenter);
+        if pkt.packet_len > pkt.sent_bytes {
+            if let Some(tx_token) = device.transmit(self.inner.now) {
+                self.inner
+                    .dispatch_ieee802154_frag(tx_token, &mut self.fragmenter);
+                self.inner.clear_device_exhausted();
+            } else {
+                self.inner.mark_device_exhausted();
+            }
         }
     }
 

--- a/src/iface/interface/tests/mod.rs
+++ b/src/iface/interface/tests/mod.rs
@@ -18,7 +18,7 @@ use crate::iface::Interface;
 use crate::phy::ChecksumCapabilities;
 #[cfg(feature = "alloc")]
 use crate::phy::Loopback;
-use crate::time::Instant;
+use crate::time::{Duration, Instant};
 
 #[allow(unused)]
 fn fill_slice(s: &mut [u8], val: u8) {
@@ -244,4 +244,92 @@ pub fn tcp_not_accepted() {
         ),
         None,
     );
+}
+
+#[cfg(all(feature = "medium-ip", feature = "socket-udp", feature = "proto-ipv4"))]
+mod device_exhausted {
+    use super::*;
+    use crate::socket::udp;
+
+    fn setup_udp_with_data() -> (Interface, SocketSet<'static>, crate::tests::TestingDevice) {
+        let (iface, mut sockets, device) = setup(Medium::Ip);
+
+        let rx_buffer = udp::PacketBuffer::new(vec![udp::PacketMetadata::EMPTY], vec![0; 64]);
+        let tx_buffer = udp::PacketBuffer::new(vec![udp::PacketMetadata::EMPTY], vec![0; 64]);
+        let mut socket = udp::Socket::new(rx_buffer, tx_buffer);
+        socket.bind(1234).unwrap();
+        let handle = sockets.add(socket);
+
+        let socket = sockets.get_mut::<udp::Socket>(handle);
+        socket
+            .send_slice(
+                b"hello",
+                IpEndpoint::new(IpAddress::v4(192, 168, 1, 2), 4321),
+            )
+            .unwrap();
+
+        (iface, sockets, device)
+    }
+
+    #[test]
+    fn first_exhaustion_allows_immediate_repoll() {
+        let (mut iface, mut sockets, mut device) = setup_udp_with_data();
+        device.transmit_exhausted = true;
+
+        let t = Instant::from_millis(1000);
+        iface.poll(t, &mut device, &mut sockets);
+
+        assert_eq!(
+            iface.poll_delay(t, &sockets),
+            Some(Duration::from_millis(0))
+        );
+    }
+
+    #[test]
+    fn second_exhaustion_starts_backoff() {
+        let (mut iface, mut sockets, mut device) = setup_udp_with_data();
+        device.transmit_exhausted = true;
+
+        iface.poll(Instant::from_millis(1000), &mut device, &mut sockets);
+
+        let t = Instant::from_millis(1001);
+        iface.poll(t, &mut device, &mut sockets);
+
+        let delay = iface.poll_delay(t, &sockets).unwrap();
+        assert!(delay > Duration::from_millis(0));
+    }
+
+    #[test]
+    fn backoff_caps_when_poll_interval_ignored() {
+        let (mut iface, mut sockets, mut device) = setup_udp_with_data();
+        device.transmit_exhausted = true;
+
+        iface.poll(Instant::from_millis(1000), &mut device, &mut sockets);
+        iface.poll(Instant::from_millis(1001), &mut device, &mut sockets);
+
+        // Tight-loop poll at the same timestamp to ramp to the cap.
+        let t = Instant::from_millis(1001);
+        for _ in 0..100 {
+            iface.poll(t, &mut device, &mut sockets);
+        }
+
+        let delay = iface.poll_delay(t, &sockets).unwrap();
+        assert_eq!(delay, InterfaceInner::DEVICE_EXHAUST_SILENT_TIME);
+    }
+
+    #[test]
+    fn successful_transmit_clears_backoff() {
+        let (mut iface, mut sockets, mut device) = setup_udp_with_data();
+        device.transmit_exhausted = true;
+
+        iface.poll(Instant::from_millis(1000), &mut device, &mut sockets);
+        iface.poll(Instant::from_millis(1001), &mut device, &mut sockets);
+
+        device.transmit_exhausted = false;
+        let t = Instant::from_millis(1012);
+        iface.poll(t, &mut device, &mut sockets);
+
+        // Packet was transmitted, back-off cleared.
+        assert_eq!(iface.poll_at(t, &sockets), None);
+    }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -60,6 +60,7 @@ pub struct TestingDevice {
     pub(crate) rx_queue: VecDeque<Vec<u8>>,
     max_transmission_unit: usize,
     medium: Medium,
+    pub(crate) transmit_exhausted: bool,
 }
 
 #[allow(clippy::new_without_default)]
@@ -81,6 +82,7 @@ impl TestingDevice {
                 Medium::Ieee802154 => 1500,
             },
             medium,
+            transmit_exhausted: false,
         }
     }
 }
@@ -108,6 +110,9 @@ impl Device for TestingDevice {
     }
 
     fn transmit(&mut self, _timestamp: Instant) -> Option<Self::TxToken<'_>> {
+        if self.transmit_exhausted {
+            return None;
+        }
         Some(TxToken {
             queue: &mut self.tx_queue,
         })


### PR DESCRIPTION
If the device's buffer is full, smoltcp requests an immediate re-poll hoping the buffer clears fast enough. This causes an issue: if the device cannot hand out tokens because the network link is down (cable is unplugged, wi-fi access point is not in range, etc.), smoltcp will eat up all CPU time by polling constantly. This PR adds a small delay to prevent busy-looping forever, if an immediate re-poll can't make progress.