### PR TITLE
Sort generated config.rs outputs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::path::PathBuf;
 use std::{env, fs};
@@ -41,7 +41,7 @@ fn main() {
         println!("cargo:rerun-if-env-changed=SMOLTCP_{name}");
     }
 
-    let mut configs = HashMap::new();
+    let mut configs = BTreeMap::new();
     for (name, default) in CONFIGS {
         configs.insert(
             *name,


### PR DESCRIPTION
So far, the generated `config.rs` file contained all the config options in arbitrary order. This could lead to different file contents despite identical configuration values, making build cache systems like sccache unhappy.

Using a BTreeMap instead of a HashMap results in the outputs being sorted, making the `config.rs` output deterministic for the same values.