### PR TITLE
Fix TCP crash when receiving SYN from unspecified addr.

### DIFF
--- a/src/iface/interface/tcp.rs
+++ b/src/iface/interface/tcp.rs
@@ -11,6 +11,16 @@ impl InterfaceInner {
         ip_payload: &'frame [u8],
     ) -> Option<Packet<'frame>> {
         let (src_addr, dst_addr) = (ip_repr.src_addr(), ip_repr.dst_addr());
+
+        // Per RFC 1122 §3.2.1.3, the unspecified address must never appear as a source
+        // or destination in any IP datagram. Drop such TCP segments early to avoid
+        // creating sockets with unspecified peers (which would later panic on egress).
+        // This is not done at the iface level because it might be useful with
+        // UDP or raw sockets, but it's definitely not useful for TCP.
+        if src_addr.is_unspecified() || dst_addr.is_unspecified() {
+            return None;
+        }
+
         let tcp_packet = check!(TcpPacket::new_checked(ip_payload));
         let tcp_repr = check!(TcpRepr::parse(
             &tcp_packet,

--- a/src/iface/interface/tests/mod.rs
+++ b/src/iface/interface/tests/mod.rs
@@ -245,3 +245,57 @@ pub fn tcp_not_accepted() {
         None,
     );
 }
+
+#[test]
+#[cfg(all(feature = "medium-ip", feature = "socket-tcp", feature = "proto-ipv4"))]
+pub fn tcp_listen_drops_unspecified_src() {
+    use crate::socket::tcp;
+
+    let (mut iface, mut sockets, _) = setup(Medium::Ip);
+
+    let tcp_socket = tcp::Socket::new(
+        tcp::SocketBuffer::new(vec![0; 64]),
+        tcp::SocketBuffer::new(vec![0; 64]),
+    );
+    let handle = sockets.add(tcp_socket);
+    sockets.get_mut::<tcp::Socket>(handle).listen(1234).unwrap();
+
+    let tcp = TcpRepr {
+        src_port: 65000,
+        dst_port: 1234,
+        control: TcpControl::Syn,
+        seq_number: TcpSeqNumber(0),
+        ack_number: None,
+        window_len: 1024,
+        window_scale: None,
+        max_seg_size: Some(1460),
+        sack_permitted: false,
+        sack_ranges: [None, None, None],
+        timestamp: None,
+        payload: &[],
+    };
+
+    let mut tcp_bytes = vec![0u8; tcp.buffer_len()];
+    tcp.emit(
+        &mut TcpPacket::new_unchecked(&mut tcp_bytes),
+        &Ipv4Address::UNSPECIFIED.into(),
+        &Ipv4Address::new(127, 0, 0, 1).into(),
+        &ChecksumCapabilities::default(),
+    );
+
+    let reply = iface.inner.process_tcp(
+        &mut sockets,
+        false,
+        IpRepr::Ipv4(Ipv4Repr {
+            src_addr: Ipv4Address::UNSPECIFIED,
+            dst_addr: Ipv4Address::new(127, 0, 0, 1),
+            next_header: IpProtocol::Tcp,
+            payload_len: tcp.buffer_len(),
+            hop_limit: 64,
+        }),
+        &tcp_bytes,
+    );
+
+    assert_eq!(reply, None);
+    assert!(sockets.get_mut::<tcp::Socket>(handle).is_listening());
+}


### PR DESCRIPTION
It would cause us to reply with SYN+ACK to the unspecified addr, which
hits an assert in the iface egress path.

Found by @tomkris Artem Kryvokrysenko from AWS.
