### PR TITLE
Collapse debug information on logging macro wrappers

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,5 +1,6 @@
 #[cfg(not(test))]
 #[cfg(feature = "log")]
+#[collapse_debuginfo(yes)]
 macro_rules! net_log {
     (trace, $($arg:expr),*) => { log::trace!($($arg),*) };
     (debug, $($arg:expr),*) => { log::debug!($($arg),*) };
@@ -7,26 +8,31 @@ macro_rules! net_log {
 
 #[cfg(test)]
 #[cfg(feature = "log")]
+#[collapse_debuginfo(yes)]
 macro_rules! net_log {
     (trace, $($arg:expr),*) => { println!($($arg),*) };
     (debug, $($arg:expr),*) => { println!($($arg),*) };
 }
 
 #[cfg(feature = "defmt")]
+#[collapse_debuginfo(yes)]
 macro_rules! net_log {
     (trace, $($arg:expr),*) => { defmt::trace!($($arg),*) };
     (debug, $($arg:expr),*) => { defmt::debug!($($arg),*) };
 }
 
 #[cfg(not(any(feature = "log", feature = "defmt")))]
+#[collapse_debuginfo(yes)]
 macro_rules! net_log {
     ($level:ident, $($arg:expr),*) => {{ $( let _ = $arg; )* }}
 }
 
+#[collapse_debuginfo(yes)]
 macro_rules! net_trace {
     ($($arg:expr),*) => (net_log!(trace, $($arg),*));
 }
 
+#[collapse_debuginfo(yes)]
 macro_rules! net_debug {
     ($($arg:expr),*) => (net_log!(debug, $($arg),*));
 }


### PR DESCRIPTION
Small issue I found when testing #1151, perhaps I'm misunderstanding something. Wrapping `defmt` with trampoline macros causes duplicate symbol errors when including `smoltcp`, probably due to `defmt`'s de-duplication scheme seeing the macro wrapper as the callsite instead of the caller of the wrapper.

Telling Rust to collapse the debug info for these macros caused the duplicate `defmt` symbols to go away. Also seems to have helped logging, as I believe before I was just getting `macros.rs` in the defmt logs for anything coming from smoltcp.

Weirdly enough, I never had this issue when using `smoltcp` as a dep (i.e. from crates.io) - it only cropped up when temporarily using `path = "..."` for local dev.