### PR TITLE
Enqueue PacketBuffer metadata before closure call

### DIFF
--- a/src/storage/packet_buffer.rs
+++ b/src/storage/packet_buffer.rs
@@ -154,11 +154,14 @@ impl<'a, H> PacketBuffer<'a, H> {
             }
         }
 
+        let metadata_slot = self.metadata_ring.enqueue_one()?;
+
+        // Only call f once we know that we will succeed
         let (size, _) = self
             .payload_ring
             .enqueue_many_with(|data| (f(&mut data[..max_size]), ()));
 
-        *self.metadata_ring.enqueue_one()? = PacketMetadata::packet(size, header);
+        *metadata_slot = PacketMetadata::packet(size, header);
 
         Ok(size)
     }

--- a/src/storage/packet_buffer.rs
+++ b/src/storage/packet_buffer.rs
@@ -397,6 +397,30 @@ mod test {
     }
 
     #[test]
+    fn test_enqueue_fallible_full_metadata_fn_not_called() {
+        // Fill the metadata buffer except 1 byte and then make room at the start
+        let mut buffer = PacketBuffer::new(vec![PacketMetadata::EMPTY; 4], vec![0u8; 16]);
+
+        assert!(buffer.enqueue(12, ()).is_ok());
+        assert!(buffer.enqueue(1, ()).is_ok());
+        assert!(buffer.enqueue(1, ()).is_ok());
+        assert!(buffer.enqueue(1, ()).is_ok());
+        let dequeued_buf = buffer.dequeue().unwrap();
+        assert_eq!(dequeued_buf.1.len(), 12);
+
+        // At this point there is room at the start of the payload storage
+        // and 1 byte at the end of the payload storage
+        // but only one metadata slot.
+        assert!(
+            buffer
+                .enqueue_with_infallible(5, (), |_| {
+                    panic!("This enqueue should fail and this closure should not be called")
+                })
+                .is_err()
+        );
+    }
+
+    #[test]
     fn clear() {
         let mut buffer = buffer();
 


### PR DESCRIPTION
This is at least a small optimisation that avoids calling the closure to write the packet before we are sure that we can enqueue it.

I found it while debugging [this embassy issue](https://github.com/embassy-rs/embassy/issues/6143), as this change would avoid that issue. I think there's a chance that we could guarantee that `f` does not get called until we are sure that `enqueue_with_infallible` will succeed. In that case I should also document that and add a test.