### PR TITLE
Congestion Control Overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 No unreleased changes yet. Please send PRs!
 
+## [0.13.1] - 2026-05-01
+
+- tcp: Fix panic when a listening socket receives a SYN from the unspecified addr.
+- tcp: fix SACK sequence number overflow, which could cause a panic when compiling with overflow checks enabled.
+- ipv4: Check IPv4 IHL to be at least 20 bytes.
+
 ## [0.13.0] - 2026-03-20
 
 Highlights of this release are IPv6 SLAAC support, TCP improvements (zero window probes, retransmit fixes, RFC compliance), raw socket enhancements, and a bump to Rust Edition 2024.
@@ -380,7 +386,8 @@ only processed when directed to the 255.255.255.255 address. ([377](https://gith
 - Use #[non_exhaustive] for enums and structs ([409](https://github.com/smoltcp-rs/smoltcp/pull/409), [411](https://github.com/smoltcp-rs/smoltcp/pull/411))
 - Simplify lifetime parameters of sockets, SocketSet, EthernetInterface ([410](https://github.com/smoltcp-rs/smoltcp/pull/410), [413](https://github.com/smoltcp-rs/smoltcp/pull/413))
 
-[Unreleased]: https://github.com/smoltcp-rs/smoltcp/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/smoltcp-rs/smoltcp/compare/v0.13.1...HEAD
+[0.13.1]: https://github.com/smoltcp-rs/smoltcp/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/smoltcp-rs/smoltcp/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/smoltcp-rs/smoltcp/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/smoltcp-rs/smoltcp/compare/v0.10.0...v0.11.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoltcp"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 rust-version = "1.91"
 authors = ["whitequark <whitequark@whitequark.org>"]

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1377,6 +1377,17 @@ impl<'a> Socket<'a> {
         self.tx_buffer.len()
     }
 
+    /// Return the number of octets sent but not yet acknowledged, includes unacknowledged SYN or FIN.
+    fn bytes_in_flight(&self) -> usize {
+        let control_len = match self.state {
+            State::SynSent | State::SynReceived => 1,
+            State::FinWait1 | State::LastAck | State::Closing => 1,
+            _ => 0,
+        };
+
+        self.tx_buffer.len() + control_len
+    }
+
     /// Return the amount of octets queued in the receive buffer. This value can be larger than
     /// the slice read by the next `recv` or `peek` call because it includes all queued octets,
     /// and not only the octets that may be returned as a contiguous slice.
@@ -1572,7 +1583,6 @@ impl<'a> Socket<'a> {
             // all of the control flags we sent.
             _ => (false, false),
         };
-        let control_len = (sent_syn as usize) + (sent_fin as usize);
 
         // Reject unacceptable acknowledgements.
         match (self.state, repr.control, repr.ack_number) {
@@ -1642,7 +1652,7 @@ impl<'a> Socket<'a> {
             }
             // Every acknowledgement must be for transmitted but unacknowledged data.
             (_, _, Some(ack_number)) => {
-                let unacknowledged = self.tx_buffer.len() + control_len;
+                let unacknowledged = self.bytes_in_flight();
 
                 // Acceptable ACK range (both inclusive)
                 let mut ack_min = self.local_seq_no;
@@ -1794,9 +1804,11 @@ impl<'a> Socket<'a> {
             }
 
             self.rtte.on_ack(cx.now(), ack_number);
+
+            let in_flight = self.bytes_in_flight().saturating_sub(ack_len);
             self.congestion_controller
                 .inner_mut()
-                .on_ack(cx.now(), ack_len, &self.rtte);
+                .on_ack(cx.now(), ack_len, in_flight, &self.rtte);
         }
 
         // Disregard control flags we don't care about or shouldn't act on yet.
@@ -2050,10 +2062,12 @@ impl<'a> Socket<'a> {
                     // Increment duplicate ACK count
                     self.local_rx_dup_acks = self.local_rx_dup_acks.saturating_add(1);
 
-                    // Inform congestion controller of duplicate ACK
-                    self.congestion_controller
-                        .inner_mut()
-                        .on_duplicate_ack(cx.now());
+                    let in_flight = self.bytes_in_flight();
+                    self.congestion_controller.inner_mut().on_dup_ack(
+                        cx.now(),
+                        self.remote_mss,
+                        in_flight,
+                    );
 
                     net_debug!(
                         "received duplicate ACK for seq {} (duplicate nr {}{})",
@@ -2399,6 +2413,23 @@ impl<'a> Socket<'a> {
             // to be sent again.
             self.remote_last_seq = self.local_seq_no;
 
+            // Report the correct congestion event
+            if let Timer::Retransmit { .. } = self.timer {
+                // Inform the congestion controller that we're retransmitting.
+                // and should enter the slow start state
+                let in_flight = self.bytes_in_flight();
+                self.congestion_controller
+                    .inner_mut()
+                    .on_rto(cx.now(), in_flight);
+            } else {
+                // Inform the congestion controller that we're doing a fast retransmit
+                // and should enter the fast recovery state
+                let in_flight = self.bytes_in_flight();
+                self.congestion_controller
+                    .inner_mut()
+                    .on_loss(cx.now(), in_flight);
+            }
+
             // Clear the `should_retransmit` state. If we can't retransmit right
             // now for whatever reason (like zero window), this avoids an
             // infinite polling loop where `poll_at` returns `Now` but `dispatch`
@@ -2407,11 +2438,6 @@ impl<'a> Socket<'a> {
 
             // Inform RTTE, so that it can avoid bogus measurements.
             self.rtte.on_retransmit();
-
-            // Inform the congestion controller that we're retransmitting.
-            self.congestion_controller
-                .inner_mut()
-                .on_retransmit(cx.now());
         }
 
         #[cfg(feature = "socket-tcp-pause-synack")]

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -517,6 +517,8 @@ pub struct Socket<'a> {
     /// The number of packets received directly after
     /// each other which have the same ACK number.
     local_rx_dup_acks: u8,
+    /// If a fast retransmit needs to occur
+    pending_fast_retransmit: bool,
 
     /// Duration for Delayed ACK. If None no ACKs will be delayed.
     ack_delay: Option<Duration>,
@@ -598,6 +600,7 @@ impl<'a> Socket<'a> {
             local_rx_last_ack: None,
             local_rx_last_seq: None,
             local_rx_dup_acks: 0,
+            pending_fast_retransmit: false,
             ack_delay: Some(ACK_DELAY_DEFAULT),
             ack_delay_timer: AckDelayTimer::Idle,
             challenge_ack_timer: Instant::from_secs(0),
@@ -1377,6 +1380,19 @@ impl<'a> Socket<'a> {
         self.tx_buffer.len()
     }
 
+    /// Number of octets transmitted but not yet ACKed.
+    fn flight_size(&self) -> usize {
+        self.remote_last_seq - self.local_seq_no
+    }
+
+    /// Remaining room in the congestion window: `cwnd - FlightSize`.
+    fn cwnd_remaining(&self) -> usize {
+        self.congestion_controller
+            .inner()
+            .window()
+            .saturating_sub(self.flight_size())
+    }
+
     /// Return the amount of octets queued in the receive buffer. This value can be larger than
     /// the slice read by the next `recv` or `peek` call because it includes all queued octets,
     /// and not only the octets that may be returned as a contiguous slice.
@@ -1794,9 +1810,14 @@ impl<'a> Socket<'a> {
             }
 
             self.rtte.on_ack(cx.now(), ack_number);
-            self.congestion_controller
-                .inner_mut()
-                .on_ack(cx.now(), ack_len, &self.rtte);
+
+            let new_flight_size = self.flight_size().saturating_sub(ack_len);
+            self.congestion_controller.inner_mut().on_ack(
+                cx.now(),
+                ack_len,
+                new_flight_size,
+                &self.rtte,
+            );
         }
 
         // Disregard control flags we don't care about or shouldn't act on yet.
@@ -2050,10 +2071,12 @@ impl<'a> Socket<'a> {
                     // Increment duplicate ACK count
                     self.local_rx_dup_acks = self.local_rx_dup_acks.saturating_add(1);
 
-                    // Inform congestion controller of duplicate ACK
-                    self.congestion_controller
-                        .inner_mut()
-                        .on_duplicate_ack(cx.now());
+                    let in_flight = self.flight_size();
+                    self.congestion_controller.inner_mut().on_dup_ack(
+                        cx.now(),
+                        self.remote_mss,
+                        in_flight,
+                    );
 
                     net_debug!(
                         "received duplicate ACK for seq {} (duplicate nr {}{})",
@@ -2225,6 +2248,11 @@ impl<'a> Socket<'a> {
     }
 
     fn seq_to_transmit(&self, cx: &mut Context) -> bool {
+        // Fast retransmits should always send, even if later congestion checks would disallow
+        if self.pending_fast_retransmit && !self.tx_buffer.is_empty() {
+            return true;
+        }
+
         let ip_header_len = match self.tuple.unwrap().local.addr {
             #[cfg(feature = "proto-ipv4")]
             IpAddress::Ipv4(_) => crate::wire::IPV4_HEADER_LEN,
@@ -2251,14 +2279,14 @@ impl<'a> Socket<'a> {
             self.local_seq_no + core::cmp::min(self.remote_win_len, self.tx_buffer.len());
 
         // Max amount of octets we can send.
-        let max_send = if max_send_seq >= self.remote_last_seq {
+        let capped_send_seq = if max_send_seq >= self.remote_last_seq {
             max_send_seq - self.remote_last_seq
         } else {
             0
         };
 
-        // Compare max_send with the congestion window.
-        let max_send = max_send.min(self.congestion_controller.inner().window());
+        // compare max bytes allowed by cwnd with max bytes allowed by remote
+        let max_send = capped_send_seq.min(self.cwnd_remaining());
 
         // Can we send at least 1 octet?
         let mut can_send = max_send != 0;
@@ -2390,14 +2418,34 @@ impl<'a> Socket<'a> {
             // If a timeout expires, we should abort the connection.
             net_debug!("timeout exceeded");
             self.set_state(State::Closed);
-        } else if !self.seq_to_transmit(cx) && self.timer.should_retransmit(cx.now()) {
-            // If a retransmit timer expired, we should resend data starting at the last ACK.
-            net_debug!("retransmitting");
+        } else if self.timer.should_retransmit(cx.now()) {
+            if let Timer::Retransmit { .. } = self.timer {
+                // If a retransmit timer expired, we should resend data starting at the last ACK.
+                net_debug!("retransmitting after rto");
 
-            // Rewind "last sequence number sent", as if we never
-            // had sent them. This will cause all data in the queue
-            // to be sent again.
-            self.remote_last_seq = self.local_seq_no;
+                // Inform the congestion controller that we're retransmitting and should enter the slow start state
+                let in_flight = self.flight_size();
+                self.congestion_controller
+                    .inner_mut()
+                    .on_rto(cx.now(), in_flight);
+
+                // Rewind "last sequence number sent", as if we never
+                // had sent them. This will cause all data in the queue
+                // to be sent again.
+                self.remote_last_seq = self.local_seq_no;
+            } else {
+                // If a fast rentrasmit timer expired, we should resend only the earliest unAcked segment
+                net_debug!("retranmitting for fast-retransmit");
+
+                // Inform the congestion controller that we're doing a fast retransmit and should enter the fast recovery state
+                let in_flight = self.flight_size();
+                self.congestion_controller
+                    .inner_mut()
+                    .on_loss(cx.now(), in_flight);
+
+                // Register that a fast retransmit needs to occur
+                self.pending_fast_retransmit = true;
+            }
 
             // Clear the `should_retransmit` state. If we can't retransmit right
             // now for whatever reason (like zero window), this avoids an
@@ -2407,11 +2455,6 @@ impl<'a> Socket<'a> {
 
             // Inform RTTE, so that it can avoid bogus measurements.
             self.rtte.on_retransmit();
-
-            // Inform the congestion controller that we're retransmitting.
-            self.congestion_controller
-                .inner_mut()
-                .on_retransmit(cx.now());
         }
 
         #[cfg(feature = "socket-tcp-pause-synack")]
@@ -2515,37 +2558,51 @@ impl<'a> Socket<'a> {
                 // Extract as much data as the remote side can receive in this packet
                 // from the transmit buffer.
 
-                // Right edge of window, ie the max sequence number we're allowed to send.
-                let win_right_edge = self.local_seq_no + self.remote_win_len;
-
-                // Max amount of octets we're allowed to send according to the remote window.
-                let mut win_limit = if win_right_edge >= self.remote_last_seq {
-                    win_right_edge - self.remote_last_seq
-                } else {
-                    // This can happen if we've sent some data and later the remote side
-                    // has shrunk its window so that data is no longer inside the window.
-                    // This should be very rare and is strongly discouraged by the RFCs,
-                    // but it does happen in practice.
-                    // http://www.tcpipguide.com/free/t_TCPWindowManagementIssues.htm
-                    0
-                };
-
-                // To send a zero-window-probe, force the window limit to at least 1 byte.
-                if win_limit == 0 && self.timer.should_zero_window_probe(cx.now()) {
-                    win_limit = 1;
-                    is_zero_window_probe = true;
-                }
-
-                // Maximum size we're allowed to send. This can be limited by 3 factors:
-                // 1. remote window
-                // 2. MSS the remote is willing to accept, probably determined by their MTU
-                // 3. MSS we can send, determined by our MTU.
-                let size = win_limit
-                    .min(self.remote_mss)
+                let effective_mss = self
+                    .remote_mss
                     .min(cx.ip_mtu() - ip_repr.header_len() - TCP_HEADER_LEN);
 
-                let offset = self.remote_last_seq - self.local_seq_no;
-                repr.payload = self.tx_buffer.get_allocated(offset, size);
+                let offset = if self.pending_fast_retransmit {
+                    let size = effective_mss.min(self.tx_buffer.len());
+                    repr.seq_number = self.local_seq_no;
+                    repr.payload = self.tx_buffer.get_allocated(0, size);
+
+                    self.pending_fast_retransmit = false;
+
+                    0
+                } else {
+                    // Right edge of window, ie the max sequence number we're allowed to send.
+                    let win_right_edge = self.local_seq_no + self.remote_win_len;
+
+                    // Max amount of octets we're allowed to send according to the remote window.
+                    let mut win_limit = if win_right_edge >= self.remote_last_seq {
+                        win_right_edge - self.remote_last_seq
+                    } else {
+                        // This can happen if we've sent some data and later the remote side
+                        // has shrunk its window so that data is no longer inside the window.
+                        // This should be very rare and is strongly discouraged by the RFCs,
+                        // but it does happen in practice.
+                        // http://www.tcpipguide.com/free/t_TCPWindowManagementIssues.htm
+                        0
+                    };
+
+                    // To send a zero-window-probe, force the window limit to at least 1 byte.
+                    if win_limit == 0 && self.timer.should_zero_window_probe(cx.now()) {
+                        win_limit = 1;
+                        is_zero_window_probe = true;
+                    }
+
+                    // Maximum size we're allowed to send. This can be limited by 4 factors:
+                    // 1. remote window
+                    // 2. congestion window
+                    // 3. MSS the remote is willing to accept, probably determined by their MTU
+                    // 4. MSS we can send, determined by our MTU.
+                    let size = win_limit.min(effective_mss).min(self.cwnd_remaining());
+
+                    let offset = self.flight_size();
+                    repr.payload = self.tx_buffer.get_allocated(offset, size);
+                    offset
+                };
 
                 // If we've sent everything we had in the buffer, follow it with the PSH or FIN
                 // flags, depending on whether the transmit half of the connection is open.
@@ -2586,7 +2643,7 @@ impl<'a> Socket<'a> {
             tcp_trace!(
                 "tx buffer: sending {} octets at offset {}",
                 repr.payload.len(),
-                self.remote_last_seq - self.local_seq_no
+                self.flight_size()
             );
         }
         if repr.control != TcpControl::None || repr.payload.is_empty() {
@@ -2647,7 +2704,11 @@ impl<'a> Socket<'a> {
         }
 
         // We've sent a packet successfully, so we can update the internal state now.
-        self.remote_last_seq = repr.seq_number + repr.segment_len();
+        // Use max() so a fast-retransmit segment (whose seq_number is local_seq_no, well
+        // behind the current frontier) doesn't rewind the tracked "highest sent" sequence.
+        self.remote_last_seq = self
+            .remote_last_seq
+            .max(repr.seq_number + repr.segment_len());
         self.remote_last_ack = repr.ack_number;
         self.remote_last_win = repr.window_len;
 
@@ -6289,7 +6350,7 @@ mod test {
     #[test]
     fn test_fast_retransmit_after_triple_duplicate_ack() {
         let mut s = socket_established();
-        s.remote_mss = 6;
+        s.remote_mss = 3;
 
         // Normal ACK of previously received segment
         send!(s, time 0, TcpRepr {
@@ -6300,91 +6361,79 @@ mod test {
 
         // Send a long string of text divided into several packets
         // because of previously received "window_len"
-        s.send_slice(b"xxxxxxyyyyyywwwwwwzzzzzz").unwrap();
+        s.send_slice(b"aaaBBBcccDDDeeeFFF").unwrap();
+
         // This packet is lost
         recv!(s, time 1000, Ok(TcpRepr {
             seq_number: LOCAL_SEQ + 1,
             ack_number: Some(REMOTE_SEQ + 1),
-            payload:    &b"xxxxxx"[..],
-            ..RECV_TEMPL
-        }));
-        recv!(s, time 1005, Ok(TcpRepr {
-            seq_number: LOCAL_SEQ + 1 + 6,
-            ack_number: Some(REMOTE_SEQ + 1),
-            payload:    &b"yyyyyy"[..],
-            ..RECV_TEMPL
-        }));
-        recv!(s, time 1010, Ok(TcpRepr {
-            seq_number: LOCAL_SEQ + 1 + (6 * 2),
-            ack_number: Some(REMOTE_SEQ + 1),
-            payload:    &b"wwwwww"[..],
-            ..RECV_TEMPL
-        }));
-        recv!(s, time 1015, Ok(TcpRepr {
-            seq_number: LOCAL_SEQ + 1 + (6 * 3),
-            ack_number: Some(REMOTE_SEQ + 1),
-            payload:    &b"zzzzzz"[..],
+            payload:    &b"aaa"[..],
             ..RECV_TEMPL
         }));
 
-        // First duplicate ACK
+        // These packets arrive
+        recv!(s, time 1005, Ok(TcpRepr {
+            seq_number: LOCAL_SEQ + 1 + 3,
+            ack_number: Some(REMOTE_SEQ + 1),
+            payload:    &b"BBB"[..],
+            ..RECV_TEMPL
+        }));
+        recv!(s, time 1010, Ok(TcpRepr {
+            seq_number: LOCAL_SEQ + 1 + (3 * 2),
+            ack_number: Some(REMOTE_SEQ + 1),
+            payload:    &b"ccc"[..],
+            ..RECV_TEMPL
+        }));
+        recv!(s, time 1015, Ok(TcpRepr {
+            seq_number: LOCAL_SEQ + 1 + (3 * 3),
+            ack_number: Some(REMOTE_SEQ + 1),
+            payload:    &b"DDD"[..],
+            ..RECV_TEMPL
+        }));
+
+        // Duplicate ACKs trigger fast rentramsit after 3rd successive one
         send!(s, time 1050, TcpRepr {
             seq_number: REMOTE_SEQ + 1,
             ack_number: Some(LOCAL_SEQ + 1),
             ..SEND_TEMPL
         });
-        // Second duplicate ACK
         send!(s, time 1055, TcpRepr {
             seq_number: REMOTE_SEQ + 1,
             ack_number: Some(LOCAL_SEQ + 1),
             ..SEND_TEMPL
         });
-        // Third duplicate ACK
-        // Should trigger a fast retransmit of dropped packet
         send!(s, time 1060, TcpRepr {
             seq_number: REMOTE_SEQ + 1,
             ack_number: Some(LOCAL_SEQ + 1),
             ..SEND_TEMPL
         });
 
-        // Fast retransmit packet
+        // Fast retransmit should have triggered
         recv!(s, time 1100, Ok(TcpRepr {
             seq_number: LOCAL_SEQ + 1,
             ack_number: Some(REMOTE_SEQ + 1),
-            payload:    &b"xxxxxx"[..],
+            payload:    &b"aaa"[..],
             ..RECV_TEMPL
         }));
 
+        // Transmission should continue as normal after re-transitting the first segment
         recv!(s, time 1105, Ok(TcpRepr {
-            seq_number: LOCAL_SEQ + 1 + 6,
+            seq_number: LOCAL_SEQ + 1 + (3 * 4),
             ack_number: Some(REMOTE_SEQ + 1),
-            payload:    &b"yyyyyy"[..],
+            payload:    &b"eee"[..],
             ..RECV_TEMPL
         }));
         recv!(s, time 1110, Ok(TcpRepr {
-            seq_number: LOCAL_SEQ + 1 + (6 * 2),
+            seq_number: LOCAL_SEQ + 1 + (3 * 5),
             ack_number: Some(REMOTE_SEQ + 1),
-            payload:    &b"wwwwww"[..],
+            payload:    &b"FFF"[..],
             ..RECV_TEMPL
         }));
-        recv!(s, time 1115, Ok(TcpRepr {
-            seq_number: LOCAL_SEQ + 1 + (6 * 3),
-            ack_number: Some(REMOTE_SEQ + 1),
-            payload:    &b"zzzzzz"[..],
-            ..RECV_TEMPL
-        }));
-
-        // After all was send out, enter *normal* retransmission,
-        // don't stay in fast retransmission.
-        assert!(match s.timer {
-            Timer::Retransmit { expires_at, .. } => expires_at > Instant::from_millis(1115),
-            _ => false,
-        });
 
         // ACK all received segments
         send!(s, time 1120, TcpRepr {
             seq_number: REMOTE_SEQ + 1,
-            ack_number: Some(LOCAL_SEQ + 1 + (6 * 4)),
+            ack_number: Some(LOCAL_SEQ + 1 + (3 * 5)),
             ..SEND_TEMPL
         });
     }

--- a/src/socket/tcp/congestion.rs
+++ b/src/socket/tcp/congestion.rs
@@ -18,11 +18,16 @@ pub(super) trait Controller {
     /// Set the remote window size.
     fn set_remote_window(&mut self, remote_window: usize) {}
 
-    fn on_ack(&mut self, now: Instant, len: usize, rtt: &RttEstimator) {}
+    fn on_ack(&mut self, now: Instant, len: usize, in_flight: usize, rtt: &RttEstimator) {}
 
-    fn on_retransmit(&mut self, now: Instant) {}
+    /// Fired on each duplicate ack received, after `on_loss` has been called.
+    fn on_dup_ack(&mut self, now: Instant, len: usize, in_flight: usize) {}
 
-    fn on_duplicate_ack(&mut self, now: Instant) {}
+    /// Fired on a Retransmission Timeout.
+    fn on_rto(&mut self, now: Instant, in_flight: usize) {}
+
+    /// Fired after an inferred loss via three duplicate acks.
+    fn on_loss(&mut self, now: Instant, in_flight: usize) {}
 
     fn pre_transmit(&mut self, now: Instant) {}
 

--- a/src/socket/tcp/congestion/reno.rs
+++ b/src/socket/tcp/congestion/reno.rs
@@ -9,6 +9,7 @@ pub struct Reno {
     min_cwnd: usize,
     ssthresh: usize,
     rwnd: usize,
+    recovery_start: Option<Instant>,
 }
 
 impl Reno {
@@ -18,6 +19,7 @@ impl Reno {
             min_cwnd: 1024 * 2,
             ssthresh: usize::MAX,
             rwnd: 64 * 1024,
+            recovery_start: None,
         }
     }
 }
@@ -27,28 +29,58 @@ impl Controller for Reno {
         self.cwnd
     }
 
-    fn on_ack(&mut self, _now: Instant, len: usize, _rtt: &RttEstimator) {
-        let len = if self.cwnd < self.ssthresh {
-            // Slow start.
-            len
+    fn on_ack(&mut self, _now: Instant, len: usize, _in_flight: usize, _rtt: &RttEstimator) {
+        // First new-data-ack exits fast recovery and deflates `cwnd`
+        if self.recovery_start.is_some() {
+            self.recovery_start = None;
+            self.cwnd = self.ssthresh;
+            return;
+        }
+
+        let inc = if self.cwnd < self.ssthresh {
+            // Slow start: increase `cwnd` by 1 MSS per ACK.
+            len.min(self.min_cwnd)
         } else {
-            self.ssthresh = self.cwnd;
-            self.min_cwnd
+            // Congestion avoidance: increase by ~1 MSS per RTT.
+            (self.min_cwnd * self.min_cwnd / self.cwnd).max(1)
         };
 
         self.cwnd = self
             .cwnd
-            .saturating_add(len)
+            .saturating_add(inc)
             .min(self.rwnd)
             .max(self.min_cwnd);
     }
 
-    fn on_duplicate_ack(&mut self, _now: Instant) {
-        self.ssthresh = (self.cwnd >> 1).max(self.min_cwnd);
+    fn on_dup_ack(&mut self, _now: Instant, len: usize, _in_flight: usize) {
+        if self.recovery_start.is_some() {
+            self.cwnd = self
+                .cwnd
+                .saturating_add(len)
+                .min(self.rwnd)
+                .max(self.min_cwnd);
+        }
     }
 
-    fn on_retransmit(&mut self, _now: Instant) {
-        self.cwnd = (self.cwnd >> 1).max(self.min_cwnd);
+    fn on_loss(&mut self, now: Instant, in_flight: usize) {
+        // Only cut window size on first entrance to fast recovery.
+        if self.recovery_start.is_none() {
+            self.ssthresh = (in_flight >> 1).max(2 * self.min_cwnd);
+            self.cwnd = self
+                .ssthresh
+                .saturating_add(3 * self.min_cwnd)
+                .min(self.rwnd);
+
+            self.recovery_start = Some(now);
+        }
+    }
+
+    fn on_rto(&mut self, _now: Instant, in_flight: usize) {
+        self.ssthresh = (in_flight >> 1).max(2 * self.min_cwnd);
+        self.cwnd = self.min_cwnd;
+
+        // Major loss has occurred, ensure we move from fast recovery (if in it) to slow start.
+        self.recovery_start = None
     }
 
     fn set_mss(&mut self, mss: usize) {
@@ -81,7 +113,7 @@ mod test {
                 // Set remote window.
                 reno.set_remote_window(remote_window);
 
-                reno.on_ack(now, 4096, &RttEstimator::default());
+                reno.on_ack(now, 4096, reno.window(), &RttEstimator::default());
 
                 let mut n = i;
                 for _ in 0..j {
@@ -89,13 +121,13 @@ mod test {
                 }
 
                 if i & 1 == 0 {
-                    reno.on_retransmit(now);
+                    reno.on_rto(now, reno.window());
                 } else {
-                    reno.on_duplicate_ack(now);
+                    reno.on_loss(now, reno.window());
                 }
 
                 let elapsed = Instant::from_millis(1000);
-                reno.on_ack(elapsed, n, &RttEstimator::default());
+                reno.on_ack(elapsed, n, reno.window(), &RttEstimator::default());
 
                 let cwnd = reno.window();
                 println!("Reno: elapsed = {}, cwnd = {}", elapsed, cwnd);
@@ -115,7 +147,7 @@ mod test {
         reno.set_remote_window(remote_window);
 
         for _ in 0..100 {
-            reno.on_retransmit(now);
+            reno.on_rto(now, reno.window());
             assert!(reno.window() >= reno.min_cwnd);
         }
     }

--- a/src/socket/tcp/congestion/reno.rs
+++ b/src/socket/tcp/congestion/reno.rs
@@ -102,6 +102,221 @@ mod test {
 
     use super::*;
 
+    const MSS: usize = 1024;
+
+    fn ack(reno: &mut Reno, len: usize, now: Instant) {
+        reno.on_ack(now, len, reno.window().saturating_sub(MSS), &rtte())
+    }
+
+    fn rtte() -> RttEstimator {
+        RttEstimator::default()
+    }
+
+    #[test]
+    fn congestion_avoidance_works() {
+        let mut reno = Reno::new();
+        reno.set_mss(MSS);
+        reno.cwnd = MSS * 32;
+        reno.ssthresh = MSS * 16;
+
+        // CA should grow at less than 1 MSS per ACK.
+        for i in 0..10 {
+            let initial_cwnd = reno.window();
+            ack(&mut reno, MSS, Instant::from_millis(i));
+            assert!(reno.window() < initial_cwnd + MSS);
+        }
+
+        // CA should cap at the receive window
+        reno.cwnd = reno.rwnd - 1;
+        ack(&mut reno, MSS, Instant::from_millis(20));
+        assert_eq!(reno.window(), reno.rwnd);
+    }
+
+    #[test]
+    fn fast_recovery_works() {
+        let mut reno = Reno::new();
+        reno.set_mss(MSS);
+        reno.cwnd = MSS * 32;
+
+        // duplicate ACKs before fast recovery should do nothing
+        let initial_cwnd = reno.window();
+        for _ in 0..3 {
+            reno.on_dup_ack(Instant::from_millis(0), MSS, initial_cwnd);
+        }
+        assert_eq!(reno.window(), initial_cwnd);
+
+        // we enter fast recovery upon minor loss (three duplicate ACKs)
+        // window should become half the in-flight bytes
+        // sstresh should be the reduced cwnd, advanced by MSS for the 3 dup ACKs
+        let inflight = initial_cwnd / 2;
+        reno.on_loss(Instant::from_millis(0), inflight);
+        assert_eq!(reno.ssthresh, inflight / 2);
+        assert_eq!(reno.cwnd, inflight / 2 + 3 * MSS);
+
+        // in fast recovery, each dup-ACK should increase  the cwnd by 1 MSS
+        let initial_cwnd = reno.window();
+        for i in 0..3 {
+            for _ in 0..3 {
+                let initial_cwnd = reno.window();
+                reno.on_dup_ack(Instant::from_millis(i), MSS, initial_cwnd);
+                assert_eq!(reno.window(), initial_cwnd + MSS);
+            }
+
+            // multiple loss events (trip-dup-ack) should not trigger additional fast recovery reductions
+            let initial_cwnd = reno.window();
+            let initial_ssthresh = reno.ssthresh;
+            reno.on_loss(Instant::from_millis(i), initial_cwnd);
+            assert_eq!(reno.window(), initial_cwnd);
+            assert_eq!(reno.ssthresh, initial_ssthresh);
+        }
+        assert_eq!(reno.window(), initial_cwnd + MSS * 9);
+
+        // a non-duplicate ACK exits fast recovery and enters congestion avoidance
+        ack(&mut reno, MSS, Instant::from_millis(10));
+        assert_eq!(reno.window(), reno.ssthresh);
+
+        // CA is slower growth so should be less than 1MSS per ACK
+        let initial_cwnd = reno.window();
+        ack(&mut reno, MSS, Instant::from_millis(30));
+        assert!(reno.window() < initial_cwnd + MSS);
+    }
+
+    #[test]
+    fn slow_start_works() {
+        let mut reno = Reno::new();
+        reno.set_mss(MSS);
+        reno.cwnd = MSS * 32;
+        reno.ssthresh = MSS * 16;
+
+        // we enter recovery upon major loss (an RTO)
+        // window should become to 1MSS
+        // sstresh should become half the in-flight bytes
+        let initial_cwnd = reno.window();
+        let inflight = initial_cwnd;
+        reno.on_rto(Instant::from_millis(0), initial_cwnd);
+        assert_eq!(reno.ssthresh, inflight / 2);
+        assert_eq!(reno.window(), MSS);
+
+        // slow start grows by at most the MSS per ack
+        let initial_cwnd = reno.window();
+        for i in 0..10 {
+            let initial_cwnd = reno.window();
+            let now = Instant::from_millis(i);
+            ack(&mut reno, MSS * 2, now);
+            assert_eq!(reno.window(), initial_cwnd + MSS);
+        }
+        assert_eq!(reno.window(), initial_cwnd + MSS * 10);
+
+        // slow start uses the number of ACKed bytes if they're less than the MSS
+        let initial_cwnd = reno.window();
+        for i in 0..10 {
+            let initial_cwnd = reno.window();
+            let now = Instant::from_millis(10 + i);
+            ack(&mut reno, MSS / 2, now);
+            assert_eq!(reno.window(), initial_cwnd + MSS / 2);
+        }
+        assert_eq!(reno.window(), initial_cwnd + MSS / 2 * 10);
+
+        // slow start transitions to congestion avoidance at ssthresh
+        let initial_cwnd = reno.window();
+        reno.ssthresh = initial_cwnd + MSS;
+        ack(&mut reno, MSS, Instant::from_millis(30));
+        assert_eq!(reno.window(), initial_cwnd + MSS);
+        assert_eq!(reno.ssthresh, initial_cwnd + MSS);
+
+        // slow start transitions to congestion avoidance at ssthresh
+        // CA is slower growth so should be less than 1MSS per ACK
+        let initial_cwnd = reno.window();
+        ack(&mut reno, MSS, Instant::from_millis(30));
+        assert!(reno.window() < initial_cwnd + MSS);
+    }
+
+    #[test]
+    fn progress_to_ca_via_rto() {
+        let mut reno = Reno::new();
+        reno.set_mss(MSS);
+
+        let mut time = 0;
+
+        // slow start from default state
+        let initial_cwnd = reno.window();
+        for _ in 0..30 {
+            time += 1;
+            ack(&mut reno, MSS, Instant::from_millis(time));
+        }
+        assert_eq!(reno.window(), initial_cwnd + MSS * 30);
+        assert!(reno.window() < reno.ssthresh);
+
+        // rto: cwnd resets to MSS, ssthresh becomes half in-flight bytes
+        let rto_cwnd = reno.window();
+        reno.on_rto(Instant::from_millis(time), rto_cwnd);
+        assert_eq!(reno.window(), MSS);
+        assert_eq!(reno.ssthresh, rto_cwnd / 2);
+
+        // slow start again until cwnd reaches new ssthresh
+        while reno.window() < reno.ssthresh {
+            time += 1;
+            let initial_cwnd = reno.window();
+            ack(&mut reno, MSS, Instant::from_millis(time));
+            assert_eq!(reno.window(), initial_cwnd + MSS);
+        }
+        assert_eq!(reno.window(), reno.ssthresh);
+
+        // ca: each ack at or above ssthresh grows by less than MSS
+        time += 1;
+        let initial_cwnd = reno.window();
+        ack(&mut reno, MSS, Instant::from_millis(time));
+        assert!(reno.window() > initial_cwnd);
+        assert!(reno.window() < initial_cwnd + MSS);
+    }
+
+    #[test]
+    fn progress_to_ca_via_loss() {
+        let mut reno = Reno::new();
+        reno.set_mss(MSS);
+
+        let mut time = 0;
+
+        // slow start from default state
+        let initial_cwnd = reno.window();
+        for _ in 0..30 {
+            time += 1;
+            ack(&mut reno, MSS, Instant::from_millis(time));
+        }
+        assert_eq!(reno.window(), initial_cwnd + MSS * 30);
+        assert!(reno.window() < reno.ssthresh);
+
+        // dup ACKs: cwnd and sstresh become half in-flight bytes AND cwnd gets advanced for each dup-ack it had received
+        time += 1;
+        let loss_cwnd = reno.window();
+        let expected_ssthresh = loss_cwnd / 2;
+        reno.on_loss(Instant::from_millis(time), loss_cwnd);
+        assert_eq!(reno.ssthresh, expected_ssthresh);
+        assert_eq!(reno.window(), expected_ssthresh + 3 * MSS);
+        assert_eq!(reno.recovery_start, Some(Instant::from_millis(time)));
+
+        // inflate cwnd until on each duplicate ACK
+        for _ in 0..9 {
+            time += 1;
+            let initial_cwnd = reno.window();
+            reno.on_dup_ack(Instant::from_millis(time), MSS, reno.cwnd);
+            assert_eq!(reno.window(), initial_cwnd + MSS);
+        }
+
+        // non-duplicate ACK deflates cwnd to ssthresh
+        time += 1;
+        ack(&mut reno, MSS, Instant::from_millis(time));
+        assert_eq!(reno.window(), expected_ssthresh);
+        assert_eq!(reno.recovery_start, None);
+
+        // ca: each ack at or above ssthresh grows by less than MSS
+        time += 1;
+        let initial_cwnd = reno.window();
+        ack(&mut reno, MSS, Instant::from_millis(time));
+        assert!(reno.window() > initial_cwnd);
+        assert!(reno.window() < initial_cwnd + MSS);
+    }
+
     #[test]
     fn test_reno() {
         let remote_window = 64 * 1024;

--- a/src/socket/tcp/congestion/reno.rs
+++ b/src/socket/tcp/congestion/reno.rs
@@ -2,6 +2,8 @@ use crate::{socket::tcp::RttEstimator, time::Instant};
 
 use super::Controller;
 
+const DEFAULT_MSS: usize = 1024;
+
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Reno {
@@ -9,15 +11,17 @@ pub struct Reno {
     min_cwnd: usize,
     ssthresh: usize,
     rwnd: usize,
+    recovery_start: Option<Instant>,
 }
 
 impl Reno {
     pub fn new() -> Self {
         Reno {
-            cwnd: 1024 * 2,
-            min_cwnd: 1024 * 2,
+            cwnd: DEFAULT_MSS * 2,
+            min_cwnd: DEFAULT_MSS * 2,
             ssthresh: usize::MAX,
-            rwnd: 64 * 1024,
+            rwnd: 64 * DEFAULT_MSS,
+            recovery_start: None,
         }
     }
 }
@@ -27,28 +31,58 @@ impl Controller for Reno {
         self.cwnd
     }
 
-    fn on_ack(&mut self, _now: Instant, len: usize, _rtt: &RttEstimator) {
-        let len = if self.cwnd < self.ssthresh {
-            // Slow start.
-            len
+    fn on_ack(&mut self, _now: Instant, len: usize, _in_flight: usize, _rtt: &RttEstimator) {
+        // First new-data-ack exits fast recovery and deflates `cwnd`
+        if self.recovery_start.is_some() {
+            self.recovery_start = None;
+            self.cwnd = self.ssthresh;
+            return;
+        }
+
+        let inc = if self.cwnd < self.ssthresh {
+            // Slow start: increase `cwnd` by 1 MSS per ACK.
+            len.min(self.min_cwnd)
         } else {
-            self.ssthresh = self.cwnd;
-            self.min_cwnd
+            // Congestion avoidance: increase by ~1 MSS per RTT.
+            (self.min_cwnd * self.min_cwnd / self.cwnd).max(1)
         };
 
         self.cwnd = self
             .cwnd
-            .saturating_add(len)
+            .saturating_add(inc)
             .min(self.rwnd)
             .max(self.min_cwnd);
     }
 
-    fn on_duplicate_ack(&mut self, _now: Instant) {
-        self.ssthresh = (self.cwnd >> 1).max(self.min_cwnd);
+    fn on_dup_ack(&mut self, _now: Instant, len: usize, _in_flight: usize) {
+        if self.recovery_start.is_some() {
+            self.cwnd = self
+                .cwnd
+                .saturating_add(len)
+                .min(self.rwnd)
+                .max(self.min_cwnd);
+        }
     }
 
-    fn on_retransmit(&mut self, _now: Instant) {
-        self.cwnd = (self.cwnd >> 1).max(self.min_cwnd);
+    fn on_loss(&mut self, now: Instant, in_flight: usize) {
+        // Only cut window size on first entrance to fast recovery.
+        if self.recovery_start.is_none() {
+            self.ssthresh = (in_flight >> 1).max(2 * self.min_cwnd);
+            self.cwnd = self
+                .ssthresh
+                .saturating_add(3 * self.min_cwnd)
+                .min(self.rwnd);
+
+            self.recovery_start = Some(now);
+        }
+    }
+
+    fn on_rto(&mut self, _now: Instant, in_flight: usize) {
+        self.ssthresh = (in_flight >> 1).max(2 * self.min_cwnd);
+        self.cwnd = self.min_cwnd;
+
+        // Major loss has occurred, ensure we move from fast recovery (if in it) to slow start.
+        self.recovery_start = None
     }
 
     fn set_mss(&mut self, mss: usize) {
@@ -81,7 +115,7 @@ mod test {
                 // Set remote window.
                 reno.set_remote_window(remote_window);
 
-                reno.on_ack(now, 4096, &RttEstimator::default());
+                reno.on_ack(now, 4096, reno.window(), &RttEstimator::default());
 
                 let mut n = i;
                 for _ in 0..j {
@@ -89,13 +123,13 @@ mod test {
                 }
 
                 if i & 1 == 0 {
-                    reno.on_retransmit(now);
+                    reno.on_rto(now, reno.window());
                 } else {
-                    reno.on_duplicate_ack(now);
+                    reno.on_loss(now, reno.window());
                 }
 
                 let elapsed = Instant::from_millis(1000);
-                reno.on_ack(elapsed, n, &RttEstimator::default());
+                reno.on_ack(elapsed, n, reno.window(), &RttEstimator::default());
 
                 let cwnd = reno.window();
                 println!("Reno: elapsed = {}, cwnd = {}", elapsed, cwnd);
@@ -115,7 +149,7 @@ mod test {
         reno.set_remote_window(remote_window);
 
         for _ in 0..100 {
-            reno.on_retransmit(now);
+            reno.on_rto(now, reno.window());
             assert!(reno.window() >= reno.min_cwnd);
         }
     }


### PR DESCRIPTION
Edited. Again.

> TL;DR: refactors Controller trait to distinguish RTO / 3-dup-ACK / per-dup-ACK events, fixes some Reno bugs and fixes some CUBIC bugs, with more fixes and tests to come.

This has turned into a much bigger thing than I thought.

In short, the congestion implementations have many bugs and I'm now trying to fix them. This comes in three parts. Changes to the `Controller`, changes to `Reno` and changes to `Cubic`.

### The Controller
The controller doesn't understand congestion events and this is a source of multiple bugs.

`Controller::retransmit` is used to notify of both an RTO and the fast retransmit timer, making it hard for the congestion control implementations to decide between entering slow start or entering fast recovery.

`Controller::on_duplicate_ack` is seemingly treated as notification of a single duplicated ACK (as the name suggests) in `socket/tcp.rs` but as a notification of congestion in the congestion control implementations.

In CUBIC, after 3 consecutive duplicate ACKs this means `w_max` could end up more than half what it should be (`0.3 * w_max` vs `0.7 * w_max`). In Reno, after 3 consecutive duplicate ACKs this means `ssthresh` could end up three times  smaller than  it should be (`cwnd / 6` vs `cwnd / 2`).

My fix here has been to distinguish between congestion events (RTO and repeated duplicate ACKs).

I've added `Controller::on_rto` and `Controller::on_loss`. These can be used by the congestion algorithms to decide between entering slow start and fast recovery.

I've also introduced the `bytes_in_flight` parameter to these methods to give the congestion controllers more information (NewReno would like it for example) and added `len` to `Controller::on_dup_ack` for when SACK and D-SACK come about (within a month given the time I've been allocated to all this).

### Reno
Beyond the bugs that came from the inability to distinguish between loss events and whatnot, there were a number of bugs in the Reno implementation. Here's some:

- Exiting fast recovery (receiving a non-duplicated ACK) should deflate the `cwnd` back to the `ssthresh` (as the `cwnd` is artificially inflated from all the duplicate ACKs we advanced it by). This implementation however had it the wrong way round and was setting `ssthresh` equal to the `cwnd`. This would have increased the chance of running into more packetloss.

- Doing fast recovery involves incrementing the `cwnd` for each duplicate ACK received. This implementation wasn't doing anything with duplicated ACKs.

- Not setting `cwnd` to the correct value after an RTO and entering slow start. 

### CUBIC
Beyond the bugs that came from the inability to distinguish between events, CUBIC had other bugs too. Here's some:

- Entering fast recovery on startup without any packet loss occurring, significantly reducing `cwnd` and growth rate for no reason.

### Next
Treating this as a scratchpad PR. Feedback appreciated. Once happy will break into three PRs. Controller changes, Reno changes, Cubic changes.
