### PR TITLE
 feat(phy): add TCP segmentation support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,9 @@ defmt = ["dep:defmt", "heapless/defmt"]
 
 "packetmeta-id" = []
 
+# Enables segmentation offload support.
+"segmentation-offload" = []
+
 "async" = []
 
 # Automatically reply on an ICMP echo request

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -770,13 +770,11 @@ impl Interface {
                     })
                 }
                 #[cfg(feature = "socket-tcp")]
-                Socket::Tcp(socket) => socket.dispatch(&mut self.inner, |inner, (ip, tcp)| {
-                    respond(
-                        inner,
-                        PacketMeta::default(),
-                        Packet::new(ip, IpPayload::Tcp(tcp)),
-                    )
-                }),
+                Socket::Tcp(socket) => {
+                    socket.dispatch(&mut self.inner, |inner, meta, (ip, tcp)| {
+                        respond(inner, meta, Packet::new(ip, IpPayload::Tcp(tcp)))
+                    })
+                }
                 #[cfg(feature = "socket-dhcpv4")]
                 Socket::Dhcpv4(socket) => {
                     socket.dispatch(&mut self.inner, |inner, (ip, udp, dhcp)| {
@@ -831,6 +829,12 @@ impl InterfaceInner {
     #[allow(unused)] // unused depending on which sockets are enabled
     pub(crate) fn checksum_caps(&self) -> ChecksumCapabilities {
         self.caps.checksum.clone()
+    }
+
+    #[cfg(feature = "segmentation-offload")]
+    #[allow(unused)] // unused depending on which sockets are enabled
+    pub(crate) fn segmentation_caps(&self) -> crate::phy::SegmentationCapabilities {
+        self.caps.segmentation.clone()
     }
 
     #[allow(unused)] // unused depending on which sockets are enabled
@@ -1273,7 +1277,15 @@ impl InterfaceInner {
             #[cfg(feature = "proto-ipv4")]
             IpRepr::Ipv4(repr) => {
                 // If we have an IPv4 packet, then we need to check if we need to fragment it.
-                if total_ip_len > self.caps.ip_mtu() {
+                let should_fragment = total_ip_len > self.caps.ip_mtu();
+
+                // If the second condition is false (i.e. the metadata includes a target segment
+                // size), the packet will be segmented by the device and fragmentation on our side
+                // is not necessary.
+                #[cfg(feature = "segmentation-offload")]
+                let should_fragment = should_fragment && meta.segmentation_offload_size.is_none();
+
+                if should_fragment {
                     #[cfg(feature = "proto-ipv4-fragmentation")]
                     {
                         net_debug!("start fragmentation");

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -212,6 +212,18 @@ impl Interface {
             "The hardware address does not match the medium of the interface."
         );
 
+        #[cfg(feature = "segmentation-offload")]
+        // Segmentation offload requires checksum offload.
+        if [caps.segmentation.tcpv4, caps.segmentation.tcpv6]
+            .iter()
+            .any(Option::is_some)
+        {
+            assert!(
+                !caps.checksum.tcp.tx(),
+                "Device capabilities are inconsistent."
+            )
+        }
+
         let mut rand = Rand::new(config.random_seed);
 
         #[cfg(feature = "medium-ieee802154")]
@@ -770,13 +782,11 @@ impl Interface {
                     })
                 }
                 #[cfg(feature = "socket-tcp")]
-                Socket::Tcp(socket) => socket.dispatch(&mut self.inner, |inner, (ip, tcp)| {
-                    respond(
-                        inner,
-                        PacketMeta::default(),
-                        Packet::new(ip, IpPayload::Tcp(tcp)),
-                    )
-                }),
+                Socket::Tcp(socket) => {
+                    socket.dispatch(&mut self.inner, |inner, meta, (ip, tcp)| {
+                        respond(inner, meta, Packet::new(ip, IpPayload::Tcp(tcp)))
+                    })
+                }
                 #[cfg(feature = "socket-dhcpv4")]
                 Socket::Dhcpv4(socket) => {
                     socket.dispatch(&mut self.inner, |inner, (ip, udp, dhcp)| {
@@ -831,6 +841,17 @@ impl InterfaceInner {
     #[allow(unused)] // unused depending on which sockets are enabled
     pub(crate) fn checksum_caps(&self) -> ChecksumCapabilities {
         self.caps.checksum.clone()
+    }
+
+    #[cfg(feature = "segmentation-offload")]
+    #[allow(unused)] // unused depending on which sockets are enabled
+    pub(crate) fn segmentation_caps(&self) -> crate::phy::SegmentationCapabilities {
+        self.caps.segmentation.clone()
+    }
+
+    #[allow(unused)] // unused depending on which sockets are enabled
+    pub(crate) fn max_transmission_unit(&self) -> usize {
+        self.caps.max_transmission_unit
     }
 
     #[allow(unused)] // unused depending on which sockets are enabled
@@ -1273,7 +1294,15 @@ impl InterfaceInner {
             #[cfg(feature = "proto-ipv4")]
             IpRepr::Ipv4(repr) => {
                 // If we have an IPv4 packet, then we need to check if we need to fragment it.
-                if total_ip_len > self.caps.ip_mtu() {
+                let should_fragment = total_ip_len > self.caps.ip_mtu();
+
+                // If the second condition is false (i.e. the metadata includes a target segment
+                // size), the packet will be segmented by the device and fragmentation on our side
+                // is not necessary.
+                #[cfg(feature = "segmentation-offload")]
+                let should_fragment = should_fragment && meta.segmentation_offload_size.is_none();
+
+                if should_fragment {
                     #[cfg(feature = "proto-ipv4-fragmentation")]
                     {
                         net_debug!("start fragmentation");

--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -89,6 +89,8 @@ impl<'a> phy::TxToken for StmPhyTxToken<'a> {
 )]
 
 use crate::time::Instant;
+#[cfg(feature = "segmentation-offload")]
+use core::num::{NonZeroU16, NonZeroUsize};
 
 #[cfg(all(
     any(feature = "phy-raw_socket", feature = "phy-tuntap_interface"),
@@ -147,7 +149,7 @@ pub const IPV4_FRAGMENT_PAYLOAD_ALIGNMENT: usize = 8;
 /// struct becomes zero-sized, which allows the compiler to optimize it out as if
 /// the packet metadata mechanism didn't exist at all.
 ///
-/// Currently only UDP sockets allow setting/retrieving packet metadata. The metadata
+/// Currently only TCP and UDP sockets allow setting/retrieving packet metadata. The metadata
 /// for packets emitted with other sockets will be all default values.
 ///
 /// This struct is marked as `#[non_exhaustive]`. This means it is not possible to
@@ -168,6 +170,8 @@ pub const IPV4_FRAGMENT_PAYLOAD_ALIGNMENT: usize = 8;
 pub struct PacketMeta {
     #[cfg(feature = "packetmeta-id")]
     pub id: u32,
+    #[cfg(feature = "segmentation-offload")]
+    pub segmentation_offload_size: Option<NonZeroU16>,
 }
 
 /// A description of checksum behavior for a particular protocol.
@@ -233,6 +237,28 @@ impl ChecksumCapabilities {
     }
 }
 
+/// The maximum buffer size for a particular protocol or protocol pair that
+/// can be offloaded to the device for segmentation, or [None] if segmentation
+/// offload is not supported.
+///
+/// For Ethernet devices, this includes the Ethernet header (14 octets), but
+/// *not* the Ethernet FCS (4 octets).
+///
+/// If the device supports unsegmented IP packets with (depending on the IP
+/// version, total or payload) lengths greater than [u16::MAX], it should not
+/// rely on the length field in the IP header, as the actual length cannot be
+/// represented there. The value will be 0 instead.
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+#[cfg(feature = "segmentation-offload")]
+pub struct SegmentationCapabilities {
+    #[cfg(all(feature = "socket-tcp", feature = "proto-ipv4"))]
+    pub tcpv4: Option<NonZeroUsize>,
+    #[cfg(all(feature = "socket-tcp", feature = "proto-ipv6"))]
+    pub tcpv6: Option<NonZeroUsize>,
+}
+
 /// A description of device capabilities.
 ///
 /// Higher-level protocols may achieve higher throughput or lower latency if they consider
@@ -276,6 +302,13 @@ pub struct DeviceCapabilities {
     /// If the network device is capable of verifying or computing checksums for some protocols,
     /// it can request that the stack not do so in software to improve performance.
     pub checksum: ChecksumCapabilities,
+
+    #[cfg(feature = "segmentation-offload")]
+    /// Segmentation offload capabilities.
+    ///
+    /// If the network device is capable of segmenting packets for some protocols,
+    /// it can request that the stack not do so in software to improve performance.
+    pub segmentation: SegmentationCapabilities,
 }
 
 impl DeviceCapabilities {

--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -89,6 +89,8 @@ impl<'a> phy::TxToken for StmPhyTxToken<'a> {
 )]
 
 use crate::time::Instant;
+#[cfg(feature = "segmentation-offload")]
+use core::num::{NonZeroU16, NonZeroUsize};
 
 #[cfg(all(
     any(feature = "phy-raw_socket", feature = "phy-tuntap_interface"),
@@ -147,7 +149,7 @@ pub const IPV4_FRAGMENT_PAYLOAD_ALIGNMENT: usize = 8;
 /// struct becomes zero-sized, which allows the compiler to optimize it out as if
 /// the packet metadata mechanism didn't exist at all.
 ///
-/// Currently only UDP sockets allow setting/retrieving packet metadata. The metadata
+/// Currently only TCP and UDP sockets allow setting/retrieving packet metadata. The metadata
 /// for packets emitted with other sockets will be all default values.
 ///
 /// This struct is marked as `#[non_exhaustive]`. This means it is not possible to
@@ -168,6 +170,17 @@ pub const IPV4_FRAGMENT_PAYLOAD_ALIGNMENT: usize = 8;
 pub struct PacketMeta {
     #[cfg(feature = "packetmeta-id")]
     pub id: u32,
+
+    /// Segmentation offload size.
+    ///
+    /// If the network device advertised support for segmentation offload, the
+    /// stack can request that the device segments the provided packet into
+    /// segments of this size. The size does not include the headers that will
+    /// be replicated across the segments (e.g. TCP, IP, Ethernet headers).
+    ///
+    /// If `None`, no segmentation will be performed by the device.
+    #[cfg(feature = "segmentation-offload")]
+    pub segmentation_offload_size: Option<NonZeroU16>,
 }
 
 /// A description of checksum behavior for a particular protocol.
@@ -233,6 +246,28 @@ impl ChecksumCapabilities {
     }
 }
 
+/// The maximum buffer size for a particular protocol or protocol pair that
+/// can be offloaded to the device for segmentation, or [None] if segmentation
+/// offload is not supported.
+///
+/// For Ethernet devices, this includes the Ethernet header (14 octets), but
+/// *not* the Ethernet FCS (4 octets).
+///
+/// If the device supports unsegmented IP packets with (depending on the IP
+/// version, total or payload) lengths greater than [u16::MAX], it should not
+/// rely on the length field in the IP header, as the actual length cannot be
+/// represented there. The value will be 0 instead.
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+#[cfg(feature = "segmentation-offload")]
+pub struct SegmentationCapabilities {
+    #[cfg(all(feature = "socket-tcp", feature = "proto-ipv4"))]
+    pub tcpv4: Option<NonZeroUsize>,
+    #[cfg(all(feature = "socket-tcp", feature = "proto-ipv6"))]
+    pub tcpv6: Option<NonZeroUsize>,
+}
+
 /// A description of device capabilities.
 ///
 /// Higher-level protocols may achieve higher throughput or lower latency if they consider
@@ -276,6 +311,16 @@ pub struct DeviceCapabilities {
     /// If the network device is capable of verifying or computing checksums for some protocols,
     /// it can request that the stack not do so in software to improve performance.
     pub checksum: ChecksumCapabilities,
+
+    #[cfg(feature = "segmentation-offload")]
+    /// Segmentation offload capabilities.
+    ///
+    /// If the network device is capable of segmenting packets for some protocols,
+    /// it can request that the stack not do so in software to improve performance.
+    ///
+    /// The device needs to support checksum offload in the send direction for
+    /// the corresponding protocol.
+    pub segmentation: SegmentationCapabilities,
 }
 
 impl DeviceCapabilities {

--- a/src/phy/pcap_writer.rs
+++ b/src/phy/pcap_writer.rs
@@ -62,7 +62,7 @@ pub trait PcapSink {
         self.write_u16(4); // minor version
         self.write_u32(0); // timezone (= UTC)
         self.write_u32(0); // accuracy (not used)
-        self.write_u32(65535); // maximum packet length
+        self.write_u32(self.max_packet_size()); // maximum packet length
         self.write_u32(link_type.into()); // link-layer header type
     }
 
@@ -71,23 +71,40 @@ pub trait PcapSink {
     /// See also the note for [global_header](#method.global_header).
     ///
     /// # Panics
-    /// This function panics if `length` is greater than 65535.
+    /// This function panics if `length` is greater than [u32::MAX].
     fn packet_header(&mut self, timestamp: Instant, length: usize) {
-        assert!(length <= 65535);
+        let original_length = length.try_into().unwrap();
 
         self.write_u32(timestamp.secs() as u32); // timestamp seconds
         self.write_u32(timestamp.micros() as u32); // timestamp microseconds
-        self.write_u32(length as u32); // captured length
-        self.write_u32(length as u32); // original length
+        self.write_u32(self.max_packet_size().min(original_length)); // captured length
+        self.write_u32(original_length);
     }
 
     /// Write the libpcap packet header followed by packet data into the sink.
     ///
+    /// The default implementation truncates packets that are larger than [Self::max_packet_size].
+    ///
     /// See also the note for [global_header](#method.global_header).
     fn packet(&mut self, timestamp: Instant, packet: &[u8]) {
-        self.packet_header(timestamp, packet.len());
-        self.write(packet);
+        let packet_len = packet.len();
+        let max_packet_size = usize::try_from(self.max_packet_size()).unwrap();
+
+        self.packet_header(timestamp, packet_len);
+        self.write(&packet[..max_packet_size.min(packet_len)]);
         self.flush();
+    }
+
+    /// Return the maximum size for captured packets.
+    ///
+    /// The captures of packets larger than this size will be truncated by default. Excessively
+    /// large values may cause the software reading the captures to allocate unnecessarily large
+    /// buffers.
+    fn max_packet_size(&self) -> u32 {
+        // Use the default value used by [libpcap] and [Wireshark].
+        // [Wireshark]: https://gitlab.com/wireshark/wireshark/-/blob/v3.5.0/wiretap/wtap.h#L334
+        // [libpcap]: https://github.com/the-tcpdump-group/libpcap/blob/libpcap-1.6.0-bp/pcap-int.h#L106
+        262144
     }
 }
 

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -7,6 +7,7 @@ use core::fmt::Display;
 use core::task::Waker;
 use core::{fmt, mem};
 
+use crate::phy::PacketMeta;
 #[cfg(feature = "async")]
 use crate::socket::WakerRegistration;
 use crate::socket::{Context, PollAt};
@@ -2351,7 +2352,7 @@ impl<'a> Socket<'a> {
 
     pub(crate) fn dispatch<F, E>(&mut self, cx: &mut Context, emit: F) -> Result<(), E>
     where
-        F: FnOnce(&mut Context, (IpRepr, TcpRepr)) -> Result<(), E>,
+        F: FnOnce(&mut Context, PacketMeta, (IpRepr, TcpRepr)) -> Result<(), E>,
     {
         if self.tuple.is_none() {
             return Ok(());
@@ -2478,6 +2479,15 @@ impl<'a> Socket<'a> {
 
         let mut is_zero_window_probe = false;
 
+        #[cfg_attr(
+            not(feature = "segmentation-offload"),
+            expect(
+                unused_mut,
+                reason = "The default is not mutated if the segmentation offload feature is not enabled."
+            )
+        )]
+        let mut packet_meta = PacketMeta::default();
+
         match self.state {
             // We transmit an RST in the CLOSED state. If we ended up in the CLOSED state
             // with a specified endpoint, it means that the socket was aborted.
@@ -2536,16 +2546,53 @@ impl<'a> Socket<'a> {
                     is_zero_window_probe = true;
                 }
 
-                // Maximum size we're allowed to send. This can be limited by 3 factors:
+                // Maximum size we're allowed to send can be limited by 3 factors:
                 // 1. remote window
                 // 2. MSS the remote is willing to accept, probably determined by their MTU
                 // 3. MSS we can send, determined by our MTU.
-                let size = win_limit
-                    .min(self.remote_mss)
+                //
+                // If the device supports its offload, segmentation that is needed
+                // to comply with the latter two will be handled by the device based on the
+                // metadata we provide.
+
+                let segment_size = self
+                    .remote_mss
                     .min(cx.ip_mtu() - ip_repr.header_len() - TCP_HEADER_LEN);
+
+                #[cfg(not(feature = "segmentation-offload"))]
+                let device_limit = segment_size;
+
+                #[cfg(feature = "segmentation-offload")]
+                let device_limit = {
+                    let segmentation_caps = cx.segmentation_caps();
+                    match ip_repr.version() {
+                        #[cfg(feature = "proto-ipv4")]
+                        crate::wire::IpVersion::Ipv4 => segmentation_caps.tcpv4,
+                        #[cfg(feature = "proto-ipv6")]
+                        crate::wire::IpVersion::Ipv6 => segmentation_caps.tcpv6,
+                    }
+                    .map(|buf_size| {
+                        #[cfg(feature = "medium-ethernet")]
+                        let ip_mtu = buf_size.get() - crate::wire::ETHERNET_HEADER_LEN;
+                        #[cfg(not(feature = "medium-ethernet"))]
+                        let ip_mtu = buf_size.get();
+                        ip_mtu - ip_repr.header_len() - TCP_HEADER_LEN
+                    })
+                    .unwrap_or(segment_size)
+                };
+
+                let size = win_limit.min(device_limit);
 
                 let offset = self.remote_last_seq - self.local_seq_no;
                 repr.payload = self.tx_buffer.get_allocated(offset, size);
+
+                #[cfg(feature = "segmentation-offload")]
+                if repr.payload.len() > segment_size {
+                    packet_meta.segmentation_offload_size =
+                        core::num::NonZeroU16::try_from(u16::try_from(segment_size).unwrap())
+                            .unwrap()
+                            .into();
+                }
 
                 // If we've sent everything we had in the buffer, follow it with the PSH or FIN
                 // flags, depending on whether the transmit half of the connection is open.
@@ -2616,7 +2663,7 @@ impl<'a> Socket<'a> {
         // to not waste time waiting for the retransmit timer on packets that we know
         // for sure will not be successfully transmitted.
         ip_repr.set_payload_len(repr.buffer_len());
-        emit(cx, (ip_repr, repr))?;
+        emit(cx, packet_meta, (ip_repr, repr))?;
 
         // We've sent something, whether useful data or a keep-alive packet, so rewind
         // the keep-alive timer.
@@ -2909,7 +2956,7 @@ mod test {
         let mut sent = 0;
         let result = socket
             .socket
-            .dispatch(&mut socket.cx, |_, (ip_repr, tcp_repr)| {
+            .dispatch(&mut socket.cx, |_, _, (ip_repr, tcp_repr)| {
                 assert_eq!(ip_repr.next_header(), IpProtocol::Tcp);
                 assert_eq!(ip_repr.src_addr(), LOCAL_ADDR.into());
                 assert_eq!(ip_repr.dst_addr(), REMOTE_ADDR.into());
@@ -2930,7 +2977,7 @@ mod test {
         socket.cx.set_now(timestamp);
 
         let mut fail = false;
-        let result: Result<(), ()> = socket.socket.dispatch(&mut socket.cx, |_, _| {
+        let result: Result<(), ()> = socket.socket.dispatch(&mut socket.cx, |_, _, _| {
             fail = true;
             Ok(())
         });
@@ -7994,7 +8041,7 @@ mod test {
 
         s.set_hop_limit(Some(0x2a));
         assert_eq!(
-            s.socket.dispatch(&mut s.cx, |_, (ip_repr, _)| {
+            s.socket.dispatch(&mut s.cx, |_, _, (ip_repr, _)| {
                 assert_eq!(ip_repr.hop_limit(), 0x2a);
                 Ok::<_, ()>(())
             }),

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -7570,6 +7570,94 @@ mod test {
         );
     }
 
+    #[cfg(feature = "segmentation-offload")]
+    #[test]
+    fn test_segmentation_offload() {
+        use crate::tests::segmentation_offload::MAX_SEGMENTABLE_SIZE;
+        use crate::wire;
+
+        let (interface, _, _) =
+            crate::tests::segmentation_offload::setup_segmenting(crate::phy::Medium::Ip);
+        let mut s = TestSocket {
+            cx: interface.inner,
+            ..socket_listen()
+        };
+        s.tx_buffer = SocketBuffer::new(vec![0; 2 * MAX_SEGMENTABLE_SIZE]);
+
+        send!(
+            s,
+            TcpRepr {
+                control: TcpControl::Syn,
+                seq_number: REMOTE_SEQ,
+                ack_number: None,
+                window_scale: Some(2),
+                ..SEND_TEMPL
+            }
+        );
+        recv!(
+            s,
+            [TcpRepr {
+                control: TcpControl::Syn,
+                seq_number: LOCAL_SEQ,
+                ack_number: Some(REMOTE_SEQ + 1),
+                max_seg_size: Some(BASE_MSS),
+                window_scale: Some(0),
+                ..RECV_TEMPL
+            }]
+        );
+        send!(
+            s,
+            TcpRepr {
+                seq_number: REMOTE_SEQ + 1,
+                ack_number: Some(LOCAL_SEQ + 1),
+                window_len: u16::MAX,
+                ..SEND_TEMPL
+            }
+        );
+
+        s.send_slice(&[0; 2 * MAX_SEGMENTABLE_SIZE][..]).unwrap();
+
+        // We want to ensure that the size of the unsegmented packets exceed the
+        // maximum allowed by the length field in the IP headers to check if the
+        // relevant code incorrectly assumes that the length fits into the
+        // field.
+        let ip_header_len = match s.local_endpoint().unwrap().addr {
+            #[cfg(feature = "proto-ipv4")]
+            IpAddress::Ipv4(_) => {
+                assert!(MAX_SEGMENTABLE_SIZE > usize::from(u16::MAX));
+                wire::IPV4_HEADER_LEN
+            }
+            #[cfg(feature = "proto-ipv6")]
+            IpAddress::Ipv6(_) => {
+                assert!(MAX_SEGMENTABLE_SIZE - wire::IPV6_HEADER_LEN > usize::from(u16::MAX));
+                wire::IPV6_HEADER_LEN
+            }
+        };
+        let payload = vec![0; MAX_SEGMENTABLE_SIZE - ip_header_len - TCP_HEADER_LEN];
+        assert!(
+            payload.len() > usize::from(BASE_MSS),
+            "the payload is not large enough to require segmentation!"
+        );
+
+        recv!(
+            s,
+            [
+                TcpRepr {
+                    seq_number: LOCAL_SEQ + 1,
+                    ack_number: Some(REMOTE_SEQ + 1),
+                    payload: payload.as_slice(),
+                    ..RECV_TEMPL
+                },
+                TcpRepr {
+                    seq_number: LOCAL_SEQ + payload.len() + 1,
+                    ack_number: Some(REMOTE_SEQ + 1),
+                    payload: payload.as_slice(),
+                    ..RECV_TEMPL
+                }
+            ]
+        );
+    }
+
     #[test]
     fn test_recv_out_of_recv_win() {
         let mut s = socket_established();

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -7,6 +7,7 @@ use core::fmt::Display;
 use core::task::Waker;
 use core::{fmt, mem};
 
+use crate::phy::PacketMeta;
 #[cfg(feature = "async")]
 use crate::socket::WakerRegistration;
 use crate::socket::{Context, PollAt};
@@ -2435,7 +2436,7 @@ impl<'a> Socket<'a> {
 
     pub(crate) fn dispatch<F, E>(&mut self, cx: &mut Context, emit: F) -> Result<(), E>
     where
-        F: FnOnce(&mut Context, (IpRepr, TcpRepr)) -> Result<(), E>,
+        F: FnOnce(&mut Context, PacketMeta, (IpRepr, TcpRepr)) -> Result<(), E>,
     {
         if self.tuple.is_none() {
             return Ok(());
@@ -2579,6 +2580,15 @@ impl<'a> Socket<'a> {
 
         let mut is_zero_window_probe = false;
 
+        #[cfg_attr(
+            not(feature = "segmentation-offload"),
+            expect(
+                unused_mut,
+                reason = "The default is not mutated if the segmentation offload feature is not enabled."
+            )
+        )]
+        let mut packet_meta = PacketMeta::default();
+
         match self.state {
             // We transmit an RST in the CLOSED state. If we ended up in the CLOSED state
             // with a specified endpoint, it means that the socket was aborted.
@@ -2660,19 +2670,56 @@ impl<'a> Socket<'a> {
                     // 2. congestion window
                     // 3. MSS the remote is willing to accept, probably determined by their MTU
                     // 4. MSS we can send, determined by our MTU.
+                    //
+                    // If the device supports its offload, segmentation that is needed
+                    // to comply with the latter two will be handled by the device based on the
+                    // metadata we provide.
+
+                    #[cfg(not(feature = "segmentation-offload"))]
+                    let device_limit = effective_mss;
+
+                    #[cfg(feature = "segmentation-offload")]
+                    let device_limit = {
+                        let segmentation_caps = cx.segmentation_caps();
+                        match ip_repr.version() {
+                            #[cfg(feature = "proto-ipv4")]
+                            crate::wire::IpVersion::Ipv4 => segmentation_caps.tcpv4,
+                            #[cfg(feature = "proto-ipv6")]
+                            crate::wire::IpVersion::Ipv6 => segmentation_caps.tcpv6,
+                        }
+                        .map(|buf_size| {
+                            let pre_ip_header_len = cx.max_transmission_unit() - cx.ip_mtu();
+                            buf_size.get()
+                                - pre_ip_header_len
+                                - ip_repr.header_len()
+                                - TCP_HEADER_LEN
+                                - options_len
+                        })
+                        .unwrap_or(effective_mss)
+                    };
+
                     let size = if is_zero_window_probe {
                         // Zero-window probes are exempt from the congestion window: they
                         // are sent precisely when normal transmission is impossible, and
                         // an empty segment elicits no reply, so capping the probe to a
                         // zero length would stall the connection if a window update from
                         // the remote got lost.
-                        win_limit.min(effective_mss)
+                        win_limit.min(device_limit)
                     } else {
-                        win_limit.min(effective_mss).min(self.cwnd_remaining())
+                        win_limit.min(device_limit).min(self.cwnd_remaining())
                     };
 
                     let offset = self.flight_size();
                     repr.payload = self.tx_buffer.get_allocated(offset, size);
+
+                    #[cfg(feature = "segmentation-offload")]
+                    if repr.payload.len() > effective_mss {
+                        packet_meta.segmentation_offload_size =
+                            core::num::NonZeroU16::try_from(u16::try_from(effective_mss).unwrap())
+                                .unwrap()
+                                .into();
+                    }
+
                     offset
                 };
 
@@ -2745,7 +2792,7 @@ impl<'a> Socket<'a> {
         // to not waste time waiting for the retransmit timer on packets that we know
         // for sure will not be successfully transmitted.
         ip_repr.set_payload_len(repr.buffer_len());
-        emit(cx, (ip_repr, repr))?;
+        emit(cx, packet_meta, (ip_repr, repr))?;
 
         // We've sent something, whether useful data or a keep-alive packet, so rewind
         // the keep-alive timer.
@@ -3042,7 +3089,7 @@ mod test {
         let mut sent = 0;
         let result = socket
             .socket
-            .dispatch(&mut socket.cx, |_, (ip_repr, tcp_repr)| {
+            .dispatch(&mut socket.cx, |_, _, (ip_repr, tcp_repr)| {
                 assert_eq!(ip_repr.next_header(), IpProtocol::Tcp);
                 assert_eq!(ip_repr.src_addr(), LOCAL_ADDR.into());
                 assert_eq!(ip_repr.dst_addr(), REMOTE_ADDR.into());
@@ -3063,7 +3110,7 @@ mod test {
         socket.cx.set_now(timestamp);
 
         let mut fail = false;
-        let result: Result<(), ()> = socket.socket.dispatch(&mut socket.cx, |_, _| {
+        let result: Result<(), ()> = socket.socket.dispatch(&mut socket.cx, |_, _, _| {
             fail = true;
             Ok(())
         });
@@ -8699,7 +8746,7 @@ mod test {
 
         s.set_hop_limit(Some(0x2a));
         assert_eq!(
-            s.socket.dispatch(&mut s.cx, |_, (ip_repr, _)| {
+            s.socket.dispatch(&mut s.cx, |_, _, (ip_repr, _)| {
                 assert_eq!(ip_repr.hop_limit(), 0x2a);
                 Ok::<_, ()>(())
             }),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -7,7 +7,11 @@ use crate::wire::*;
 
 pub(crate) fn setup<'a>(medium: Medium) -> (Interface, SocketSet<'a>, TestingDevice) {
     let mut device = TestingDevice::new(medium);
+    let iface = setup_with_device(medium, &mut device);
+    (iface, SocketSet::new(vec![]), device)
+}
 
+fn setup_with_device(medium: Medium, device: &mut impl Device) -> Interface {
     let config = Config::new(match medium {
         #[cfg(feature = "medium-ethernet")]
         Medium::Ethernet => {
@@ -21,7 +25,7 @@ pub(crate) fn setup<'a>(medium: Medium) -> (Interface, SocketSet<'a>, TestingDev
         ])),
     });
 
-    let mut iface = Interface::new(config, &mut device, Instant::ZERO);
+    let mut iface = Interface::new(config, device, Instant::ZERO);
 
     #[cfg(feature = "proto-ipv4")]
     {
@@ -49,8 +53,7 @@ pub(crate) fn setup<'a>(medium: Medium) -> (Interface, SocketSet<'a>, TestingDev
                 .unwrap();
         });
     }
-
-    (iface, SocketSet::new(vec![]), device)
+    iface
 }
 
 /// A testing device.
@@ -143,5 +146,169 @@ impl<'a> phy::TxToken for TxToken<'a> {
         let result = f(&mut buffer);
         self.queue.push_back(buffer);
         result
+    }
+}
+
+#[cfg(feature = "segmentation-offload")]
+pub(crate) mod segmentation_offload {
+    use std::collections::VecDeque;
+
+    use crate::iface::*;
+    use crate::phy::{
+        self, Checksum, ChecksumCapabilities, Device, DeviceCapabilities, Medium, PacketMeta,
+        SegmentationCapabilities,
+    };
+    use crate::time::Instant;
+    use crate::wire::*;
+
+    use super::{RxToken, TestingDevice, setup_with_device};
+
+    // The value is chosen to allow dispatching unsegmented packets whose sizes
+    // exceed the length field in the IP header.
+    pub const MAX_SEGMENTABLE_SIZE: usize =
+        ETHERNET_HEADER_LEN + IPV6_HEADER_LEN + (u16::MAX as usize) + 1;
+
+    pub fn setup_segmenting<'a>(
+        medium: Medium,
+    ) -> (Interface, SocketSet<'a>, SegmentationOffloadTestingDevice) {
+        let mut device = SegmentationOffloadTestingDevice::new(TestingDevice::new(medium));
+        let iface = setup_with_device(medium, &mut device);
+        (iface, SocketSet::new(vec![]), device)
+    }
+
+    /// A segmentation offload testing device.
+    #[derive(Debug)]
+    pub struct SegmentationOffloadTestingDevice {
+        pub(crate) testing_device: TestingDevice,
+        pub(crate) checksum: ChecksumCapabilities,
+        pub(crate) segmentation: SegmentationCapabilities,
+    }
+
+    impl SegmentationOffloadTestingDevice {
+        pub(crate) fn new(testing_device: TestingDevice) -> Self {
+            Self {
+                testing_device,
+                checksum: ChecksumCapabilities {
+                    tcp: Checksum::Rx,
+                    ..Default::default()
+                },
+                segmentation: SegmentationCapabilities {
+                    tcpv4: Some(MAX_SEGMENTABLE_SIZE.try_into().unwrap()),
+                    tcpv6: Some(MAX_SEGMENTABLE_SIZE.try_into().unwrap()),
+                },
+            }
+        }
+    }
+
+    impl Device for SegmentationOffloadTestingDevice {
+        type RxToken<'a> = RxToken;
+        type TxToken<'a> = SegmentingTxToken<'a>;
+
+        fn receive(
+            &mut self,
+            timestamp: Instant,
+        ) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+            let (rx_token, _) = self.testing_device.receive(timestamp).unzip();
+            rx_token.map(|rx_token| {
+                (
+                    rx_token,
+                    SegmentingTxToken {
+                        medium: self.testing_device.medium,
+                        queue: &mut self.testing_device.tx_queue,
+                        meta: PacketMeta::default(),
+                    },
+                )
+            })
+        }
+
+        fn transmit(&mut self, _timestamp: Instant) -> Option<Self::TxToken<'_>> {
+            Some(SegmentingTxToken {
+                medium: self.testing_device.medium,
+                queue: &mut self.testing_device.tx_queue,
+                meta: PacketMeta::default(),
+            })
+        }
+
+        fn capabilities(&self) -> DeviceCapabilities {
+            DeviceCapabilities {
+                segmentation: self.segmentation.clone(),
+                checksum: self.checksum.clone(),
+                ..self.testing_device.capabilities()
+            }
+        }
+    }
+
+    #[doc(hidden)]
+    #[derive(Debug)]
+    pub struct SegmentingTxToken<'a> {
+        pub(crate) queue: &'a mut VecDeque<Vec<u8>>,
+        pub(crate) medium: Medium,
+        pub(crate) meta: PacketMeta,
+    }
+
+    impl<'a> phy::TxToken for SegmentingTxToken<'a> {
+        fn consume<R, F>(self, len: usize, f: F) -> R
+        where
+            F: FnOnce(&mut [u8]) -> R,
+        {
+            let mut buffer = vec![0; len];
+            let result = f(&mut buffer);
+
+            if let Some(segmentation_offload_size) = self
+                .meta
+                .segmentation_offload_size
+                .map(|size| size.get().into())
+            {
+                net_debug!("Segmenting testing device will not actually fill in checksums");
+                let ip_buffer = match self.medium {
+                    #[cfg(feature = "medium-ethernet")]
+                    Medium::Ethernet => EthernetFrame::new_checked(buffer.as_slice())
+                        .unwrap()
+                        .payload(),
+                    #[cfg(feature = "medium-ip")]
+                    Medium::Ip => buffer.as_slice(),
+                    #[cfg(feature = "medium-ieee802154")]
+                    Medium::Ieee802154 => todo!(),
+                };
+                let (next_header, transport_buffer) = match IpVersion::of_packet(ip_buffer).unwrap()
+                {
+                    #[cfg(feature = "proto-ipv4")]
+                    IpVersion::Ipv4 => {
+                        let packet = Ipv4Packet::new_checked(ip_buffer).unwrap();
+                        (packet.next_header(), packet.payload())
+                    }
+                    #[cfg(feature = "proto-ipv6")]
+                    IpVersion::Ipv6 => {
+                        let packet = Ipv6Packet::new_checked(ip_buffer).unwrap();
+                        (packet.next_header(), packet.payload())
+                    }
+                };
+                assert_eq!(
+                    next_header,
+                    IpProtocol::Tcp,
+                    "segmentation offload requested for an unsupported protocol"
+                );
+                let transport_payload = TcpPacket::new_checked(transport_buffer).unwrap().payload();
+                let headers_size = buffer.element_offset(&transport_payload[0]).unwrap();
+                self.queue
+                    .extend(transport_buffer.chunks(segmentation_offload_size).map(
+                        |segment_payload| {
+                            let mut segment =
+                                Vec::with_capacity(headers_size + segmentation_offload_size);
+                            segment.extend_from_slice(&buffer[..headers_size]);
+                            segment.extend_from_slice(segment_payload);
+                            segment
+                        },
+                    ));
+            } else {
+                self.queue.push_back(buffer);
+            }
+
+            result
+        }
+
+        fn set_meta(&mut self, meta: PacketMeta) {
+            self.meta = meta
+        }
     }
 }

--- a/src/wire/ipv4.rs
+++ b/src/wire/ipv4.rs
@@ -590,7 +590,16 @@ impl Repr {
         packet.set_header_len(field::DST_ADDR.end as u8);
         packet.set_dscp(0);
         packet.set_ecn(0);
+        #[cfg(not(feature = "segmentation-offload"))]
         let total_len = packet.header_len() as u16 + self.payload_len as u16;
+        #[cfg(feature = "segmentation-offload")]
+        // If because of segmentation offload the length of the buffer exceeds what can be
+        // represented in the length field of the IP header, we fall back to 0. It will be
+        // filled by the device during segmentation anyways.
+        let total_len = u16::try_from(self.payload_len)
+            .ok()
+            .and_then(|payload_len: u16| payload_len.checked_add(packet.header_len() as u16))
+            .unwrap_or(0);
         packet.set_total_len(total_len);
         packet.set_ident(0);
         packet.clear_flags();

--- a/src/wire/ipv6.rs
+++ b/src/wire/ipv6.rs
@@ -631,7 +631,14 @@ impl Repr {
         packet.set_version(6);
         packet.set_traffic_class(0);
         packet.set_flow_label(0);
-        packet.set_payload_len(self.payload_len as u16);
+        #[cfg(not(feature = "segmentation-offload"))]
+        let payload_len = self.payload_len as u16;
+        #[cfg(feature = "segmentation-offload")]
+        // If because of segmentation offload the length of the buffer exceeds what can be
+        // represented in the length field of the IP header, we fall back to 0. It will be
+        // filled by the device during segmentation anyways.
+        let payload_len = u16::try_from(self.payload_len).unwrap_or(0);
+        packet.set_payload_len(payload_len);
         packet.set_hop_limit(self.hop_limit);
         packet.set_next_header(self.next_header);
         packet.set_src_addr(self.src_addr);


### PR DESCRIPTION
The Windows and Linux documentations for the same feature were used as references. It was more difficult to find information on how devices support the feature, so the interface is mostly based on how virtio-net devices expect to be driven. The code was [tested](https://github.com/hermit-os/kernel/pull/2308) on the Hermit kernel with a virtio-net device, but only with IPv4, as Hermit does not support IPv6.

## Design rationale
- The segmentation capabilities are specified separately for TCP on IPv4 and IPv6. This follows the example of [Linux](https://docs.kernel.org/networking/netdev-features.html#:~:text=TCPv4%20%28when%20NETIF%5FF%5FTSO%20is%20enabled%29%20or%20TCPv6%20%28NETIF%5FF%5FTSO6%29%2E) and [Windows](https://learn.microsoft.com/en-us/windows-hardware/drivers/network/offloading-the-segmentation-of-large-tcp-packets#:~:text=Support%20IPv4%20or%20IPv6%2C%20or%20both%20IPv4%20and%20IPv6.). This should provide flexibility for devices that support only one of the IP versions and should not be a problem for devices that support both as a single feature.
- As it is necessary to communicate to the device what the target segment size is, a field is added to [PacketMeta](https://docs.rs/smoltcp/latest/smoltcp/phy/struct.PacketMeta.html). To keep the compiler able to optimise out the structure if the features associated with the fields, the segmentation offload feature is optional, following the example of  [`packetmeta-id`](https://docs.rs/smoltcp/latest/smoltcp/phy/struct.PacketMeta.html#:~:text=If%20no%20field%20is%20enabled%2C%20this%20struct%20becomes%20zero%2Dsized%2C%20which%20allows%20the%20compiler%20to%20optimize%20it%20out%20as%20if%20the%20packet%20metadata%20mechanism%20didn%E2%80%99t%20exist%20at%20all.).
- For pre-segmentation IP packets whose size exceeds the maximum that is allowed by the length field of the IP header, we fall back to zero. An alternative would be to set the field to zero unconditionally, and this [seems](https://www.intel.com/content/dam/doc/manual/pci-pci-x-family-gbe-controllers-software-dev-manual.pdf#page=73) to be a "should" level expectation for at least for some Intel cards. The fallback approach has the advantage of keeping code that uses the IP header field (for example for [constructing `TcpPacket`s](https://docs.rs/smoltcp/latest/smoltcp/wire/struct.TcpPacket.html#method.new_checked) to set the partial checksum in our case) functional for sufficiently small unsegmented packets. On the other hand, it can also be argued that causing a failure even for smaller packets can help uncover the error case with the larger packets earlier in the development of the device drivers.

## Comparison to  #830
- The segmentation capabilities struct in the older PR follows the structure of [`ChecksumCapabilities`](https://docs.rs/smoltcp/latest/smoltcp/phy/struct.ChecksumCapabilities.html). This PR does not do so for the following reasons:
  - The segmentation capability for a given protocol is not binary. Different devices may support large (i.e. unsegmented) packets of different maximum sizes ([references for various devices](https://github.com/hermit-os/kernel/issues/1861#:~:text=Different,10%5D%2E))
  - On the receive side the related feature seems to be called "coalescing." It may be somewhat confusing to represent information for the receive side in a structure whose name refers to "segmentation."
- The capability structure is named `SegmentationCapabilities` rather than the TCP specific name `TsoCapabilities`. I believe the current structure can be expanded to support UDP, though I currently do not have a prototype for that.
- The current PR has support for communicating the target segment size to the device.
- This PR is missing an equivalent to [this line](https://github.com/smoltcp-rs/smoltcp/pull/830/changes#diff-9797218dceaf8c0bdfeddfab917f17b8d1028fd1e817a5b3de18bc4814fd894eR1742). The addition of the `set_meta` calls seems correct to me but because it is not segmentation offload specific and I was not able to test its necessity because of the lack of IPv6 support on our test platform, I did not include it in this PR.