### PR TITLE
reno congestion control fixes

### DIFF
--- a/src/socket/tcp/congestion/reno.rs
+++ b/src/socket/tcp/congestion/reno.rs
@@ -38,6 +38,14 @@ impl Controller for Reno {
     }
 
     fn on_ack(&mut self, _now: Instant, len: usize, _in_flight: usize, _rtt: &RttEstimator) {
+        // RFC 5681 only acts on ACKs of new data. The socket also notifies us
+        // of accepted segments that acknowledge nothing (window updates, data
+        // segments from the remote): those must not exit fast recovery nor
+        // grow the window.
+        if len == 0 {
+            return;
+        }
+
         // New data was ACKed: a timer-based loss episode, if any, is over.
         self.in_rto_recovery = false;
 
@@ -332,6 +340,49 @@ mod test {
         ack(&mut reno, MSS, Instant::from_millis(time));
         assert!(reno.window() > initial_cwnd);
         assert!(reno.window() < initial_cwnd + MSS);
+    }
+
+    #[test]
+    fn zero_length_ack_does_not_exit_fast_recovery() {
+        let mut reno = Reno::new();
+        reno.set_mss(MSS);
+        reno.cwnd = MSS * 32;
+
+        reno.on_loss(Instant::from_millis(0), reno.cwnd);
+        assert!(reno.in_fast_recovery);
+
+        let cwnd = reno.window();
+        let ssthresh = reno.ssthresh;
+
+        // Accepted segments that acknowledge no new data (window updates,
+        // data segments from the remote) must not end fast recovery or
+        // change the window.
+        ack(&mut reno, 0, Instant::from_millis(1));
+        assert!(reno.in_fast_recovery);
+        assert_eq!(reno.window(), cwnd);
+        assert_eq!(reno.ssthresh, ssthresh);
+
+        // The first ACK of new data still exits and deflates.
+        ack(&mut reno, MSS, Instant::from_millis(2));
+        assert!(!reno.in_fast_recovery);
+        assert_eq!(reno.window(), ssthresh);
+    }
+
+    #[test]
+    fn zero_length_ack_does_not_grow_window() {
+        let mut reno = Reno::new();
+        reno.set_mss(MSS);
+
+        // Slow start.
+        let cwnd = reno.window();
+        ack(&mut reno, 0, Instant::from_millis(0));
+        assert_eq!(reno.window(), cwnd);
+
+        // Congestion avoidance.
+        reno.cwnd = MSS * 32;
+        reno.ssthresh = MSS * 16;
+        ack(&mut reno, 0, Instant::from_millis(1));
+        assert_eq!(reno.window(), MSS * 32);
     }
 
     #[test]

--- a/src/socket/tcp/congestion/reno.rs
+++ b/src/socket/tcp/congestion/reno.rs
@@ -103,6 +103,221 @@ mod test {
 
     use super::*;
 
+    const MSS: usize = 1024;
+
+    fn ack(reno: &mut Reno, len: usize, now: Instant) {
+        reno.on_ack(now, len, reno.window().saturating_sub(MSS), &rtte())
+    }
+
+    fn rtte() -> RttEstimator {
+        RttEstimator::default()
+    }
+
+    #[test]
+    fn congestion_avoidance_works() {
+        let mut reno = Reno::new();
+        reno.set_mss(MSS);
+        reno.cwnd = MSS * 32;
+        reno.ssthresh = MSS * 16;
+
+        // CA should grow at less than 1 MSS per ACK.
+        for i in 0..10 {
+            let initial_cwnd = reno.window();
+            ack(&mut reno, MSS, Instant::from_millis(i));
+            assert!(reno.window() < initial_cwnd + MSS);
+        }
+
+        // CA should cap at the receive window
+        reno.cwnd = reno.rwnd - 1;
+        ack(&mut reno, MSS, Instant::from_millis(20));
+        assert_eq!(reno.window(), reno.rwnd);
+    }
+
+    #[test]
+    fn fast_recovery_works() {
+        let mut reno = Reno::new();
+        reno.set_mss(MSS);
+        reno.cwnd = MSS * 32;
+
+        // duplicate ACKs before fast recovery should do nothing
+        let initial_cwnd = reno.window();
+        for _ in 0..3 {
+            reno.on_dup_ack(Instant::from_millis(0), MSS, initial_cwnd);
+        }
+        assert_eq!(reno.window(), initial_cwnd);
+
+        // we enter fast recovery upon minor loss (three duplicate ACKs)
+        // window should become half the in-flight bytes
+        // sstresh should be the reduced cwnd, advanced by MSS for the 3 dup ACKs
+        let inflight = initial_cwnd / 2;
+        reno.on_loss(Instant::from_millis(0), inflight);
+        assert_eq!(reno.ssthresh, inflight / 2);
+        assert_eq!(reno.cwnd, inflight / 2 + 3 * MSS);
+
+        // in fast recovery, each dup-ACK should increase  the cwnd by 1 MSS
+        let initial_cwnd = reno.window();
+        for i in 0..3 {
+            for _ in 0..3 {
+                let initial_cwnd = reno.window();
+                reno.on_dup_ack(Instant::from_millis(i), MSS, initial_cwnd);
+                assert_eq!(reno.window(), initial_cwnd + MSS);
+            }
+
+            // multiple loss events (trip-dup-ack) should not trigger additional fast recovery reductions
+            let initial_cwnd = reno.window();
+            let initial_ssthresh = reno.ssthresh;
+            reno.on_loss(Instant::from_millis(i), initial_cwnd);
+            assert_eq!(reno.window(), initial_cwnd);
+            assert_eq!(reno.ssthresh, initial_ssthresh);
+        }
+        assert_eq!(reno.window(), initial_cwnd + MSS * 9);
+
+        // a non-duplicate ACK exits fast recovery and enters congestion avoidance
+        ack(&mut reno, MSS, Instant::from_millis(10));
+        assert_eq!(reno.window(), reno.ssthresh);
+
+        // CA is slower growth so should be less than 1MSS per ACK
+        let initial_cwnd = reno.window();
+        ack(&mut reno, MSS, Instant::from_millis(30));
+        assert!(reno.window() < initial_cwnd + MSS);
+    }
+
+    #[test]
+    fn slow_start_works() {
+        let mut reno = Reno::new();
+        reno.set_mss(MSS);
+        reno.cwnd = MSS * 32;
+        reno.ssthresh = MSS * 16;
+
+        // we enter recovery upon major loss (an RTO)
+        // window should become to 1MSS
+        // sstresh should become half the in-flight bytes
+        let initial_cwnd = reno.window();
+        let inflight = initial_cwnd;
+        reno.on_rto(Instant::from_millis(0), initial_cwnd);
+        assert_eq!(reno.ssthresh, inflight / 2);
+        assert_eq!(reno.window(), MSS);
+
+        // slow start grows by at most the MSS per ack
+        let initial_cwnd = reno.window();
+        for i in 0..10 {
+            let initial_cwnd = reno.window();
+            let now = Instant::from_millis(i);
+            ack(&mut reno, MSS * 2, now);
+            assert_eq!(reno.window(), initial_cwnd + MSS);
+        }
+        assert_eq!(reno.window(), initial_cwnd + MSS * 10);
+
+        // slow start uses the number of ACKed bytes if they're less than the MSS
+        let initial_cwnd = reno.window();
+        for i in 0..10 {
+            let initial_cwnd = reno.window();
+            let now = Instant::from_millis(10 + i);
+            ack(&mut reno, MSS / 2, now);
+            assert_eq!(reno.window(), initial_cwnd + MSS / 2);
+        }
+        assert_eq!(reno.window(), initial_cwnd + MSS / 2 * 10);
+
+        // slow start transitions to congestion avoidance at ssthresh
+        let initial_cwnd = reno.window();
+        reno.ssthresh = initial_cwnd + MSS;
+        ack(&mut reno, MSS, Instant::from_millis(30));
+        assert_eq!(reno.window(), initial_cwnd + MSS);
+        assert_eq!(reno.ssthresh, initial_cwnd + MSS);
+
+        // slow start transitions to congestion avoidance at ssthresh
+        // CA is slower growth so should be less than 1MSS per ACK
+        let initial_cwnd = reno.window();
+        ack(&mut reno, MSS, Instant::from_millis(30));
+        assert!(reno.window() < initial_cwnd + MSS);
+    }
+
+    #[test]
+    fn progress_to_ca_via_rto() {
+        let mut reno = Reno::new();
+        reno.set_mss(MSS);
+
+        let mut time = 0;
+
+        // slow start from default state
+        let initial_cwnd = reno.window();
+        for _ in 0..30 {
+            time += 1;
+            ack(&mut reno, MSS, Instant::from_millis(time));
+        }
+        assert_eq!(reno.window(), initial_cwnd + MSS * 30);
+        assert!(reno.window() < reno.ssthresh);
+
+        // rto: cwnd resets to MSS, ssthresh becomes half in-flight bytes
+        let rto_cwnd = reno.window();
+        reno.on_rto(Instant::from_millis(time), rto_cwnd);
+        assert_eq!(reno.window(), MSS);
+        assert_eq!(reno.ssthresh, rto_cwnd / 2);
+
+        // slow start again until cwnd reaches new ssthresh
+        while reno.window() < reno.ssthresh {
+            time += 1;
+            let initial_cwnd = reno.window();
+            ack(&mut reno, MSS, Instant::from_millis(time));
+            assert_eq!(reno.window(), initial_cwnd + MSS);
+        }
+        assert_eq!(reno.window(), reno.ssthresh);
+
+        // ca: each ack at or above ssthresh grows by less than MSS
+        time += 1;
+        let initial_cwnd = reno.window();
+        ack(&mut reno, MSS, Instant::from_millis(time));
+        assert!(reno.window() > initial_cwnd);
+        assert!(reno.window() < initial_cwnd + MSS);
+    }
+
+    #[test]
+    fn progress_to_ca_via_loss() {
+        let mut reno = Reno::new();
+        reno.set_mss(MSS);
+
+        let mut time = 0;
+
+        // slow start from default state
+        let initial_cwnd = reno.window();
+        for _ in 0..30 {
+            time += 1;
+            ack(&mut reno, MSS, Instant::from_millis(time));
+        }
+        assert_eq!(reno.window(), initial_cwnd + MSS * 30);
+        assert!(reno.window() < reno.ssthresh);
+
+        // dup ACKs: cwnd and sstresh become half in-flight bytes AND cwnd gets advanced for each dup-ack it had received
+        time += 1;
+        let loss_cwnd = reno.window();
+        let expected_ssthresh = loss_cwnd / 2;
+        reno.on_loss(Instant::from_millis(time), loss_cwnd);
+        assert_eq!(reno.ssthresh, expected_ssthresh);
+        assert_eq!(reno.window(), expected_ssthresh + 3 * MSS);
+        assert!(reno.in_fast_recovery);
+
+        // inflate cwnd until on each duplicate ACK
+        for _ in 0..9 {
+            time += 1;
+            let initial_cwnd = reno.window();
+            reno.on_dup_ack(Instant::from_millis(time), MSS, reno.cwnd);
+            assert_eq!(reno.window(), initial_cwnd + MSS);
+        }
+
+        // non-duplicate ACK deflates cwnd to ssthresh
+        time += 1;
+        ack(&mut reno, MSS, Instant::from_millis(time));
+        assert_eq!(reno.window(), expected_ssthresh);
+        assert!(!reno.in_fast_recovery);
+
+        // ca: each ack at or above ssthresh grows by less than MSS
+        time += 1;
+        let initial_cwnd = reno.window();
+        ack(&mut reno, MSS, Instant::from_millis(time));
+        assert!(reno.window() > initial_cwnd);
+        assert!(reno.window() < initial_cwnd + MSS);
+    }
+
     #[test]
     fn test_reno() {
         let remote_window = 64 * 1024;
@@ -126,7 +341,7 @@ mod test {
                 if i & 1 == 0 {
                     reno.on_rto(now, reno.window());
                 } else {
-                    reno.on_dup_ack(now, 1480, reno.window());
+                    reno.on_loss(now, reno.window());
                 }
 
                 let elapsed = Instant::from_millis(1000);

--- a/src/socket/tcp/congestion/reno.rs
+++ b/src/socket/tcp/congestion/reno.rs
@@ -13,6 +13,10 @@ pub struct Reno {
     rwnd: usize,
 
     in_fast_recovery: bool,
+    // Set on RTO, cleared when new data is ACKed. While set, further RTOs
+    // are retransmissions of the same segment and must not reduce ssthresh
+    // again (RFC 5681 section 3.1).
+    in_rto_recovery: bool,
 }
 
 impl Reno {
@@ -23,6 +27,7 @@ impl Reno {
             ssthresh: usize::MAX,
             rwnd: 64 * DEFAULT_MSS,
             in_fast_recovery: false,
+            in_rto_recovery: false,
         }
     }
 }
@@ -33,6 +38,9 @@ impl Controller for Reno {
     }
 
     fn on_ack(&mut self, _now: Instant, len: usize, _in_flight: usize, _rtt: &RttEstimator) {
+        // New data was ACKed: a timer-based loss episode, if any, is over.
+        self.in_rto_recovery = false;
+
         // First new-data-ack exits fast recovery and deflates `cwnd`
         if self.in_fast_recovery {
             self.in_fast_recovery = false;
@@ -79,7 +87,15 @@ impl Controller for Reno {
     }
 
     fn on_rto(&mut self, _now: Instant, in_flight: usize) {
-        self.ssthresh = (in_flight >> 1).max(2 * self.min_cwnd);
+        // RFC 5681: when the retransmission timer fires for a segment that has
+        // already been retransmitted by the timer (no new data was ACKed since
+        // the previous RTO), ssthresh is held constant.
+        if !self.in_rto_recovery {
+            self.ssthresh = (in_flight >> 1).max(2 * self.min_cwnd);
+            self.in_rto_recovery = true;
+        }
+
+        // cwnd collapses to the loss window (1 MSS) and we re-enter slow start.
         self.cwnd = self.min_cwnd;
 
         // Major loss has occurred, ensure we move from fast recovery (if in it) to slow start.
@@ -316,6 +332,31 @@ mod test {
         ack(&mut reno, MSS, Instant::from_millis(time));
         assert!(reno.window() > initial_cwnd);
         assert!(reno.window() < initial_cwnd + MSS);
+    }
+
+    #[test]
+    fn repeated_rto_holds_ssthresh() {
+        let mut reno = Reno::new();
+        reno.set_mss(MSS);
+        reno.cwnd = MSS * 32;
+
+        // First RTO halves ssthresh based on the flight size.
+        reno.on_rto(Instant::from_millis(0), MSS * 32);
+        assert_eq!(reno.ssthresh, MSS * 16);
+        assert_eq!(reno.window(), MSS);
+
+        // Until new data is ACKed, further RTOs are retransmissions of the
+        // same segment and must hold ssthresh constant instead of collapsing
+        // it towards the minimum.
+        reno.on_rto(Instant::from_millis(1), MSS);
+        assert_eq!(reno.ssthresh, MSS * 16);
+        assert_eq!(reno.window(), MSS);
+
+        // Once new data is ACKed, the next RTO is a fresh loss detection
+        // and reduces ssthresh again.
+        ack(&mut reno, MSS, Instant::from_millis(2));
+        reno.on_rto(Instant::from_millis(3), MSS * 4);
+        assert_eq!(reno.ssthresh, MSS * 2);
     }
 
     #[test]

--- a/src/socket/tcp/congestion/reno.rs
+++ b/src/socket/tcp/congestion/reno.rs
@@ -2,6 +2,8 @@ use crate::{socket::tcp::RttEstimator, time::Instant};
 
 use super::Controller;
 
+const DEFAULT_MSS: usize = 1024;
+
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Reno {
@@ -9,15 +11,18 @@ pub struct Reno {
     min_cwnd: usize,
     ssthresh: usize,
     rwnd: usize,
+
+    in_fast_recovery: bool,
 }
 
 impl Reno {
     pub fn new() -> Self {
         Reno {
-            cwnd: 1024 * 2,
-            min_cwnd: 1024 * 2,
+            cwnd: DEFAULT_MSS * 2,
+            min_cwnd: DEFAULT_MSS * 2,
             ssthresh: usize::MAX,
-            rwnd: 64 * 1024,
+            rwnd: 64 * DEFAULT_MSS,
+            in_fast_recovery: false,
         }
     }
 }
@@ -28,27 +33,57 @@ impl Controller for Reno {
     }
 
     fn on_ack(&mut self, _now: Instant, len: usize, _in_flight: usize, _rtt: &RttEstimator) {
-        let len = if self.cwnd < self.ssthresh {
-            // Slow start.
-            len
+        // First new-data-ack exits fast recovery and deflates `cwnd`
+        if self.in_fast_recovery {
+            self.in_fast_recovery = false;
+            self.cwnd = self.ssthresh;
+            return;
+        }
+
+        let inc = if self.cwnd < self.ssthresh {
+            // Slow start: increase `cwnd` by 1 MSS per ACK.
+            len.min(self.min_cwnd)
         } else {
-            self.ssthresh = self.cwnd;
-            self.min_cwnd
+            // Congestion avoidance: increase by ~1 MSS per RTT.
+            (self.min_cwnd * self.min_cwnd / self.cwnd).max(1)
         };
 
         self.cwnd = self
             .cwnd
-            .saturating_add(len)
+            .saturating_add(inc)
             .min(self.rwnd)
             .max(self.min_cwnd);
     }
 
-    fn on_dup_ack(&mut self, _now: Instant, _len: usize, _in_flight: usize) {
-        self.ssthresh = (self.cwnd >> 1).max(self.min_cwnd);
+    fn on_dup_ack(&mut self, _now: Instant, len: usize, _in_flight: usize) {
+        if self.in_fast_recovery {
+            self.cwnd = self
+                .cwnd
+                .saturating_add(len)
+                .min(self.rwnd)
+                .max(self.min_cwnd);
+        }
     }
 
-    fn on_rto(&mut self, _now: Instant, _in_flight: usize) {
-        self.cwnd = (self.cwnd >> 1).max(self.min_cwnd);
+    fn on_loss(&mut self, _now: Instant, in_flight: usize) {
+        // Only cut window size on first entrance to fast recovery.
+        if !self.in_fast_recovery {
+            self.ssthresh = (in_flight >> 1).max(2 * self.min_cwnd);
+            self.cwnd = self
+                .ssthresh
+                .min(self.rwnd)
+                .saturating_add(3 * self.min_cwnd);
+
+            self.in_fast_recovery = true;
+        }
+    }
+
+    fn on_rto(&mut self, _now: Instant, in_flight: usize) {
+        self.ssthresh = (in_flight >> 1).max(2 * self.min_cwnd);
+        self.cwnd = self.min_cwnd;
+
+        // Major loss has occurred, ensure we move from fast recovery (if in it) to slow start.
+        self.in_fast_recovery = false
     }
 
     fn set_mss(&mut self, mss: usize) {

--- a/src/socket/tcp/congestion/reno.rs
+++ b/src/socket/tcp/congestion/reno.rs
@@ -8,7 +8,7 @@ const DEFAULT_MSS: usize = 1024;
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Reno {
     cwnd: usize,
-    min_cwnd: usize,
+    mss: usize,
     ssthresh: usize,
     rwnd: usize,
 
@@ -23,7 +23,7 @@ impl Reno {
     pub fn new() -> Self {
         Reno {
             cwnd: DEFAULT_MSS * 2,
-            min_cwnd: DEFAULT_MSS * 2,
+            mss: DEFAULT_MSS,
             ssthresh: usize::MAX,
             rwnd: 64 * DEFAULT_MSS,
             in_fast_recovery: false,
@@ -58,37 +58,26 @@ impl Controller for Reno {
 
         let inc = if self.cwnd < self.ssthresh {
             // Slow start: increase `cwnd` by 1 MSS per ACK.
-            len.min(self.min_cwnd)
+            len.min(self.mss)
         } else {
             // Congestion avoidance: increase by ~1 MSS per RTT.
-            (self.min_cwnd * self.min_cwnd / self.cwnd).max(1)
+            (self.mss * self.mss / self.cwnd).max(1)
         };
 
-        self.cwnd = self
-            .cwnd
-            .saturating_add(inc)
-            .min(self.rwnd)
-            .max(self.min_cwnd);
+        self.cwnd = self.cwnd.saturating_add(inc).min(self.rwnd).max(self.mss);
     }
 
     fn on_dup_ack(&mut self, _now: Instant, len: usize, _in_flight: usize) {
         if self.in_fast_recovery {
-            self.cwnd = self
-                .cwnd
-                .saturating_add(len)
-                .min(self.rwnd)
-                .max(self.min_cwnd);
+            self.cwnd = self.cwnd.saturating_add(len).min(self.rwnd).max(self.mss);
         }
     }
 
     fn on_loss(&mut self, _now: Instant, in_flight: usize) {
         // Only cut window size on first entrance to fast recovery.
         if !self.in_fast_recovery {
-            self.ssthresh = (in_flight >> 1).max(2 * self.min_cwnd);
-            self.cwnd = self
-                .ssthresh
-                .min(self.rwnd)
-                .saturating_add(3 * self.min_cwnd);
+            self.ssthresh = (in_flight >> 1).max(2 * self.mss);
+            self.cwnd = self.ssthresh.min(self.rwnd).saturating_add(3 * self.mss);
 
             self.in_fast_recovery = true;
         }
@@ -99,19 +88,19 @@ impl Controller for Reno {
         // already been retransmitted by the timer (no new data was ACKed since
         // the previous RTO), ssthresh is held constant.
         if !self.in_rto_recovery {
-            self.ssthresh = (in_flight >> 1).max(2 * self.min_cwnd);
+            self.ssthresh = (in_flight >> 1).max(2 * self.mss);
             self.in_rto_recovery = true;
         }
 
         // cwnd collapses to the loss window (1 MSS) and we re-enter slow start.
-        self.cwnd = self.min_cwnd;
+        self.cwnd = self.mss;
 
         // Major loss has occurred, ensure we move from fast recovery (if in it) to slow start.
         self.in_fast_recovery = false
     }
 
     fn set_mss(&mut self, mss: usize) {
-        self.min_cwnd = mss;
+        self.mss = mss;
     }
 
     fn set_remote_window(&mut self, remote_window: usize) {
@@ -442,7 +431,7 @@ mod test {
                 let cwnd = reno.window();
                 println!("Reno: elapsed = {}, cwnd = {}", elapsed, cwnd);
 
-                assert!(cwnd >= reno.min_cwnd);
+                assert!(cwnd >= reno.mss);
                 assert!(reno.window() <= remote_window);
             }
         }
@@ -458,7 +447,7 @@ mod test {
 
         for _ in 0..100 {
             reno.on_rto(now, reno.window());
-            assert!(reno.window() >= reno.min_cwnd);
+            assert!(reno.window() >= reno.mss);
         }
     }
 


### PR DESCRIPTION
Stacked PR. Requires #1154. Will rebase once that merges.

Reno had lots of issues - see commit messages for some details - but they're fixed now. Performance across the single flow netsim and multiflow netsim (#1153) is about what is expected.

- The single flow test uses random loss which CC doesn't react very well to. Additionally we're limiting the single flow for no reason so it naturally will be worse off. 
- The multiflow netsim uses "realistic" drop patterns and CC reacts much better to it, hence the improvement gain on the low flow count tests. Fairness and throughput are up, and drop rates are down across the board.

VS no congestion control:
```
╭───┬───────┬───────┬────────┬────────┬────────┬────────┬────────┬────────┬────────╮
│ # │  buf  │ 0.000 │ 0.001  │ 0.010  │ 0.020  │ 0.050  │ 0.100  │ 0.200  │ 0.300  │
├───┼───────┼───────┼────────┼────────┼────────┼────────┼────────┼────────┼────────┤
│ 0 │   128 │ 0%    │ 0%     │ 0%     │ 0%     │ 0%     │ 0%     │ 0%     │ 0%     │
│ 1 │   256 │ 0%    │ 0%     │ 0%     │ 0%     │ 0%     │ 0%     │ 0%     │ 0%     │
│ 2 │   512 │ 0%    │ 0%     │ 0%     │ 0%     │ 0%     │ 0%     │ 0%     │ 0%     │
│ 3 │  1024 │ 0%    │ 0%     │ 0%     │ 0%     │ 0%     │ 0%     │ 0%     │ 0%     │
│ 4 │  2048 │ 0%    │ -0.1%  │ +1.6%  │ -0.4%  │ -0.7%  │ +1.9%  │ -32.9% │ -23.9% │
│ 5 │  4096 │ 0%    │ -0.1%  │ -0.8%  │ -1.7%  │ -1.8%  │ -10.6% │ -27.2% │ -38.2% │
│ 6 │  8192 │ -0.2% │ +0.5%  │ -10.1% │ -24%   │ -45.5% │ -65.2% │ -76.3% │ -79.5% │
│ 7 │ 16384 │ -0.8% │ -12%   │ -60.2% │ -74.2% │ -84.6% │ -89.6% │ -90.8% │ -91.1% │
│ 8 │ 32768 │ -3.3% │ -46.9% │ -81%   │ -87.1% │ -90.5% │ -93.8% │ -91.8% │ -94.5% │
╰───┴───────┴───────┴────────┴────────┴────────┴────────┴────────┴────────┴────────╯

╭───┬───────┬──────────┬──────────┬──────────┬──────────┬────────╮
│ # │ flows │ agg_thru │ min_thru │ max_thru │ fairness │ drops  │
├───┼───────┼──────────┼──────────┼──────────┼──────────┼────────┤
│ 0 │     1 │ +133.1%  │ +133.1%  │ +133.1%  │ 0%       │ -100%  │
│ 1 │     2 │ +3526.4% │ +3620.4% │ +3439.4% │ +0.1%    │ -100%  │
│ 2 │     4 │ +1542.6% │ +5198.9% │ +1537.8% │ +14.4%   │ -90.3% │
│ 3 │    16 │ +1038.9% │ +1212%   │ +310.5%  │ +84.2%   │ -98.1% │
│ 4 │    32 │ +944.7%  │ +2385.7% │ +543%    │ +28%     │ -97.6% │
│ 5 │    64 │ +753.4%  │ +1910.2% │ +436.8%  │ +20%     │ -97.5% │
╰───┴───────┴──────────┴──────────┴──────────┴──────────┴────────╯
```

VS old reno implementation:
```
╭───┬───────┬──────────┬──────────┬──────────┬──────────┬────────╮
│ # │ flows │ agg_thru │ min_thru │ max_thru │ fairness │ drops  │
├───┼───────┼──────────┼──────────┼──────────┼──────────┼────────┤
│ 0 │     1 │ +261.3%  │ +261.3%  │ +261.3%  │ 0%       │ -100%  │
│ 1 │     2 │ +326.3%  │ +3771.8% │ +128.5%  │ +79.4%   │ -100%  │
│ 2 │     4 │ -3.1%    │ +1.2%    │ +5.1%    │ -0.8%    │ -94.5% │
│ 3 │    16 │ +764.8%  │ +640.3%  │ +383.5%  │ +43.4%   │ -98.4% │
│ 4 │    32 │ +618.4%  │ +1813.2% │ +319.1%  │ +44.8%   │ -97.5% │
│ 5 │    64 │ +704.6%  │ +1560.2% │ +409.7%  │ +19.2%   │ -98%   │
╰───┴───────┴──────────┴──────────┴──────────┴──────────┴────────╯
```
