### PR TITLE
More than one `PrefixInformation` in `ndisc::Repr::RouterAdvert`

### DIFF
--- a/src/iface/interface/ipv6.rs
+++ b/src/iface/interface/ipv6.rs
@@ -515,7 +515,7 @@ impl InterfaceInner {
                 retrans_time: _,
                 lladdr: _,
                 mtu: _,
-                prefix_info,
+                prefix_infos,
             } if self.slaac_enabled => {
                 if ip_repr.src_addr.is_link_local()
                     && (ip_repr.dst_addr == IPV6_LINK_LOCAL_ALL_NODES
@@ -525,7 +525,7 @@ impl InterfaceInner {
                     self.slaac.process_advertisement(
                         &ip_repr.src_addr,
                         router_lifetime,
-                        prefix_info,
+                        &prefix_infos,
                         self.now,
                     )
                 }

--- a/src/iface/interface/tests/ipv6.rs
+++ b/src/iface/interface/tests/ipv6.rs
@@ -949,6 +949,8 @@ fn test_router_advertisement(#[case] medium: Medium) {
         valid_lifetime: Duration::from_secs(600),
         preferred_lifetime: Duration::from_secs(300),
     };
+    let mut prefix_infos = heapless::Vec::new();
+    prefix_infos.push(prefix_information).unwrap();
     let mut advertisement = NdiscRepr::RouterAdvert {
         hop_limit: 255,
         flags: NdiscRouterFlags::empty(),
@@ -957,7 +959,7 @@ fn test_router_advertisement(#[case] medium: Medium) {
         retrans_time: Duration::from_secs(0),
         lladdr: None,
         mtu: None,
-        prefix_info: Some(prefix_information),
+        prefix_infos,
     };
     let ip_repr = IpRepr::Ipv6(Ipv6Repr {
         src_addr: remote_ip_addr.address(),
@@ -971,7 +973,7 @@ fn test_router_advertisement(#[case] medium: Medium) {
     frame.set_src_addr(remote_hw_addr);
     frame.set_ethertype(EthernetProtocol::Ipv6);
     ip_repr.emit(frame.payload_mut(), &ChecksumCapabilities::default());
-    Icmpv6Repr::Ndisc(advertisement).emit(
+    Icmpv6Repr::Ndisc(advertisement.clone()).emit(
         &remote_ip_addr.address(),
         &local_ip_addr.address(),
         &mut Icmpv6Packet::new_unchecked(&mut frame.payload_mut()[ip_repr.header_len()..]),
@@ -1018,11 +1020,11 @@ fn test_router_advertisement(#[case] medium: Medium) {
     prefix_information.valid_lifetime = Duration::ZERO;
     prefix_information.preferred_lifetime = Duration::ZERO;
     if let NdiscRepr::RouterAdvert {
-        ref mut prefix_info,
+        ref mut prefix_infos,
         ..
     } = advertisement
     {
-        *prefix_info = Some(prefix_information);
+        prefix_infos[0] = prefix_information;
     }
 
     let mut frame = EthernetFrame::new_unchecked(&mut eth_bytes);
@@ -1030,7 +1032,7 @@ fn test_router_advertisement(#[case] medium: Medium) {
     frame.set_src_addr(remote_hw_addr);
     frame.set_ethertype(EthernetProtocol::Ipv6);
     ip_repr.emit(frame.payload_mut(), &ChecksumCapabilities::default());
-    Icmpv6Repr::Ndisc(advertisement).emit(
+    Icmpv6Repr::Ndisc(advertisement.clone()).emit(
         &remote_ip_addr.address(),
         &local_ip_addr.address(),
         &mut Icmpv6Packet::new_unchecked(&mut frame.payload_mut()[ip_repr.header_len()..]),
@@ -1055,12 +1057,12 @@ fn test_router_advertisement(#[case] medium: Medium) {
     // Craft router advertisement with zero router lifetime
     // to remove the route
     if let NdiscRepr::RouterAdvert {
-        ref mut prefix_info,
+        ref mut prefix_infos,
         ref mut router_lifetime,
         ..
     } = advertisement
     {
-        *prefix_info = None;
+        prefix_infos.clear();
         *router_lifetime = Duration::ZERO;
     }
 
@@ -1069,7 +1071,7 @@ fn test_router_advertisement(#[case] medium: Medium) {
     frame.set_src_addr(remote_hw_addr);
     frame.set_ethertype(EthernetProtocol::Ipv6);
     ip_repr.emit(frame.payload_mut(), &ChecksumCapabilities::default());
-    Icmpv6Repr::Ndisc(advertisement).emit(
+    Icmpv6Repr::Ndisc(advertisement.clone()).emit(
         &remote_ip_addr.address(),
         &local_ip_addr.address(),
         &mut Icmpv6Packet::new_unchecked(&mut frame.payload_mut()[ip_repr.header_len()..]),

--- a/src/iface/slaac.rs
+++ b/src/iface/slaac.rs
@@ -184,14 +184,15 @@ impl Slaac {
     pub(super) fn process_advertisement(
         &mut self,
         source: &Ipv6Address,
-        router_lifetime: Duration,              // default route lifetime
-        prefix: Option<NdiscPrefixInformation>, // prefix info
+        router_lifetime: Duration,           // default route lifetime
+        prefixes: &[NdiscPrefixInformation], // advertised prefixes
         now: Instant,
     ) {
-        if let Some(prefix) = prefix
-            && prefix.is_valid_prefix_info()
+        for prefix in prefixes
+            .iter()
+            .filter(|prefix| prefix.is_valid_prefix_info())
         {
-            self.process_prefix(prefix, now)
+            self.process_prefix(*prefix, now);
         }
 
         if router_lifetime > Duration::ZERO {
@@ -369,7 +370,7 @@ mod test {
         assert!(!slaac.has_ra_update());
 
         // Unsolicited advertisement
-        slaac.process_advertisement(&SOURCE, VALID, Some(PREFIX), now);
+        slaac.process_advertisement(&SOURCE, VALID, &[PREFIX], now);
         assert_eq!(slaac.phase, Phase::Start);
         assert!(slaac.has_ra_update());
 
@@ -378,8 +379,8 @@ mod test {
         assert_eq!(slaac.phase, Phase::Discovering);
 
         // Solicited advertisement
-        slaac.process_advertisement(&SOURCE, VALID, Some(PREFIX), now);
-        slaac.process_advertisement(&SOURCE, VALID, Some(PREFIX), now);
+        slaac.process_advertisement(&SOURCE, VALID, &[PREFIX], now);
+        slaac.process_advertisement(&SOURCE, VALID, &[PREFIX], now);
         assert_eq!(slaac.phase, Phase::Maintaining);
         let poll_at = slaac.poll_at(now).unwrap();
         assert_eq!(poll_at, now + VALID);
@@ -442,7 +443,7 @@ mod test {
         let mut slaac = Slaac::new();
         let now = Instant::from_millis(1);
         slaac.rs_sent(now);
-        slaac.process_advertisement(&SOURCE, VALID, Some(PREFIX), now);
+        slaac.process_advertisement(&SOURCE, VALID, &[PREFIX], now);
 
         let now = Instant::from_secs(300);
 
@@ -460,7 +461,7 @@ mod test {
         expire_prefix.valid_lifetime = Duration::ZERO;
 
         // Invalidate the prefix, but not the route
-        slaac.process_advertisement(&SOURCE, VALID, Some(expire_prefix), now);
+        slaac.process_advertisement(&SOURCE, VALID, &[expire_prefix], now);
 
         assert!(slaac.sync_required(now));
         for (_prefix, info) in slaac.prefix() {
@@ -475,7 +476,7 @@ mod test {
 
         assert!(!slaac.sync_required(now));
         // Invalidate also the route
-        slaac.process_advertisement(&SOURCE, Duration::ZERO, Some(expire_prefix), now);
+        slaac.process_advertisement(&SOURCE, Duration::ZERO, &[expire_prefix], now);
         assert!(slaac.sync_required(now));
         for route in slaac.routes() {
             assert!(!route.is_valid(now));

--- a/src/socket/icmp.rs
+++ b/src/socket/icmp.rs
@@ -1067,7 +1067,7 @@ mod test_ipv6 {
         assert_eq!(
             socket.dispatch(cx, |_, (ip_repr, icmp_repr)| {
                 assert_eq!(ip_repr, LOCAL_IPV6_REPR.into());
-                assert_eq!(icmp_repr, ECHOV6_REPR.into());
+                assert_eq!(icmp_repr, ECHOV6_REPR.clone().into());
                 Err(())
             }),
             Err(())
@@ -1078,7 +1078,7 @@ mod test_ipv6 {
         assert_eq!(
             socket.dispatch(cx, |_, (ip_repr, icmp_repr)| {
                 assert_eq!(ip_repr, LOCAL_IPV6_REPR.into());
-                assert_eq!(icmp_repr, ECHOV6_REPR.into());
+                assert_eq!(icmp_repr, ECHOV6_REPR.clone().into());
                 Ok::<_, ()>(())
             }),
             Ok(())

--- a/src/wire/icmpv6.rs
+++ b/src/wire/icmpv6.rs
@@ -568,7 +568,7 @@ impl<T: AsRef<[u8]>> AsRef<[u8]> for Packet<T> {
 }
 
 /// A high-level representation of an Internet Control Message Protocol version 6 packet header.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum Repr<'a> {
@@ -719,7 +719,7 @@ impl<'a> Repr<'a> {
                 field::ECHO_SEQNO.end + data.len()
             }
             #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
-            &Repr::Ndisc(ndisc) => ndisc.buffer_len(),
+            Repr::Ndisc(ndisc) => ndisc.buffer_len(),
             &Repr::Mld(mld) => mld.buffer_len(),
             #[cfg(feature = "proto-rpl")]
             Repr::Rpl(rpl) => rpl.buffer_len(),
@@ -825,7 +825,7 @@ impl<'a> Repr<'a> {
             }
 
             #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
-            Repr::Ndisc(ndisc) => ndisc.emit(packet),
+            Repr::Ndisc(ref ndisc) => ndisc.emit(packet),
 
             Repr::Mld(mld) => mld.emit(packet),
 

--- a/src/wire/ndisc.rs
+++ b/src/wire/ndisc.rs
@@ -1,7 +1,9 @@
 use bitflags::bitflags;
 use byteorder::{ByteOrder, NetworkEndian};
+use heapless::Vec;
 
 use super::{Error, Result};
+use crate::config::IFACE_MAX_PREFIX_COUNT;
 use crate::time::Duration;
 use crate::wire::Ipv6Address;
 use crate::wire::RawHardwareAddress;
@@ -189,7 +191,7 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Packet<T> {
 }
 
 /// A high-level representation of an Neighbor Discovery packet header.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Repr<'a> {
     RouterSolicit {
@@ -203,7 +205,7 @@ pub enum Repr<'a> {
         retrans_time: Duration,
         lladdr: Option<RawHardwareAddress>,
         mtu: Option<u32>,
-        prefix_info: Option<NdiscPrefixInformation>,
+        prefix_infos: Vec<NdiscPrefixInformation, IFACE_MAX_PREFIX_COUNT>,
     },
     NeighborSolicit {
         target_addr: Ipv6Address,
@@ -232,8 +234,9 @@ impl<'a> Repr<'a> {
     {
         packet.check_len()?;
 
-        let (mut src_ll_addr, mut mtu, mut prefix_info, mut target_ll_addr, mut redirected_hdr) =
-            (None, None, None, None, None);
+        let (mut src_ll_addr, mut mtu, mut target_ll_addr, mut redirected_hdr) =
+            (None, None, None, None);
+        let mut prefix_infos = Vec::new();
 
         let mut offset = 0;
         while packet.payload().len() > offset {
@@ -244,7 +247,9 @@ impl<'a> Repr<'a> {
                 match opt {
                     NdiscOptionRepr::SourceLinkLayerAddr(addr) => src_ll_addr = Some(addr),
                     NdiscOptionRepr::TargetLinkLayerAddr(addr) => target_ll_addr = Some(addr),
-                    NdiscOptionRepr::PrefixInformation(prefix) => prefix_info = Some(prefix),
+                    NdiscOptionRepr::PrefixInformation(prefix) => {
+                        let _ = prefix_infos.push(prefix);
+                    }
                     NdiscOptionRepr::RedirectedHeader(redirect) => redirected_hdr = Some(redirect),
                     NdiscOptionRepr::Mtu(m) => mtu = Some(m),
                     _ => {}
@@ -270,7 +275,7 @@ impl<'a> Repr<'a> {
                 retrans_time: packet.retrans_time(),
                 lladdr: src_ll_addr,
                 mtu,
-                prefix_info,
+                prefix_infos,
             }),
             Message::NeighborSolicit => Ok(Repr::NeighborSolicit {
                 target_addr: packet.target_addr(),
@@ -291,18 +296,18 @@ impl<'a> Repr<'a> {
         }
     }
 
-    pub const fn buffer_len(&self) -> usize {
-        match self {
-            &Repr::RouterSolicit { lladdr } => match lladdr {
+    pub fn buffer_len(&self) -> usize {
+        match *self {
+            Repr::RouterSolicit { lladdr } => match lladdr {
                 Some(addr) => {
                     field::UNUSED.end + { NdiscOptionRepr::SourceLinkLayerAddr(addr).buffer_len() }
                 }
                 None => field::UNUSED.end,
             },
-            &Repr::RouterAdvert {
+            Repr::RouterAdvert {
                 lladdr,
                 mtu,
-                prefix_info,
+                ref prefix_infos,
                 ..
             } => {
                 let mut offset = 0;
@@ -312,19 +317,19 @@ impl<'a> Repr<'a> {
                 if let Some(mtu) = mtu {
                     offset += NdiscOptionRepr::Mtu(mtu).buffer_len();
                 }
-                if let Some(prefix_info) = prefix_info {
-                    offset += NdiscOptionRepr::PrefixInformation(prefix_info).buffer_len();
+                for prefix_info in prefix_infos {
+                    offset += NdiscOptionRepr::PrefixInformation(*prefix_info).buffer_len();
                 }
                 field::RETRANS_TM.end + offset
             }
-            &Repr::NeighborSolicit { lladdr, .. } | &Repr::NeighborAdvert { lladdr, .. } => {
+            Repr::NeighborSolicit { lladdr, .. } | Repr::NeighborAdvert { lladdr, .. } => {
                 let mut offset = field::TARGET_ADDR.end;
                 if let Some(lladdr) = lladdr {
                     offset += NdiscOptionRepr::SourceLinkLayerAddr(lladdr).buffer_len();
                 }
                 offset
             }
-            &Repr::Redirect {
+            Repr::Redirect {
                 lladdr,
                 redirected_hdr,
                 ..
@@ -366,7 +371,7 @@ impl<'a> Repr<'a> {
                 retrans_time,
                 lladdr,
                 mtu,
-                prefix_info,
+                ref prefix_infos,
             } => {
                 packet.set_msg_type(Message::RouterAdvert);
                 packet.set_msg_code(0);
@@ -388,10 +393,12 @@ impl<'a> Repr<'a> {
                     NdiscOptionRepr::Mtu(mtu).emit(&mut opt_pkt);
                     offset += NdiscOptionRepr::Mtu(mtu).buffer_len();
                 }
-                if let Some(prefix_info) = prefix_info {
+                for prefix_info in prefix_infos {
                     let mut opt_pkt =
                         NdiscOption::new_unchecked(&mut packet.payload_mut()[offset..]);
-                    NdiscOptionRepr::PrefixInformation(prefix_info).emit(&mut opt_pkt)
+                    let opt = NdiscOptionRepr::PrefixInformation(*prefix_info);
+                    opt.emit(&mut opt_pkt);
+                    offset += opt.buffer_len();
                 }
             }
 
@@ -480,7 +487,7 @@ mod test {
             retrans_time: Duration::from_millis(900),
             lladdr: Some(EthernetAddress([0x52, 0x54, 0x00, 0x12, 0x34, 0x56]).into()),
             mtu: None,
-            prefix_info: None,
+            prefix_infos: Vec::new(),
         })
     }
 
@@ -541,5 +548,63 @@ mod test {
             &ChecksumCapabilities::default(),
         );
         assert_eq!(&*packet.into_inner(), &ROUTER_ADVERT_BYTES[..]);
+    }
+
+    // A Router Advertisement may carry several Prefix Information options
+    // (e.g. a global prefix alongside a ULA). They must all survive parsing,
+    // up to IFACE_MAX_PREFIX_COUNT, rather than the last one overwriting the
+    // rest. Meaningful when IFACE_MAX_PREFIX_COUNT >= 2.
+    #[test]
+    fn test_router_advert_retains_multiple_prefixes() {
+        let wanted = if IFACE_MAX_PREFIX_COUNT < 2 {
+            IFACE_MAX_PREFIX_COUNT
+        } else {
+            2
+        };
+        let mk = |h: u16| NdiscPrefixInformation {
+            prefix_len: 64,
+            flags: crate::wire::NdiscPrefixInfoFlags::empty(),
+            valid_lifetime: Duration::from_secs(600),
+            preferred_lifetime: Duration::from_secs(300),
+            prefix: Ipv6Address::new(h, 0, 0, 0, 0, 0, 0, 0),
+        };
+        let mut prefix_infos = Vec::new();
+        for i in 0..wanted {
+            let _ = prefix_infos.push(mk(0x2001 + i as u16));
+        }
+        let repr = Icmpv6Repr::Ndisc(Repr::RouterAdvert {
+            hop_limit: 64,
+            flags: RouterFlags::empty(),
+            router_lifetime: Duration::from_secs(900),
+            reachable_time: Duration::from_millis(0),
+            retrans_time: Duration::from_millis(0),
+            lladdr: None,
+            mtu: None,
+            prefix_infos,
+        });
+
+        let mut bytes = vec![0u8; repr.buffer_len()];
+        let mut packet = Packet::new_unchecked(&mut bytes[..]);
+        repr.emit(
+            &MOCK_IP_ADDR_1,
+            &MOCK_IP_ADDR_2,
+            &mut packet,
+            &ChecksumCapabilities::default(),
+        );
+
+        let packet = Packet::new_unchecked(&bytes[..]);
+        let parsed = Icmpv6Repr::parse(
+            &MOCK_IP_ADDR_1,
+            &MOCK_IP_ADDR_2,
+            &packet,
+            &ChecksumCapabilities::default(),
+        )
+        .unwrap();
+        match parsed {
+            Icmpv6Repr::Ndisc(Repr::RouterAdvert { prefix_infos, .. }) => {
+                assert_eq!(prefix_infos.len(), wanted);
+            }
+            other => panic!("expected RouterAdvert, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
Solves #1165 by allowing each RouterAdvert to contain up to `IFACE_MAX_PREFIX_COUNT`!

To store a `Vec<PrefixInformation>` instead of `Option<PrefixInformation>`, `icmpv6::Repr` and `ndisc::Repr` became `!Copy`. I'm not sure if that is tolerable. If `Copy` is mandatory, the `Vec<T>` could maybe be replaced by `[Option<T>; N]`.

Note also that before this change, if a RA contained multiple prefixes, all but the _last_ one would be discarded. Now, all but the _first_ `IFACE_MAX_PREFIX_COUNT` get discarded. I don't think it'll be too big of an issue.