### PR TITLE
iface: add inbound packet drop callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No unreleased changes yet. Please send PRs!
+### Added
+
+- iface: Add an inbound packet drop callback. Use `Interface::set_packet_drop_callback` to be notified whenever the interface does not deliver an inbound packet to a socket — both silent drops (malformed, not-for-us, no route, unhandled ICMP, etc.) and well-formed packets that are rejected with a reply (TCP RST, ICMP unreachable). The callback receives a `PacketDropInfo` describing the `PacketDropReason`, the `PacketDropDisposition`, and, where they were parsed for free, the offending packet's IP header, transport ports and/or raw bytes (see `PacketDropInfo::five_tuple`). An opaque `usize` cookie supplied alongside the callback is passed back on every invocation, so the (capture-less) `fn` callback can reach application state without an allocator.
+
+
 
 ## [0.13.1] - 2026-05-01
 

--- a/src/iface/interface/drop.rs
+++ b/src/iface/interface/drop.rs
@@ -1,0 +1,326 @@
+//! Inbound packet drop / non-delivery notification.
+//!
+//! This module provides a mechanism for the user to observe what the interface
+//! does with inbound packets that are *not* delivered to a socket: packets that
+//! are silently discarded, and packets the stack rejects by replying with a TCP
+//! RST or an ICMP "unreachable" message. This is useful for diagnostics, logging
+//! or metrics, and in particular for VPN-style use cases where you want to know
+//! which inbound flows are falling through unhandled. See
+//! [`Interface::set_packet_drop_callback`].
+
+use super::*;
+
+/// The reason an inbound packet was not delivered to a socket.
+///
+/// This describes *why* and roughly *where* in the receive path the packet was
+/// dropped or rejected. New variants may be added in the future, so this enum is
+/// marked `#[non_exhaustive]`; matches on it must include a wildcard arm.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PacketDropReason {
+    /// A packet (or one of its headers) could not be parsed: it was truncated,
+    /// had an invalid checksum, used an unsupported feature, etc.
+    ///
+    /// This is reported for every malformed-packet drop in the receive path,
+    /// regardless of protocol layer. No parsed representation is available, but
+    /// the raw bytes that failed to parse can be inspected via
+    /// [`PacketDropInfo::frame`].
+    Malformed,
+
+    /// An Ethernet frame was not addressed to this interface (its destination
+    /// was neither our hardware address, nor broadcast, nor a multicast group).
+    #[cfg(feature = "medium-ethernet")]
+    NotForUs,
+
+    /// The frame carried a protocol the interface does not handle at the link
+    /// layer, e.g. an unknown EtherType, or a non-IP packet on an IP-only medium.
+    UnknownProtocol,
+
+    /// An IEEE 802.15.4 frame was not a data frame (e.g. an ACK or MAC command
+    /// frame), and so is not processed by the stack.
+    #[cfg(feature = "medium-ieee802154")]
+    NotADataFrame,
+
+    /// An IEEE 802.15.4 frame's destination PAN id did not match the configured
+    /// PAN id (and was not the broadcast PAN id).
+    #[cfg(feature = "medium-ieee802154")]
+    WrongPanId,
+
+    /// The source address of an IP packet was not a unicast address (and not the
+    /// unspecified address, where that is permitted). Such packets are never
+    /// valid and are always discarded.
+    NonUnicastSource,
+
+    /// An IP packet was not destined for this interface: its destination address
+    /// is not assigned to us, is not a multicast group we have joined, and is not
+    /// a broadcast address. The destination is itself a non-unicast address, so
+    /// the packet cannot be routed either.
+    NotForUsNonUnicast,
+
+    /// An IP packet was destined for an address that is not ours, but no route to
+    /// it could be found (the interface is not acting as a router for it).
+    NoRoute,
+
+    /// An IP packet was destined for an address that is not ours, and although a
+    /// route exists, the interface has no address assigned that would let it
+    /// originate a reply.
+    NoSourceAddress,
+
+    /// A well-formed IP packet for us carried a transport/next-header protocol
+    /// that no socket is listening for, and that the interface does not handle
+    /// itself.
+    ///
+    /// The interface normally replies with an ICMP "protocol unreachable"
+    /// message; see [`PacketDropInfo::disposition`].
+    UnknownTransportProtocol,
+
+    /// A TCP segment for us did not match any open socket.
+    ///
+    /// Unless suppressed (e.g. the segment was itself a RST), the interface
+    /// replies with a TCP RST; see [`PacketDropInfo::disposition`].
+    #[cfg(feature = "socket-tcp")]
+    TcpNoSocket,
+
+    /// A TCP segment used the unspecified address as its source or destination,
+    /// which RFC 1122 § 3.2.1.3 forbids.
+    #[cfg(feature = "socket-tcp")]
+    TcpUnspecifiedEndpoint,
+
+    /// A UDP datagram for us did not match any open socket.
+    ///
+    /// The interface normally replies with an ICMP "port unreachable" message;
+    /// see [`PacketDropInfo::disposition`].
+    #[cfg(any(feature = "socket-udp", feature = "socket-dns"))]
+    UdpNoSocket,
+
+    /// An ICMP message for us was not an echo request we answer, was not claimed
+    /// by an ICMP socket, and required no other action, so it was ignored.
+    IcmpUnhandled,
+
+    /// An ARP packet was not targeted at one of our protocol addresses.
+    #[cfg(feature = "medium-ethernet")]
+    ArpNotForUs,
+
+    /// An ARP packet was otherwise invalid: an unknown operation, a non-unicast
+    /// source address, or a source that is not on a connected network.
+    #[cfg(feature = "medium-ethernet")]
+    ArpInvalid,
+
+    /// A fragmented IP or 6LoWPAN packet could not be reassembled, either because
+    /// no reassembly buffer was available or because the fragments were
+    /// inconsistent.
+    ///
+    /// Note: a fragment that is merely *incomplete* (more fragments are still
+    /// expected) is not reported, since that is normal and not a drop.
+    #[cfg(feature = "_proto-fragmentation")]
+    FragmentReassembly,
+
+    /// 6LoWPAN header decompression failed, or fragmentation support is required
+    /// but not enabled.
+    #[cfg(feature = "proto-sixlowpan")]
+    Sixlowpan,
+}
+
+/// What the interface did with an inbound packet it would not deliver to a
+/// socket.
+///
+/// Not every "drop" is a silent discard: for several well-formed-but-unhandled
+/// cases the stack rejects the packet by sending a reply. This lets a callback
+/// distinguish those.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PacketDropDisposition {
+    /// The packet was silently discarded; no reply was generated.
+    Dropped,
+
+    /// The packet was rejected and the interface generated a TCP RST in reply.
+    #[cfg(feature = "socket-tcp")]
+    RepliedTcpReset,
+
+    /// The packet was rejected and the interface generated an ICMP "unreachable"
+    /// (destination/port/protocol unreachable) message in reply.
+    RepliedIcmpUnreachable,
+}
+
+/// Information passed to a [packet drop callback](PacketDropCallback) describing
+/// a single inbound packet that was not delivered to a socket.
+///
+/// Parsed details are provided opportunistically. [`ip_repr`] is populated
+/// wherever the IP header had already been parsed when the decision was made;
+/// [`src_port`]/[`dst_port`] are populated for TCP/UDP cases where the transport
+/// header was parsed; and [`frame`] (raw bytes) is populated where the bytes are
+/// available for free. A callback must therefore treat all of these as
+/// best-effort context — see [`five_tuple`](Self::five_tuple) for the common
+/// case.
+///
+/// [`ip_repr`]: PacketDropInfo::ip_repr
+/// [`src_port`]: PacketDropInfo::src_port
+/// [`dst_port`]: PacketDropInfo::dst_port
+/// [`frame`]: PacketDropInfo::frame
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct PacketDropInfo<'a> {
+    /// Why the packet was not delivered.
+    pub reason: PacketDropReason,
+
+    /// What the interface did with the packet (dropped, or rejected with a
+    /// reply).
+    pub disposition: PacketDropDisposition,
+
+    /// The parsed IP header, if the packet had been parsed to the IP layer
+    /// before the decision was made. `None` for malformed or pre-IP (e.g.
+    /// link-layer) drops.
+    pub ip_repr: Option<IpRepr>,
+
+    /// The source transport port, if a TCP/UDP header had been parsed.
+    pub src_port: Option<u16>,
+
+    /// The destination transport port, if a TCP/UDP header had been parsed.
+    pub dst_port: Option<u16>,
+
+    /// The raw bytes of the offending packet or frame, if available at the drop
+    /// point. The slice begins at whichever header was being processed when the
+    /// decision was made (for example, the Ethernet frame for a link-layer drop,
+    /// or the IP packet for an IP-layer drop). `None` when the bytes are not
+    /// readily available.
+    pub frame: Option<&'a [u8]>,
+}
+
+impl<'a> PacketDropInfo<'a> {
+    pub(crate) const fn new(reason: PacketDropReason) -> Self {
+        Self {
+            reason,
+            disposition: PacketDropDisposition::Dropped,
+            ip_repr: None,
+            src_port: None,
+            dst_port: None,
+            frame: None,
+        }
+    }
+
+    pub(crate) const fn with_disposition(mut self, disposition: PacketDropDisposition) -> Self {
+        self.disposition = disposition;
+        self
+    }
+
+    pub(crate) const fn with_ip_repr(mut self, ip_repr: IpRepr) -> Self {
+        self.ip_repr = Some(ip_repr);
+        self
+    }
+
+    #[allow(dead_code)] // not used by every feature combination
+    pub(crate) const fn with_ports(mut self, src_port: u16, dst_port: u16) -> Self {
+        self.src_port = Some(src_port);
+        self.dst_port = Some(dst_port);
+        self
+    }
+
+    pub(crate) const fn with_frame(mut self, frame: &'a [u8]) -> Self {
+        self.frame = Some(frame);
+        self
+    }
+
+    pub(crate) const fn with_optional_frame(mut self, frame: Option<&'a [u8]>) -> Self {
+        self.frame = frame;
+        self
+    }
+
+    /// The IP protocol (next header) of the offending packet, if its IP header
+    /// was parsed.
+    pub fn protocol(&self) -> Option<IpProtocol> {
+        self.ip_repr.as_ref().map(|repr| repr.next_header())
+    }
+
+    /// The source endpoint (address + port) of the offending packet, when both
+    /// the IP header and a transport port were available.
+    ///
+    /// Returns `None` if the IP header was not parsed. The port is `0` when the
+    /// IP header was parsed but no transport port was available (e.g. a non
+    /// TCP/UDP protocol).
+    pub fn source(&self) -> Option<IpEndpoint> {
+        self.ip_repr.as_ref().map(|repr| IpEndpoint {
+            addr: repr.src_addr(),
+            port: self.src_port.unwrap_or(0),
+        })
+    }
+
+    /// The destination endpoint (address + port) of the offending packet, when
+    /// the IP header was available.
+    ///
+    /// Returns `None` if the IP header was not parsed. The port is `0` when the
+    /// IP header was parsed but no transport port was available.
+    pub fn destination(&self) -> Option<IpEndpoint> {
+        self.ip_repr.as_ref().map(|repr| IpEndpoint {
+            addr: repr.dst_addr(),
+            port: self.dst_port.unwrap_or(0),
+        })
+    }
+
+    /// The full 5-tuple (source endpoint, destination endpoint, protocol) of the
+    /// offending packet, when its IP header was parsed.
+    ///
+    /// This is the convenient way to identify *which flow* was not handled — for
+    /// example to decide whether to open a proxied connection for it. Returns
+    /// `None` for malformed or pre-IP drops, where no IP header is available.
+    /// Ports are `0` when the packet was not TCP/UDP.
+    pub fn five_tuple(&self) -> Option<FiveTuple> {
+        let repr = self.ip_repr.as_ref()?;
+        Some(FiveTuple {
+            src: IpEndpoint {
+                addr: repr.src_addr(),
+                port: self.src_port.unwrap_or(0),
+            },
+            dst: IpEndpoint {
+                addr: repr.dst_addr(),
+                port: self.dst_port.unwrap_or(0),
+            },
+            protocol: repr.next_header(),
+        })
+    }
+}
+
+/// The transport 5-tuple identifying an inbound flow, as reported by
+/// [`PacketDropInfo::five_tuple`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct FiveTuple {
+    /// Source address and port. The port is `0` for non-TCP/UDP protocols.
+    pub src: IpEndpoint,
+    /// Destination address and port. The port is `0` for non-TCP/UDP protocols.
+    pub dst: IpEndpoint,
+    /// The IP protocol (next header).
+    pub protocol: IpProtocol,
+}
+
+/// Callback invoked whenever the interface does not deliver an inbound packet to
+/// a socket.
+///
+/// Set with [`Interface::set_packet_drop_callback`]. The callback receives a
+/// [`PacketDropInfo`] describing the [reason](PacketDropReason), the
+/// [disposition](PacketDropDisposition) (silently dropped, or rejected with a
+/// reply), and — where they were parsed for free — the offending packet's IP
+/// header, transport ports and/or raw bytes.
+///
+/// The second argument is the opaque `usize` cookie that was supplied alongside
+/// the callback to [`Interface::set_packet_drop_callback`]. The interface never
+/// interprets it: use it as an index into your own table, a tag, or (with your
+/// own `unsafe`) a pointer back to your application state. This is how the
+/// callback reaches your state, since — being a plain `fn` pointer rather than a
+/// boxed closure, so that it works in `no_std` builds without an allocator — it
+/// cannot capture anything itself.
+pub type PacketDropCallback = fn(PacketDropInfo, usize);
+
+impl InterfaceInner {
+    /// Notify the configured packet drop callback, if any, that an inbound
+    /// packet was not delivered to a socket.
+    ///
+    /// This is a no-op when no callback has been installed, so it is cheap to
+    /// call from every drop site.
+    pub(crate) fn report_packet_drop(&self, info: PacketDropInfo) {
+        if let Some((callback, cookie)) = self.packet_drop_callback {
+            callback(info, cookie);
+        }
+    }
+}

--- a/src/iface/interface/ethernet.rs
+++ b/src/iface/interface/ethernet.rs
@@ -8,13 +8,16 @@ impl InterfaceInner {
         frame: &'frame [u8],
         fragments: &'frame mut FragmentsBuffer,
     ) -> Option<EthernetPacket<'frame>> {
-        let eth_frame = check!(EthernetFrame::new_checked(frame));
+        let eth_frame = check_report!(self, Some(frame), EthernetFrame::new_checked(frame));
 
         // Ignore any packets not directed to our hardware address or any of the multicast groups.
         if !eth_frame.dst_addr().is_broadcast()
             && !eth_frame.dst_addr().is_multicast()
             && HardwareAddress::Ethernet(eth_frame.dst_addr()) != self.hardware_addr
         {
+            self.report_packet_drop(
+                PacketDropInfo::new(PacketDropReason::NotForUs).with_frame(frame),
+            );
             return None;
         }
 
@@ -23,7 +26,11 @@ impl InterfaceInner {
             EthernetProtocol::Arp => self.process_arp(self.now, &eth_frame),
             #[cfg(feature = "proto-ipv4")]
             EthernetProtocol::Ipv4 => {
-                let ipv4_packet = check!(Ipv4Packet::new_checked(eth_frame.payload()));
+                let ipv4_packet = check_report!(
+                    self,
+                    Some(eth_frame.payload()),
+                    Ipv4Packet::new_checked(eth_frame.payload())
+                );
 
                 self.process_ipv4(
                     sockets,
@@ -36,12 +43,21 @@ impl InterfaceInner {
             }
             #[cfg(feature = "proto-ipv6")]
             EthernetProtocol::Ipv6 => {
-                let ipv6_packet = check!(Ipv6Packet::new_checked(eth_frame.payload()));
+                let ipv6_packet = check_report!(
+                    self,
+                    Some(eth_frame.payload()),
+                    Ipv6Packet::new_checked(eth_frame.payload())
+                );
                 self.process_ipv6(sockets, meta, eth_frame.src_addr().into(), &ipv6_packet)
                     .map(EthernetPacket::Ip)
             }
             // Drop all other traffic.
-            _ => None,
+            _ => {
+                self.report_packet_drop(
+                    PacketDropInfo::new(PacketDropReason::UnknownProtocol).with_frame(frame),
+                );
+                None
+            }
         }
     }
 

--- a/src/iface/interface/ieee802154.rs
+++ b/src/iface/interface/ieee802154.rs
@@ -16,13 +16,21 @@ impl InterfaceInner {
         sixlowpan_payload: &'payload [u8],
         _fragments: &'output mut FragmentsBuffer,
     ) -> Option<Packet<'output>> {
-        let ieee802154_frame = check!(Ieee802154Frame::new_checked(sixlowpan_payload));
+        let ieee802154_frame = check_report!(
+            self,
+            Some(sixlowpan_payload),
+            Ieee802154Frame::new_checked(sixlowpan_payload)
+        );
 
         if ieee802154_frame.frame_type() != Ieee802154FrameType::Data {
+            self.report_packet_drop(
+                PacketDropInfo::new(PacketDropReason::NotADataFrame).with_frame(sixlowpan_payload),
+            );
             return None;
         }
 
-        let ieee802154_repr = check!(Ieee802154Repr::parse(&ieee802154_frame));
+        let ieee802154_repr =
+            check_report!(self, Some(sixlowpan_payload), Ieee802154Repr::parse(&ieee802154_frame));
 
         // Drop frames when the user has set a PAN id and the PAN id from frame is not equal to this
         // When the user didn't set a PAN id (so it is None), then we accept all PAN id's.
@@ -34,6 +42,9 @@ impl InterfaceInner {
             net_debug!(
                 "IEEE802.15.4: dropping {:?} because not our PAN id (or not broadcast)",
                 ieee802154_repr
+            );
+            self.report_packet_drop(
+                PacketDropInfo::new(PacketDropReason::WrongPanId).with_frame(sixlowpan_payload),
             );
             return None;
         }

--- a/src/iface/interface/ipv4.rs
+++ b/src/iface/interface/ipv4.rs
@@ -100,10 +100,15 @@ impl InterfaceInner {
         ipv4_packet: &Ipv4Packet<&'a [u8]>,
         frag: &'a mut FragmentsBuffer,
     ) -> Option<Packet<'a>> {
-        let mut ipv4_repr = check!(Ipv4Repr::parse(ipv4_packet, &self.caps.checksum));
+        let mut ipv4_repr =
+            check_report!(self, None, Ipv4Repr::parse(ipv4_packet, &self.caps.checksum));
         if !self.is_unicast_v4(ipv4_repr.src_addr) && !ipv4_repr.src_addr.is_unspecified() {
             // Discard packets with non-unicast source addresses but allow unspecified
             net_debug!("non-unicast or unspecified source address");
+            self.report_packet_drop(
+                PacketDropInfo::new(PacketDropReason::NonUnicastSource)
+                    .with_ip_repr(IpRepr::Ipv4(ipv4_repr)),
+            );
             return None;
         }
 
@@ -116,6 +121,10 @@ impl InterfaceInner {
                     Ok(f) => f,
                     Err(_) => {
                         net_debug!("No available packet assembler for fragmented packet");
+                        self.report_packet_drop(
+                            PacketDropInfo::new(PacketDropReason::FragmentReassembly)
+                                .with_ip_repr(IpRepr::Ipv4(ipv4_repr)),
+                        );
                         return None;
                     }
                 };
@@ -130,6 +139,10 @@ impl InterfaceInner {
 
                 if let Err(e) = f.add(ipv4_packet.payload(), ipv4_packet.frag_offset() as usize) {
                     net_debug!("fragmentation error: {:?}", e);
+                    self.report_packet_drop(
+                        PacketDropInfo::new(PacketDropReason::FragmentReassembly)
+                            .with_ip_repr(IpRepr::Ipv4(ipv4_repr)),
+                    );
                     return None;
                 }
 
@@ -193,6 +206,10 @@ impl InterfaceInner {
                     "Rejecting IPv4 packet; {} is not a unicast address",
                     ipv4_repr.dst_addr
                 );
+                self.report_packet_drop(
+                    PacketDropInfo::new(PacketDropReason::NotForUsNonUnicast)
+                        .with_ip_repr(IpRepr::Ipv4(ipv4_repr)),
+                );
                 return None;
             }
 
@@ -203,10 +220,18 @@ impl InterfaceInner {
             {
                 net_trace!("Rejecting IPv4 packet; no matching routes");
 
+                self.report_packet_drop(
+                    PacketDropInfo::new(PacketDropReason::NoRoute)
+                        .with_ip_repr(IpRepr::Ipv4(ipv4_repr)),
+                );
                 return None;
             }
 
             net_trace!("Rejecting IPv4 packet; no assigned address");
+            self.report_packet_drop(
+                PacketDropInfo::new(PacketDropReason::NoSourceAddress)
+                    .with_ip_repr(IpRepr::Ipv4(ipv4_repr)),
+            );
             return None;
         }
 
@@ -238,6 +263,11 @@ impl InterfaceInner {
             _ if handled_by_raw_socket => None,
 
             _ => {
+                self.report_packet_drop(
+                    PacketDropInfo::new(PacketDropReason::UnknownTransportProtocol)
+                        .with_disposition(PacketDropDisposition::RepliedIcmpUnreachable)
+                        .with_ip_repr(IpRepr::Ipv4(ipv4_repr)),
+                );
                 // Send back as much of the original payload as we can.
                 let payload_len =
                     icmp_reply_payload_len(ip_payload.len(), IPV4_MIN_MTU, ipv4_repr.buffer_len());
@@ -257,8 +287,12 @@ impl InterfaceInner {
         timestamp: Instant,
         eth_frame: &EthernetFrame<&'frame [u8]>,
     ) -> Option<EthernetPacket<'frame>> {
-        let arp_packet = check!(ArpPacket::new_checked(eth_frame.payload()));
-        let arp_repr = check!(ArpRepr::parse(&arp_packet));
+        let arp_packet = check_report!(
+            self,
+            Some(eth_frame.payload()),
+            ArpPacket::new_checked(eth_frame.payload())
+        );
+        let arp_repr = check_report!(self, Some(eth_frame.payload()), ArpRepr::parse(&arp_packet));
 
         match arp_repr {
             ArpRepr::EthernetIpv4 {
@@ -270,23 +304,39 @@ impl InterfaceInner {
             } => {
                 // Only process ARP packets for us.
                 if !self.has_ip_addr(target_protocol_addr) {
+                    self.report_packet_drop(
+                        PacketDropInfo::new(PacketDropReason::ArpNotForUs)
+                            .with_frame(eth_frame.payload()),
+                    );
                     return None;
                 }
 
                 // Only process REQUEST and RESPONSE.
                 if let ArpOperation::Unknown(_) = operation {
                     net_debug!("arp: unknown operation code");
+                    self.report_packet_drop(
+                        PacketDropInfo::new(PacketDropReason::ArpInvalid)
+                            .with_frame(eth_frame.payload()),
+                    );
                     return None;
                 }
 
                 // Discard packets with non-unicast source addresses.
                 if !source_protocol_addr.x_is_unicast() || !source_hardware_addr.is_unicast() {
                     net_debug!("arp: non-unicast source address");
+                    self.report_packet_drop(
+                        PacketDropInfo::new(PacketDropReason::ArpInvalid)
+                            .with_frame(eth_frame.payload()),
+                    );
                     return None;
                 }
 
                 if !self.in_same_network(&IpAddress::Ipv4(source_protocol_addr)) {
                     net_debug!("arp: source IP address not in same network as us");
+                    self.report_packet_drop(
+                        PacketDropInfo::new(PacketDropReason::ArpInvalid)
+                            .with_frame(eth_frame.payload()),
+                    );
                     return None;
                 }
 
@@ -340,6 +390,14 @@ impl InterfaceInner {
             }
         }
 
+        // Whether an ICMP socket already consumed this message (always defined,
+        // regardless of the `socket-icmp` feature), so we don't report it as
+        // unhandled below.
+        #[cfg(feature = "socket-icmp")]
+        let icmp_handled = handled_by_icmp_socket;
+        #[cfg(not(feature = "socket-icmp"))]
+        let icmp_handled = false;
+
         match icmp_repr {
             // Respond to echo requests.
             #[cfg(all(feature = "proto-ipv4", feature = "auto-icmp-echo-reply"))]
@@ -357,7 +415,15 @@ impl InterfaceInner {
             }
 
             // Ignore any echo replies.
-            Icmpv4Repr::EchoReply { .. } => None,
+            Icmpv4Repr::EchoReply { .. } => {
+                if !icmp_handled {
+                    self.report_packet_drop(
+                        PacketDropInfo::new(PacketDropReason::IcmpUnhandled)
+                            .with_ip_repr(IpRepr::Ipv4(ip_repr)),
+                    );
+                }
+                None
+            }
 
             // Don't report an error if a packet with unknown type
             // has been handled by an ICMP socket
@@ -366,7 +432,13 @@ impl InterfaceInner {
 
             // FIXME: do something correct here?
             // By doing nothing, this arm handles the case when auto echo replies are disabled.
-            _ => None,
+            _ => {
+                self.report_packet_drop(
+                    PacketDropInfo::new(PacketDropReason::IcmpUnhandled)
+                        .with_ip_repr(IpRepr::Ipv4(ip_repr)),
+                );
+                None
+            }
         }
     }
 

--- a/src/iface/interface/ipv6.rs
+++ b/src/iface/interface/ipv6.rs
@@ -193,11 +193,15 @@ impl InterfaceInner {
         source_hardware_addr: HardwareAddress,
         ipv6_packet: &Ipv6Packet<&'frame [u8]>,
     ) -> Option<Packet<'frame>> {
-        let ipv6_repr = check!(Ipv6Repr::parse(ipv6_packet));
+        let ipv6_repr = check_report!(self, None, Ipv6Repr::parse(ipv6_packet));
 
         if !ipv6_repr.src_addr.x_is_unicast() {
             // Discard packets with non-unicast source addresses.
             net_debug!("non-unicast source address");
+            self.report_packet_drop(
+                PacketDropInfo::new(PacketDropReason::NonUnicastSource)
+                    .with_ip_repr(IpRepr::Ipv6(ipv6_repr)),
+            );
             return None;
         }
 
@@ -219,6 +223,10 @@ impl InterfaceInner {
                     "Rejecting IPv6 packet; {} is not a unicast address",
                     ipv6_repr.dst_addr
                 );
+                self.report_packet_drop(
+                    PacketDropInfo::new(PacketDropReason::NotForUsNonUnicast)
+                        .with_ip_repr(IpRepr::Ipv6(ipv6_repr)),
+                );
                 return None;
             }
 
@@ -229,10 +237,18 @@ impl InterfaceInner {
             {
                 net_trace!("Rejecting IPv6 packet; no matching routes");
 
+                self.report_packet_drop(
+                    PacketDropInfo::new(PacketDropReason::NoRoute)
+                        .with_ip_repr(IpRepr::Ipv6(ipv6_repr)),
+                );
                 return None;
             }
 
             net_trace!("Rejecting IPv6 packet; no assigned address");
+            self.report_packet_drop(
+                PacketDropInfo::new(PacketDropReason::NoSourceAddress)
+                    .with_ip_repr(IpRepr::Ipv6(ipv6_repr)),
+            );
             return None;
         }
 
@@ -350,6 +366,11 @@ impl InterfaceInner {
             _ if handled_by_raw_socket => None,
 
             _ => {
+                self.report_packet_drop(
+                    PacketDropInfo::new(PacketDropReason::UnknownTransportProtocol)
+                        .with_disposition(PacketDropDisposition::RepliedIcmpUnreachable)
+                        .with_ip_repr(IpRepr::Ipv6(ipv6_repr)),
+                );
                 // Send back as much of the original payload as we can.
                 let payload_len =
                     icmp_reply_payload_len(ip_payload.len(), IPV6_MIN_MTU, ipv6_repr.buffer_len());
@@ -396,6 +417,14 @@ impl InterfaceInner {
             }
         }
 
+        // Whether an ICMP socket already consumed this message (always defined,
+        // regardless of the `socket-icmp` feature), so we don't report it as
+        // unhandled below.
+        #[cfg(feature = "socket-icmp")]
+        let icmp_handled = handled_by_icmp_socket;
+        #[cfg(not(feature = "socket-icmp"))]
+        let icmp_handled = false;
+
         match icmp_repr {
             // Respond to echo requests.
             #[cfg(feature = "auto-icmp-echo-reply")]
@@ -413,7 +442,15 @@ impl InterfaceInner {
             }
 
             // Ignore any echo replies.
-            Icmpv6Repr::EchoReply { .. } => None,
+            Icmpv6Repr::EchoReply { .. } => {
+                if !icmp_handled {
+                    self.report_packet_drop(
+                        PacketDropInfo::new(PacketDropReason::IcmpUnhandled)
+                            .with_ip_repr(IpRepr::Ipv6(ip_repr)),
+                    );
+                }
+                None
+            }
 
             // Forward any NDISC packets to the ndisc packet handler
             #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
@@ -433,7 +470,15 @@ impl InterfaceInner {
                 {
                     self.process_mldv2(ip_repr, repr)
                 }
-                _ => None,
+                _ => {
+                    if !icmp_handled {
+                        self.report_packet_drop(
+                            PacketDropInfo::new(PacketDropReason::IcmpUnhandled)
+                                .with_ip_repr(IpRepr::Ipv6(ip_repr)),
+                        );
+                    }
+                    None
+                }
             },
 
             // Don't report an error if a packet with unknown type
@@ -443,7 +488,13 @@ impl InterfaceInner {
 
             // FIXME: do something correct here?
             // By doing nothing, this arm handles the case when auto echo replies are disabled.
-            _ => None,
+            _ => {
+                self.report_packet_drop(
+                    PacketDropInfo::new(PacketDropReason::IcmpUnhandled)
+                        .with_ip_repr(IpRepr::Ipv6(ip_repr)),
+                );
+                None
+            }
         }
     }
 

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -5,6 +5,8 @@
 #[cfg(test)]
 mod tests;
 
+mod drop;
+
 #[cfg(feature = "medium-ethernet")]
 mod ethernet;
 #[cfg(feature = "medium-ieee802154")]
@@ -25,6 +27,10 @@ mod tcp;
 mod udp;
 
 use super::packet::*;
+
+pub use self::drop::{
+    FiveTuple, PacketDropCallback, PacketDropDisposition, PacketDropInfo, PacketDropReason,
+};
 
 use core::result::Result;
 use heapless::Vec;
@@ -68,6 +74,34 @@ macro_rules! check {
     };
 }
 use check;
+
+/// Like [`check!`], but additionally reports a [`PacketDropReason::Malformed`]
+/// drop to the interface's packet drop callback.
+///
+/// A `macro_rules!` macro cannot refer to the caller's `self`, so the
+/// [`InterfaceInner`] must be passed in explicitly as the first argument. The
+/// second argument is an `Option<&[u8]>` of the raw bytes that failed to parse
+/// (pass `None` when unavailable), forwarded to the callback as
+/// [`PacketDropInfo::frame`].
+macro_rules! check_report {
+    ($iface:expr, $frame:expr, $e:expr) => {
+        match $e {
+            Ok(x) => x,
+            Err(_) => {
+                // concat!/stringify! doesn't work with defmt macros
+                #[cfg(not(feature = "defmt"))]
+                net_trace!(concat!("iface: malformed ", stringify!($e)));
+                #[cfg(feature = "defmt")]
+                net_trace!("iface: malformed");
+                $iface.report_packet_drop(
+                    PacketDropInfo::new(PacketDropReason::Malformed).with_optional_frame($frame),
+                );
+                return Default::default();
+            }
+        }
+    };
+}
+use check_report;
 
 /// Result returned by [`Interface::poll`].
 ///
@@ -155,6 +189,9 @@ pub struct InterfaceInner {
     routes: Routes,
     #[cfg(feature = "multicast")]
     multicast: multicast::State,
+    /// Callback invoked whenever an inbound packet is dropped, together with the
+    /// opaque cookie to pass it. See [`Interface::set_packet_drop_callback`].
+    packet_drop_callback: Option<(PacketDropCallback, usize)>,
 }
 
 /// Configuration structure used for creating a network interface.
@@ -285,6 +322,7 @@ impl Interface {
                 #[cfg(feature = "proto-ipv6-slaac")]
                 slaac_updated: Instant::from_millis(0),
                 rand,
+                packet_drop_callback: None,
             },
         }
     }
@@ -427,6 +465,71 @@ impl Interface {
     /// See [`set_any_ip`](Self::set_any_ip) for details on AnyIP
     pub fn any_ip(&self) -> bool {
         self.inner.any_ip
+    }
+
+    /// Set a callback to be invoked whenever the interface does not deliver an
+    /// inbound packet to a socket.
+    ///
+    /// The interface declines to deliver an inbound packet to a socket in many
+    /// situations: when it is malformed, when it is not addressed to this
+    /// interface, when no route or local address is available to handle it, when
+    /// no socket is listening for it, and so on. Some of these are silent drops;
+    /// others the stack rejects by sending a reply (a TCP RST, or an ICMP
+    /// "unreachable"). In all of these cases the callback is invoked with a
+    /// [`PacketDropInfo`] describing the [reason](PacketDropReason), the
+    /// [disposition](PacketDropDisposition) (silently dropped, or rejected with a
+    /// reply), and — where they are available for free — parsed and/or raw
+    /// details of the offending packet.
+    ///
+    /// This is intended for diagnostics, logging or metrics, and in particular
+    /// for VPN-style use cases that want to observe which inbound flows are not
+    /// being handled (see [`PacketDropInfo::five_tuple`]). It is *not* invoked
+    /// for packets that are successfully delivered to a socket.
+    ///
+    /// The callback is a plain `fn` pointer so that it works without an allocator
+    /// and therefore cannot capture state. To let it reach your application
+    /// state, you supply an opaque `usize` *cookie* alongside it; the interface
+    /// stores the cookie and passes it back as the callback's second argument on
+    /// every invocation, without ever interpreting it. Use it as an index into
+    /// your own table, a tag, or (with your own `unsafe`) a pointer back to your
+    /// state. (If you don't need it, pass `0`.)
+    ///
+    /// Pass `None` to remove a previously-installed callback.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use core::sync::atomic::{AtomicUsize, Ordering};
+    /// use smoltcp::iface::PacketDropInfo;
+    ///
+    /// static DROPPED: AtomicUsize = AtomicUsize::new(0);
+    ///
+    /// // `cookie` is the opaque value you passed to `set_packet_drop_callback`.
+    /// fn on_drop(info: PacketDropInfo, cookie: usize) {
+    ///     DROPPED.fetch_add(1, Ordering::Relaxed);
+    ///     # let _ = (info.reason, cookie);
+    /// }
+    ///
+    /// # #[cfg(all(feature = "medium-ethernet", feature = "alloc"))] {
+    /// # use smoltcp::iface::{Config, Interface};
+    /// # use smoltcp::phy::{Loopback, Medium};
+    /// # use smoltcp::time::Instant;
+    /// # let mut device = Loopback::new(Medium::Ethernet);
+    /// # let config = Config::new(smoltcp::wire::EthernetAddress([2, 0, 0, 0, 0, 1]).into());
+    /// # let mut iface = Interface::new(config, &mut device, Instant::ZERO);
+    /// iface.set_packet_drop_callback(Some((on_drop, 0)));
+    /// # }
+    /// ```
+    pub fn set_packet_drop_callback(&mut self, callback: Option<(PacketDropCallback, usize)>) {
+        self.inner.packet_drop_callback = callback;
+    }
+
+    /// Get the currently installed inbound packet drop callback and its cookie,
+    /// if any.
+    ///
+    /// See [`set_packet_drop_callback`](Self::set_packet_drop_callback).
+    pub fn packet_drop_callback(&self) -> Option<(PacketDropCallback, usize)> {
+        self.inner.packet_drop_callback
     }
 
     /// Get the packet reassembly timeout.
@@ -927,16 +1030,23 @@ impl InterfaceInner {
         match IpVersion::of_packet(ip_payload) {
             #[cfg(feature = "proto-ipv4")]
             Ok(IpVersion::Ipv4) => {
-                let ipv4_packet = check!(Ipv4Packet::new_checked(ip_payload));
+                let ipv4_packet =
+                    check_report!(self, Some(ip_payload), Ipv4Packet::new_checked(ip_payload));
                 self.process_ipv4(sockets, meta, HardwareAddress::Ip, &ipv4_packet, frag)
             }
             #[cfg(feature = "proto-ipv6")]
             Ok(IpVersion::Ipv6) => {
-                let ipv6_packet = check!(Ipv6Packet::new_checked(ip_payload));
+                let ipv6_packet =
+                    check_report!(self, Some(ip_payload), Ipv6Packet::new_checked(ip_payload));
                 self.process_ipv6(sockets, meta, HardwareAddress::Ip, &ipv6_packet)
             }
             // Drop all other traffic.
-            _ => None,
+            _ => {
+                self.report_packet_drop(
+                    PacketDropInfo::new(PacketDropReason::UnknownProtocol).with_frame(ip_payload),
+                );
+                None
+            }
         }
     }
 

--- a/src/iface/interface/sixlowpan.rs
+++ b/src/iface/interface/sixlowpan.rs
@@ -57,12 +57,20 @@ impl InterfaceInner {
         payload: &'payload [u8],
         f: &'output mut FragmentsBuffer,
     ) -> Option<Packet<'output>> {
-        let payload = match check!(SixlowpanPacket::dispatch(payload)) {
+        let original_payload = payload;
+        let payload = match check_report!(
+            self,
+            Some(original_payload),
+            SixlowpanPacket::dispatch(payload)
+        ) {
             #[cfg(not(feature = "proto-sixlowpan-fragmentation"))]
             SixlowpanPacket::FragmentHeader => {
                 net_debug!(
                     "Fragmentation is not supported, \
                     use the `proto-sixlowpan-fragmentation` feature to add support."
+                );
+                self.report_packet_drop(
+                    PacketDropInfo::new(PacketDropReason::Sixlowpan).with_frame(original_payload),
                 );
                 return None;
             }
@@ -81,6 +89,10 @@ impl InterfaceInner {
                     Ok(len) => &f.decompress_buf[..len],
                     Err(e) => {
                         net_debug!("sixlowpan decompress failed: {:?}", e);
+                        self.report_packet_drop(
+                            PacketDropInfo::new(PacketDropReason::Sixlowpan)
+                                .with_frame(original_payload),
+                        );
                         return None;
                     }
                 }
@@ -94,7 +106,7 @@ impl InterfaceInner {
                 Some(s) => HardwareAddress::Ieee802154(s),
                 None => HardwareAddress::Ieee802154(Ieee802154Address::Absent),
             },
-            &check!(Ipv6Packet::new_checked(payload)),
+            &check_report!(self, None, Ipv6Packet::new_checked(payload)),
         )
     }
 

--- a/src/iface/interface/tcp.rs
+++ b/src/iface/interface/tcp.rs
@@ -18,16 +18,19 @@ impl InterfaceInner {
         // This is not done at the iface level because it might be useful with
         // UDP or raw sockets, but it's definitely not useful for TCP.
         if src_addr.is_unspecified() || dst_addr.is_unspecified() {
+            self.report_packet_drop(
+                PacketDropInfo::new(PacketDropReason::TcpUnspecifiedEndpoint)
+                    .with_ip_repr(ip_repr.clone()),
+            );
             return None;
         }
 
-        let tcp_packet = check!(TcpPacket::new_checked(ip_payload));
-        let tcp_repr = check!(TcpRepr::parse(
-            &tcp_packet,
-            &src_addr,
-            &dst_addr,
-            &self.caps.checksum
-        ));
+        let tcp_packet = check_report!(self, None, TcpPacket::new_checked(ip_payload));
+        let tcp_repr = check_report!(
+            self,
+            None,
+            TcpRepr::parse(&tcp_packet, &src_addr, &dst_addr, &self.caps.checksum)
+        );
 
         for tcp_socket in sockets
             .items_mut()
@@ -48,9 +51,24 @@ impl InterfaceInner {
             // Never reply to a TCP RST packet with another TCP RST packet.
             // Never send a TCP RST packet with unspecified addresses.
             // Never send a TCP RST when packet has been handled by raw socket.
+            if !handled_by_raw_socket {
+                // The segment found no socket and we won't reply; report it as a
+                // silent drop. (When handled by a raw socket it isn't a drop.)
+                self.report_packet_drop(
+                    PacketDropInfo::new(PacketDropReason::TcpNoSocket)
+                        .with_ip_repr(ip_repr.clone())
+                        .with_ports(tcp_repr.src_port, tcp_repr.dst_port),
+                );
+            }
             None
         } else {
             // The packet wasn't handled by a socket, send a TCP RST packet.
+            self.report_packet_drop(
+                PacketDropInfo::new(PacketDropReason::TcpNoSocket)
+                    .with_disposition(PacketDropDisposition::RepliedTcpReset)
+                    .with_ip_repr(ip_repr.clone())
+                    .with_ports(tcp_repr.src_port, tcp_repr.dst_port),
+            );
             let (ip, tcp) = tcp::Socket::rst_reply(&ip_repr, &tcp_repr);
             Some(Packet::new(ip, IpPayload::Tcp(tcp)))
         }

--- a/src/iface/interface/tests/drop.rs
+++ b/src/iface/interface/tests/drop.rs
@@ -1,0 +1,434 @@
+//! Tests for the inbound packet drop / non-delivery callback.
+
+use super::*;
+
+use core::cell::RefCell;
+
+use crate::tests::setup;
+
+/// An owned, `'static` copy of the parts of a [`PacketDropInfo`] we want to
+/// assert on (the real struct borrows the frame, so it can't be stored), plus
+/// the opaque cookie that was passed to the callback.
+#[derive(Debug, Clone, PartialEq)]
+struct RecordedDrop {
+    reason: PacketDropReason,
+    disposition: PacketDropDisposition,
+    five_tuple: Option<FiveTuple>,
+    had_frame: bool,
+    cookie: usize,
+}
+
+thread_local! {
+    static RECORDED: RefCell<Vec<RecordedDrop>> = const { RefCell::new(Vec::new()) };
+}
+
+/// The cookie we hand to the interface; the callback must receive it verbatim.
+const TEST_COOKIE: usize = 0xdead_beef;
+
+fn record_drop(info: PacketDropInfo, cookie: usize) {
+    RECORDED.with(|r| {
+        r.borrow_mut().push(RecordedDrop {
+            reason: info.reason,
+            disposition: info.disposition,
+            five_tuple: info.five_tuple(),
+            had_frame: info.frame.is_some(),
+            cookie,
+        })
+    });
+}
+
+fn take_recorded() -> Vec<RecordedDrop> {
+    RECORDED.with(|r| core::mem::take(&mut *r.borrow_mut()))
+}
+
+fn clear_recorded() {
+    RECORDED.with(|r| r.borrow_mut().clear());
+}
+
+/// A TCP segment for us that matches no socket is dropped with a TCP RST reply,
+/// and the callback reports the flow's 5-tuple.
+#[cfg(feature = "socket-tcp")]
+#[test]
+fn test_drop_tcp_no_socket() {
+    use crate::wire::{TcpControl, TcpRepr, TcpSeqNumber};
+
+    clear_recorded();
+    let (mut iface, mut sockets, _device) = setup(Medium::Ip);
+    iface.set_packet_drop_callback(Some((record_drop, TEST_COOKIE)));
+
+    let tcp_repr = TcpRepr {
+        src_port: 49500,
+        dst_port: 80,
+        control: TcpControl::Syn,
+        seq_number: TcpSeqNumber(0),
+        ack_number: None,
+        window_len: 1500,
+        window_scale: None,
+        max_seg_size: None,
+        sack_permitted: false,
+        sack_ranges: [None, None, None],
+        timestamp: None,
+        payload: &[],
+    };
+    let ip_repr = IpRepr::Ipv4(Ipv4Repr {
+        src_addr: Ipv4Address::new(192, 168, 1, 2),
+        dst_addr: Ipv4Address::new(192, 168, 1, 1),
+        next_header: IpProtocol::Tcp,
+        payload_len: tcp_repr.buffer_len(),
+        hop_limit: 64,
+    });
+
+    let mut bytes = vec![0xa5u8; tcp_repr.buffer_len()];
+    tcp_repr.emit(
+        &mut TcpPacket::new_unchecked(&mut bytes),
+        &ip_repr.src_addr(),
+        &ip_repr.dst_addr(),
+        &ChecksumCapabilities::default(),
+    );
+
+    // Not handled by a socket -> a RST reply is generated.
+    let reply = iface
+        .inner
+        .process_tcp(&mut sockets, false, ip_repr, &bytes);
+    assert!(reply.is_some());
+
+    let recorded = take_recorded();
+    assert_eq!(recorded.len(), 1);
+    let drop = &recorded[0];
+    assert_eq!(drop.reason, PacketDropReason::TcpNoSocket);
+    assert_eq!(drop.disposition, PacketDropDisposition::RepliedTcpReset);
+    // The opaque cookie is passed back to the callback verbatim.
+    assert_eq!(drop.cookie, TEST_COOKIE);
+    let ft = drop.five_tuple.expect("five-tuple should be present");
+    assert_eq!(ft.protocol, IpProtocol::Tcp);
+    assert_eq!(ft.src.addr, IpAddress::v4(192, 168, 1, 2));
+    assert_eq!(ft.src.port, 49500);
+    assert_eq!(ft.dst.addr, IpAddress::v4(192, 168, 1, 1));
+    assert_eq!(ft.dst.port, 80);
+}
+
+/// A UDP datagram for us that matches no socket is dropped with an ICMP port
+/// unreachable reply, and the callback reports the flow's 5-tuple.
+#[cfg(feature = "socket-udp")]
+#[test]
+fn test_drop_udp_no_socket() {
+    use crate::wire::UdpRepr;
+
+    clear_recorded();
+    let (mut iface, mut sockets, _device) = setup(Medium::Ip);
+    iface.set_packet_drop_callback(Some((record_drop, TEST_COOKIE)));
+
+    let udp_repr = UdpRepr {
+        src_port: 12345,
+        dst_port: 54321,
+    };
+    static PAYLOAD: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
+    let ip_repr = IpRepr::Ipv4(Ipv4Repr {
+        src_addr: Ipv4Address::new(192, 168, 1, 2),
+        dst_addr: Ipv4Address::new(192, 168, 1, 1),
+        next_header: IpProtocol::Udp,
+        payload_len: udp_repr.header_len() + PAYLOAD.len(),
+        hop_limit: 64,
+    });
+
+    let mut bytes = vec![0u8; udp_repr.header_len() + PAYLOAD.len()];
+    udp_repr.emit(
+        &mut UdpPacket::new_unchecked(&mut bytes),
+        &ip_repr.src_addr(),
+        &ip_repr.dst_addr(),
+        PAYLOAD.len(),
+        |buf| buf.copy_from_slice(&PAYLOAD),
+        &ChecksumCapabilities::default(),
+    );
+
+    let reply =
+        iface
+            .inner
+            .process_udp(&mut sockets, PacketMeta::default(), false, ip_repr, &bytes);
+    assert!(reply.is_some());
+
+    let recorded = take_recorded();
+    assert_eq!(recorded.len(), 1);
+    let drop = &recorded[0];
+    assert_eq!(drop.reason, PacketDropReason::UdpNoSocket);
+    assert_eq!(
+        drop.disposition,
+        PacketDropDisposition::RepliedIcmpUnreachable
+    );
+    let ft = drop.five_tuple.expect("five-tuple should be present");
+    assert_eq!(ft.protocol, IpProtocol::Udp);
+    assert_eq!(ft.src.port, 12345);
+    assert_eq!(ft.dst.port, 54321);
+}
+
+/// A well-formed IP packet for us carrying a protocol with no socket / handler
+/// is dropped with an ICMP unreachable reply.
+#[test]
+fn test_drop_unknown_protocol() {
+    clear_recorded();
+    let (mut iface, mut sockets, _device) = setup(Medium::Ip);
+    iface.set_packet_drop_callback(Some((record_drop, TEST_COOKIE)));
+
+    let repr = IpRepr::Ipv4(Ipv4Repr {
+        src_addr: Ipv4Address::new(192, 168, 1, 2),
+        dst_addr: Ipv4Address::new(192, 168, 1, 1),
+        next_header: IpProtocol::Unknown(0x0c),
+        payload_len: 0,
+        hop_limit: 64,
+    });
+    let mut bytes = vec![0u8; repr.buffer_len()];
+    repr.emit(&mut bytes, &ChecksumCapabilities::default());
+    let frame = Ipv4Packet::new_unchecked(&bytes[..]);
+
+    let reply = iface.inner.process_ipv4(
+        &mut sockets,
+        PacketMeta::default(),
+        HardwareAddress::default(),
+        &frame,
+        &mut iface.fragments,
+    );
+    assert!(reply.is_some());
+
+    let recorded = take_recorded();
+    assert_eq!(recorded.len(), 1);
+    assert_eq!(recorded[0].reason, PacketDropReason::UnknownTransportProtocol);
+    assert_eq!(
+        recorded[0].disposition,
+        PacketDropDisposition::RepliedIcmpUnreachable
+    );
+    let ft = recorded[0].five_tuple.expect("five-tuple present");
+    assert_eq!(ft.protocol, IpProtocol::Unknown(0x0c));
+    // No transport header was parsed, so ports default to 0.
+    assert_eq!(ft.src.port, 0);
+    assert_eq!(ft.dst.port, 0);
+}
+
+/// An IP packet whose destination is neither ours nor routable is silently
+/// dropped, and the callback reports it with no reply.
+#[test]
+fn test_drop_not_for_us_no_route() {
+    clear_recorded();
+    let (mut iface, mut sockets, _device) = setup(Medium::Ip);
+    iface.set_packet_drop_callback(Some((record_drop, TEST_COOKIE)));
+
+    // Destination is a unicast address that is not ours and has no route.
+    let repr = IpRepr::Ipv4(Ipv4Repr {
+        src_addr: Ipv4Address::new(192, 168, 1, 2),
+        dst_addr: Ipv4Address::new(10, 9, 8, 7),
+        next_header: IpProtocol::Udp,
+        payload_len: 0,
+        hop_limit: 64,
+    });
+    let mut bytes = vec![0u8; repr.buffer_len()];
+    repr.emit(&mut bytes, &ChecksumCapabilities::default());
+    let frame = Ipv4Packet::new_unchecked(&bytes[..]);
+
+    let reply = iface.inner.process_ipv4(
+        &mut sockets,
+        PacketMeta::default(),
+        HardwareAddress::default(),
+        &frame,
+        &mut iface.fragments,
+    );
+    // Silently dropped, no reply.
+    assert!(reply.is_none());
+
+    let recorded = take_recorded();
+    assert_eq!(recorded.len(), 1);
+    assert_eq!(recorded[0].reason, PacketDropReason::NoRoute);
+    assert_eq!(recorded[0].disposition, PacketDropDisposition::Dropped);
+    assert_eq!(
+        recorded[0].five_tuple.map(|ft| ft.dst.addr),
+        Some(IpAddress::v4(10, 9, 8, 7))
+    );
+}
+
+/// A malformed IP packet is reported as a `Malformed` drop with the raw frame
+/// bytes attached and no parsed 5-tuple.
+#[test]
+fn test_drop_malformed() {
+    clear_recorded();
+    let (mut iface, mut sockets, _device) = setup(Medium::Ip);
+    iface.set_packet_drop_callback(Some((record_drop, TEST_COOKIE)));
+
+    // An IPv4 header claiming a total length far larger than the buffer fails
+    // `Ipv4Repr::parse`.
+    let mut bytes = vec![0u8; 20];
+    bytes[0] = 0x45; // version 4, IHL 5
+    bytes[3] = 0xff; // total length = 255, but buffer is only 20 bytes
+    let frame = Ipv4Packet::new_unchecked(&bytes[..]);
+
+    let reply = iface.inner.process_ipv4(
+        &mut sockets,
+        PacketMeta::default(),
+        HardwareAddress::default(),
+        &frame,
+        &mut iface.fragments,
+    );
+    assert!(reply.is_none());
+
+    let recorded = take_recorded();
+    assert_eq!(recorded.len(), 1);
+    assert_eq!(recorded[0].reason, PacketDropReason::Malformed);
+    assert_eq!(recorded[0].disposition, PacketDropDisposition::Dropped);
+    assert!(recorded[0].five_tuple.is_none());
+}
+
+/// No callback is invoked for a packet that is delivered to a socket, and
+/// removing the callback stops notifications.
+#[cfg(feature = "socket-udp")]
+#[test]
+fn test_no_drop_when_delivered_and_callback_removable() {
+    use crate::socket::udp;
+    use crate::wire::UdpRepr;
+
+    clear_recorded();
+    let (mut iface, mut sockets, _device) = setup(Medium::Ip);
+    iface.set_packet_drop_callback(Some((record_drop, TEST_COOKIE)));
+
+    // Bind a UDP socket on the destination port.
+    let rx = udp::PacketBuffer::new(vec![udp::PacketMetadata::EMPTY], vec![0; 64]);
+    let tx = udp::PacketBuffer::new(vec![udp::PacketMetadata::EMPTY], vec![0; 64]);
+    let mut socket = udp::Socket::new(rx, tx);
+    socket.bind(54321).unwrap();
+    let handle = sockets.add(socket);
+
+    let udp_repr = UdpRepr {
+        src_port: 12345,
+        dst_port: 54321,
+    };
+    static PAYLOAD: [u8; 4] = [1, 2, 3, 4];
+    let ip_repr = IpRepr::Ipv4(Ipv4Repr {
+        src_addr: Ipv4Address::new(192, 168, 1, 2),
+        dst_addr: Ipv4Address::new(192, 168, 1, 1),
+        next_header: IpProtocol::Udp,
+        payload_len: udp_repr.header_len() + PAYLOAD.len(),
+        hop_limit: 64,
+    });
+    let mut bytes = vec![0u8; udp_repr.header_len() + PAYLOAD.len()];
+    udp_repr.emit(
+        &mut UdpPacket::new_unchecked(&mut bytes),
+        &ip_repr.src_addr(),
+        &ip_repr.dst_addr(),
+        PAYLOAD.len(),
+        |buf| buf.copy_from_slice(&PAYLOAD),
+        &ChecksumCapabilities::default(),
+    );
+
+    iface.inner.process_udp(
+        &mut sockets,
+        PacketMeta::default(),
+        false,
+        ip_repr,
+        &bytes,
+    );
+
+    // The datagram was delivered to the socket: no drop reported.
+    assert!(take_recorded().is_empty());
+    let _ = handle;
+
+    // Removing the callback stops further notifications.
+    iface.set_packet_drop_callback(None);
+    assert!(iface.packet_drop_callback().is_none());
+}
+
+/// An ICMP message that no socket handled and that the stack does not answer
+/// (here, an unsolicited echo *reply*) is reported as `IcmpUnhandled`, dropped
+/// with no reply.
+#[test]
+fn test_drop_icmp_unhandled() {
+    use crate::wire::{Icmpv4Packet, Icmpv4Repr};
+
+    clear_recorded();
+    let (mut iface, mut sockets, _device) = setup(Medium::Ip);
+    iface.set_packet_drop_callback(Some((record_drop, TEST_COOKIE)));
+
+    // Build an ICMP echo *reply* (which we never solicited) addressed to us.
+    static ECHO_DATA: [u8; 4] = [b'p', b'i', b'n', b'g'];
+    let echo_reply = Icmpv4Repr::EchoReply {
+        ident: 0x1234,
+        seq_no: 1,
+        data: &ECHO_DATA,
+    };
+    let mut icmp_bytes = vec![0u8; echo_reply.buffer_len()];
+    echo_reply.emit(
+        &mut Icmpv4Packet::new_unchecked(&mut icmp_bytes),
+        &ChecksumCapabilities::default(),
+    );
+
+    let ipv4_repr = Ipv4Repr {
+        src_addr: Ipv4Address::new(192, 168, 1, 2),
+        dst_addr: Ipv4Address::new(192, 168, 1, 1),
+        next_header: IpProtocol::Icmp,
+        payload_len: echo_reply.buffer_len(),
+        hop_limit: 64,
+    };
+
+    let reply = iface
+        .inner
+        .process_icmpv4(&mut sockets, ipv4_repr, &icmp_bytes);
+    // Echo replies are ignored: no reply generated.
+    assert!(reply.is_none());
+
+    let recorded = take_recorded();
+    assert_eq!(recorded.len(), 1);
+    assert_eq!(recorded[0].reason, PacketDropReason::IcmpUnhandled);
+    assert_eq!(recorded[0].disposition, PacketDropDisposition::Dropped);
+    assert_eq!(recorded[0].cookie, TEST_COOKIE);
+    assert_eq!(
+        recorded[0].five_tuple.map(|ft| ft.protocol),
+        Some(IpProtocol::Icmp)
+    );
+}
+
+/// The opaque cookie is stored and returned by the getter, and can be used as an
+/// index to route drops into per-context buckets (the canonical "user data" use
+/// case).
+#[test]
+fn test_cookie_as_index() {
+    // Per-context drop counters; the cookie selects which one to bump.
+    thread_local! {
+        static COUNTERS: RefCell<[usize; 4]> = const { RefCell::new([0; 4]) };
+    }
+
+    fn count_by_cookie(_info: PacketDropInfo, cookie: usize) {
+        COUNTERS.with(|c| c.borrow_mut()[cookie] += 1);
+    }
+
+    let (mut iface, mut sockets, _device) = setup(Medium::Ip);
+
+    // Install the callback with cookie = 2 (an index into COUNTERS).
+    iface.set_packet_drop_callback(Some((count_by_cookie, 2)));
+    assert_eq!(
+        iface.packet_drop_callback().map(|(_, cookie)| cookie),
+        Some(2)
+    );
+
+    // Drive a packet that gets dropped (destination not for us, no route).
+    let repr = IpRepr::Ipv4(Ipv4Repr {
+        src_addr: Ipv4Address::new(192, 168, 1, 2),
+        dst_addr: Ipv4Address::new(10, 9, 8, 7),
+        next_header: IpProtocol::Udp,
+        payload_len: 0,
+        hop_limit: 64,
+    });
+    let mut bytes = vec![0u8; repr.buffer_len()];
+    repr.emit(&mut bytes, &ChecksumCapabilities::default());
+    let frame = Ipv4Packet::new_unchecked(&bytes[..]);
+    iface.inner.process_ipv4(
+        &mut sockets,
+        PacketMeta::default(),
+        HardwareAddress::default(),
+        &frame,
+        &mut iface.fragments,
+    );
+
+    // Only bucket 2 (our cookie) was incremented.
+    COUNTERS.with(|c| {
+        let c = c.borrow();
+        assert_eq!(c[2], 1);
+        assert_eq!(c[0], 0);
+        assert_eq!(c[1], 0);
+        assert_eq!(c[3], 0);
+    });
+}

--- a/src/iface/interface/tests/mod.rs
+++ b/src/iface/interface/tests/mod.rs
@@ -5,6 +5,9 @@ mod ipv6;
 #[cfg(feature = "proto-sixlowpan")]
 mod sixlowpan;
 
+#[cfg(all(feature = "medium-ip", feature = "proto-ipv4"))]
+mod drop;
+
 #[allow(unused)]
 use std::vec::Vec;
 

--- a/src/iface/interface/udp.rs
+++ b/src/iface/interface/udp.rs
@@ -16,13 +16,12 @@ impl InterfaceInner {
         ip_payload: &'frame [u8],
     ) -> Option<Packet<'frame>> {
         let (src_addr, dst_addr) = (ip_repr.src_addr(), ip_repr.dst_addr());
-        let udp_packet = check!(UdpPacket::new_checked(ip_payload));
-        let udp_repr = check!(UdpRepr::parse(
-            &udp_packet,
-            &src_addr,
-            &dst_addr,
-            &self.caps.checksum
-        ));
+        let udp_packet = check_report!(self, None, UdpPacket::new_checked(ip_payload));
+        let udp_repr = check_report!(
+            self,
+            None,
+            UdpRepr::parse(&udp_packet, &src_addr, &dst_addr, &self.caps.checksum)
+        );
 
         #[cfg(feature = "socket-udp")]
         for udp_socket in sockets
@@ -54,6 +53,12 @@ impl InterfaceInner {
             IpRepr::Ipv6(_) if handled_by_raw_socket => None,
             #[cfg(feature = "proto-ipv4")]
             IpRepr::Ipv4(ipv4_repr) => {
+                self.report_packet_drop(
+                    PacketDropInfo::new(PacketDropReason::UdpNoSocket)
+                        .with_disposition(PacketDropDisposition::RepliedIcmpUnreachable)
+                        .with_ip_repr(IpRepr::Ipv4(ipv4_repr))
+                        .with_ports(udp_repr.src_port, udp_repr.dst_port),
+                );
                 let payload_len =
                     icmp_reply_payload_len(ip_payload.len(), IPV4_MIN_MTU, ipv4_repr.buffer_len());
                 let icmpv4_reply_repr = Icmpv4Repr::DstUnreachable {
@@ -65,6 +70,12 @@ impl InterfaceInner {
             }
             #[cfg(feature = "proto-ipv6")]
             IpRepr::Ipv6(ipv6_repr) => {
+                self.report_packet_drop(
+                    PacketDropInfo::new(PacketDropReason::UdpNoSocket)
+                        .with_disposition(PacketDropDisposition::RepliedIcmpUnreachable)
+                        .with_ip_repr(IpRepr::Ipv6(ipv6_repr))
+                        .with_ports(udp_repr.src_port, udp_repr.dst_port),
+                );
                 let payload_len =
                     icmp_reply_payload_len(ip_payload.len(), IPV6_MIN_MTU, ipv6_repr.buffer_len());
                 let icmpv6_reply_repr = Icmpv6Repr::DstUnreachable {

--- a/src/iface/mod.rs
+++ b/src/iface/mod.rs
@@ -21,7 +21,8 @@ mod packet;
 #[cfg(feature = "multicast")]
 pub use self::interface::multicast::MulticastError;
 pub use self::interface::{
-    Config, Interface, InterfaceInner as Context, PollIngressSingleResult, PollResult,
+    Config, FiveTuple, Interface, InterfaceInner as Context, PacketDropCallback,
+    PacketDropDisposition, PacketDropInfo, PacketDropReason, PollIngressSingleResult, PollResult,
 };
 
 pub use self::route::{Route, RouteTableFull, Routes};


### PR DESCRIPTION
Add `Interface::set_packet_drop_callback` to observe inbound packets that the interface does not deliver to a socket: both silent drops (malformed, not-for-us, no route, unhandled ICMP, ...) and well-formed packets it rejects with a reply (TCP RST, ICMP unreachable).

The callback receives a `PacketDropInfo` carrying the `PacketDropReason`, the `PacketDropDisposition` (dropped vs. replied), and — where parsed for free — the offending packet's IP header, transport ports and/or raw bytes (`PacketDropInfo::five_tuple`). An opaque `usize` cookie supplied with the callback is passed back on each invocation, so the capture-less `fn` callback can reach application state without an allocator and without any `unsafe` in the core iface.

Drops are reported across the ethernet, IP-demux, IPv4, IPv6, ARP, TCP, UDP, ICMP, IEEE 802.15.4 and 6LoWPAN receive paths. Malformed-packet drops go through a new `check_report!` macro (a self-aware sibling of `check!`). Reporting is a no-op when no callback is installed.