### PR TITLE
Minimum impl of RFC 4861 for RFC 6775 Work

### DIFF
--- a/src/iface/interface/ipv6.rs
+++ b/src/iface/interface/ipv6.rs
@@ -513,7 +513,7 @@ impl InterfaceInner {
                 router_lifetime,
                 reachable_time: _,
                 retrans_time: _,
-                lladdr: _,
+                lladdr,
                 mtu: _,
                 prefix_info,
             } if self.slaac_enabled => {
@@ -522,6 +522,17 @@ impl InterfaceInner {
                         || ip_repr.dst_addr.is_link_local())
                     && ip_repr.hop_limit == 255
                 {
+                    // Capture the router's link-layer address so unicast NS (e.g. for RFC 6775
+                    // ARO) can be sent without a prior broadcast solicitation.
+                    #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
+                    if let Some(lladdr) = lladdr {
+                        if let Ok(hw_addr) = lladdr.parse(self.caps.medium) {
+                            if hw_addr.is_unicast() && ip_repr.src_addr.x_is_unicast() {
+                                self.neighbor_cache
+                                    .fill(ip_repr.src_addr.into(), hw_addr, self.now);
+                            }
+                        }
+                    }
                     self.slaac.process_advertisement(
                         &ip_repr.src_addr,
                         router_lifetime,

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -411,6 +411,15 @@ impl Interface {
         &mut self.inner.routes
     }
 
+    /// Returns an iterator over all IPv6 default routers known to this interface.
+    ///
+    /// These are the routers learned from Router Advertisements (`::/0` routes). RFC 6775 ARO
+    /// registration must be sent to each of these routers.
+    #[cfg(feature = "proto-ipv6")]
+    pub fn default_ipv6_routers(&self) -> impl Iterator<Item = Ipv6Address> + '_ {
+        self.inner.routes.default_ipv6_routers()
+    }
+
     /// Enable or disable the AnyIP capability.
     ///
     /// AnyIP allowins packets to be received

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -384,8 +384,11 @@ impl Interface {
     /// # Panics
     /// This function panics if any of the addresses are not unicast.
     pub fn update_ip_addrs<F: FnOnce(&mut Vec<IpCidr, IFACE_MAX_ADDR_COUNT>)>(&mut self, f: F) {
+        let old = self.inner.ip_addrs.clone();
         f(&mut self.inner.ip_addrs);
-        InterfaceInner::flush_neighbor_cache(&mut self.inner);
+        if old != self.inner.ip_addrs {
+            InterfaceInner::flush_neighbor_cache(&mut self.inner);
+        }
         InterfaceInner::check_ip_addrs(&self.inner.ip_addrs);
 
         #[cfg(all(
@@ -1205,6 +1208,7 @@ impl InterfaceInner {
         #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
         self.neighbor_cache.flush()
     }
+
 
     fn dispatch_ip<Tx: TxToken>(
         &mut self,

--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -1032,6 +1032,13 @@ impl InterfaceInner {
         self.routes.lookup(addr, timestamp)
     }
 
+    /// Return whether the neighbor cache has a live entry for the given address (direct lookup,
+    /// no routing). Used by tests to verify SLLAO capture without going through routing logic.
+    #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
+    pub(crate) fn neighbor_cache_has(&self, addr: IpAddress) -> bool {
+        self.neighbor_cache.lookup(&addr, self.now).found()
+    }
+
     fn has_neighbor(&self, addr: &IpAddress) -> bool {
         match self.route(addr, self.now) {
             Some(_routed_addr) => match self.caps.medium {

--- a/src/iface/interface/tests/ipv6.rs
+++ b/src/iface/interface/tests/ipv6.rs
@@ -1866,3 +1866,224 @@ fn test_solicited_node_multicast_autojoin(#[case] medium: Medium) {
     assert!(!iface.has_multicast_group(addr1.solicited_node()));
     assert!(!iface.has_multicast_group(addr2.solicited_node()));
 }
+
+/// Helper: build and inject an Ethernet-framed RouterAdvert into the interface.
+#[cfg(all(feature = "proto-ipv6-slaac", feature = "medium-ethernet"))]
+fn inject_router_advert(
+    iface: &mut Interface,
+    sockets: &mut SocketSet,
+    local_hw_addr: EthernetAddress,
+    local_ip_addr: Ipv6Cidr,
+    remote_hw_addr: EthernetAddress,
+    remote_ip_addr: Ipv6Cidr,
+    router_lifetime: Duration,
+    lladdr: Option<EthernetAddress>,
+) {
+    let advertisement = NdiscRepr::RouterAdvert {
+        hop_limit: 255,
+        flags: NdiscRouterFlags::empty(),
+        router_lifetime,
+        reachable_time: Duration::from_secs(0),
+        retrans_time: Duration::from_secs(0),
+        lladdr: lladdr.map(|a| a.into()),
+        mtu: None,
+        prefix_info: None,
+    };
+    let ip_repr = IpRepr::Ipv6(Ipv6Repr {
+        src_addr: remote_ip_addr.address(),
+        dst_addr: local_ip_addr.address(),
+        next_header: IpProtocol::Icmpv6,
+        hop_limit: 255,
+        payload_len: advertisement.buffer_len(),
+    });
+    let frame_len = EthernetFrame::<&[u8]>::header_len() + ip_repr.header_len() + advertisement.buffer_len();
+    let mut eth_bytes = vec![0u8; frame_len];
+    let mut frame = EthernetFrame::new_unchecked(&mut eth_bytes);
+    frame.set_dst_addr(local_hw_addr);
+    frame.set_src_addr(remote_hw_addr);
+    frame.set_ethertype(EthernetProtocol::Ipv6);
+    ip_repr.emit(frame.payload_mut(), &ChecksumCapabilities::default());
+    Icmpv6Repr::Ndisc(advertisement).emit(
+        &remote_ip_addr.address(),
+        &local_ip_addr.address(),
+        &mut Icmpv6Packet::new_unchecked(&mut frame.payload_mut()[ip_repr.header_len()..]),
+        &ChecksumCapabilities::default(),
+    );
+    iface.inner.process_ethernet(
+        sockets,
+        PacketMeta::default(),
+        frame.into_inner(),
+        &mut iface.fragments,
+    );
+}
+
+/// A RouterAdvert with an SLLAO must fill the neighbor cache with the router's
+/// link-layer address so that subsequent unicast NS (e.g. RFC 6775 ARO) can be
+/// sent without a prior broadcast solicitation.
+#[test]
+#[cfg(all(feature = "proto-ipv6-slaac", feature = "medium-ethernet"))]
+fn test_router_advert_sllao_fills_neighbor_cache() {
+    let local_hw_addr = EthernetAddress([0x02, 0x02, 0x02, 0x02, 0x02, 0x02]);
+    let remote_hw_addr = EthernetAddress([0x52, 0x54, 0x00, 0x00, 0x00, 0x01]);
+    let ll_prefix = Ipv6Cidr::new(Ipv6Cidr::LINK_LOCAL_PREFIX.address(), 64);
+    let local_ip_addr =
+        Ipv6Cidr::from_link_prefix(&ll_prefix, HardwareAddress::Ethernet(local_hw_addr)).unwrap();
+    let remote_ip_addr =
+        Ipv6Cidr::from_link_prefix(&ll_prefix, HardwareAddress::Ethernet(remote_hw_addr)).unwrap();
+
+    let mut config = Config::new(HardwareAddress::Ethernet(local_hw_addr));
+    config.slaac = true;
+    let mut device = crate::tests::TestingDevice::new(Medium::Ethernet);
+    let mut iface = Interface::new(config, &mut device, Instant::ZERO);
+    iface.update_ip_addrs(|ip_addrs| {
+        ip_addrs.push(IpCidr::Ipv6(local_ip_addr)).unwrap();
+    });
+    let mut sockets = SocketSet::new(vec![]);
+
+    // Before the RA, the router's link-layer address should not be cached.
+    assert!(!iface
+        .inner
+        .neighbor_cache_has(IpAddress::Ipv6(remote_ip_addr.address())));
+
+    // Inject an RA with SLLAO.
+    inject_router_advert(
+        &mut iface,
+        &mut sockets,
+        local_hw_addr,
+        local_ip_addr,
+        remote_hw_addr,
+        remote_ip_addr,
+        Duration::from_secs(600),
+        Some(remote_hw_addr),
+    );
+
+    // The router's link-layer address must now be in the neighbor cache.
+    assert!(iface
+        .inner
+        .neighbor_cache_has(IpAddress::Ipv6(remote_ip_addr.address())));
+}
+
+/// An RA without an SLLAO must not cache anything (no regression).
+#[test]
+#[cfg(all(feature = "proto-ipv6-slaac", feature = "medium-ethernet"))]
+fn test_router_advert_no_sllao_does_not_fill_neighbor_cache() {
+    let local_hw_addr = EthernetAddress([0x02, 0x02, 0x02, 0x02, 0x02, 0x02]);
+    let remote_hw_addr = EthernetAddress([0x52, 0x54, 0x00, 0x00, 0x00, 0x01]);
+    let ll_prefix = Ipv6Cidr::new(Ipv6Cidr::LINK_LOCAL_PREFIX.address(), 64);
+    let local_ip_addr =
+        Ipv6Cidr::from_link_prefix(&ll_prefix, HardwareAddress::Ethernet(local_hw_addr)).unwrap();
+    let remote_ip_addr =
+        Ipv6Cidr::from_link_prefix(&ll_prefix, HardwareAddress::Ethernet(remote_hw_addr)).unwrap();
+
+    let mut config = Config::new(HardwareAddress::Ethernet(local_hw_addr));
+    config.slaac = true;
+    let mut device = crate::tests::TestingDevice::new(Medium::Ethernet);
+    let mut iface = Interface::new(config, &mut device, Instant::ZERO);
+    iface.update_ip_addrs(|ip_addrs| {
+        ip_addrs.push(IpCidr::Ipv6(local_ip_addr)).unwrap();
+    });
+    let mut sockets = SocketSet::new(vec![]);
+
+    inject_router_advert(
+        &mut iface,
+        &mut sockets,
+        local_hw_addr,
+        local_ip_addr,
+        remote_hw_addr,
+        remote_ip_addr,
+        Duration::from_secs(600),
+        None, // no SLLAO
+    );
+
+    assert!(!iface
+        .inner
+        .neighbor_cache_has(IpAddress::Ipv6(remote_ip_addr.address())));
+}
+
+/// Two RAs from different routers must both appear in default_ipv6_routers()
+/// and both must be resolvable in the neighbor cache when they carry SLLAOs.
+/// Expiring one router must remove it from the iterator but leave the other.
+#[test]
+#[cfg(all(feature = "proto-ipv6-slaac", feature = "medium-ethernet"))]
+fn test_multiple_default_routers() {
+    let local_hw_addr = EthernetAddress([0x02, 0x02, 0x02, 0x02, 0x02, 0x02]);
+    let router1_hw_addr = EthernetAddress([0x52, 0x54, 0x00, 0x00, 0x00, 0x01]);
+    let router2_hw_addr = EthernetAddress([0x52, 0x54, 0x00, 0x00, 0x00, 0x02]);
+    let ll_prefix = Ipv6Cidr::new(Ipv6Cidr::LINK_LOCAL_PREFIX.address(), 64);
+    let local_ip_addr =
+        Ipv6Cidr::from_link_prefix(&ll_prefix, HardwareAddress::Ethernet(local_hw_addr)).unwrap();
+    let router1_ip_addr =
+        Ipv6Cidr::from_link_prefix(&ll_prefix, HardwareAddress::Ethernet(router1_hw_addr))
+            .unwrap();
+    let router2_ip_addr =
+        Ipv6Cidr::from_link_prefix(&ll_prefix, HardwareAddress::Ethernet(router2_hw_addr))
+            .unwrap();
+
+    let mut config = Config::new(HardwareAddress::Ethernet(local_hw_addr));
+    config.slaac = true;
+    let mut device = crate::tests::TestingDevice::new(Medium::Ethernet);
+    let mut iface = Interface::new(config, &mut device, Instant::ZERO);
+    iface.update_ip_addrs(|ip_addrs| {
+        ip_addrs.push(IpCidr::Ipv6(local_ip_addr)).unwrap();
+    });
+    let mut sockets = SocketSet::new(vec![]);
+
+    // Inject RAs from two different routers.
+    inject_router_advert(
+        &mut iface,
+        &mut sockets,
+        local_hw_addr,
+        local_ip_addr,
+        router1_hw_addr,
+        router1_ip_addr,
+        Duration::from_secs(600),
+        Some(router1_hw_addr),
+    );
+    inject_router_advert(
+        &mut iface,
+        &mut sockets,
+        local_hw_addr,
+        local_ip_addr,
+        router2_hw_addr,
+        router2_ip_addr,
+        Duration::from_secs(600),
+        Some(router2_hw_addr),
+    );
+
+    // Both must be in the neighbor cache immediately after the RAs (before poll).
+    // Note: poll flushes the neighbor cache via update_ip_addrs during SLAAC sync,
+    // so this must be verified before calling poll.
+    assert!(iface
+        .inner
+        .neighbor_cache_has(IpAddress::Ipv6(router1_ip_addr.address())));
+    assert!(iface
+        .inner
+        .neighbor_cache_has(IpAddress::Ipv6(router2_ip_addr.address())));
+
+    // Sync SLAAC state so routes are pushed to the interface route table.
+    iface.poll(Instant::ZERO, &mut device, &mut sockets);
+
+    // Both routers must appear in the default router list after poll.
+    let routers: std::vec::Vec<_> = iface.default_ipv6_routers().collect();
+    assert_eq!(routers.len(), 2);
+    assert!(routers.contains(&router1_ip_addr.address()));
+    assert!(routers.contains(&router2_ip_addr.address()));
+
+    // Expire router1 by sending an RA with router_lifetime = 0.
+    inject_router_advert(
+        &mut iface,
+        &mut sockets,
+        local_hw_addr,
+        local_ip_addr,
+        router1_hw_addr,
+        router1_ip_addr,
+        Duration::ZERO,
+        None,
+    );
+    iface.poll(Instant::from_secs(1), &mut device, &mut sockets);
+
+    let routers: std::vec::Vec<_> = iface.default_ipv6_routers().collect();
+    assert_eq!(routers.len(), 1);
+    assert!(!routers.contains(&router1_ip_addr.address()));
+    assert!(routers.contains(&router2_ip_addr.address()));
+}

--- a/src/iface/interface/tests/ipv6.rs
+++ b/src/iface/interface/tests/ipv6.rs
@@ -2051,8 +2051,9 @@ fn test_multiple_default_routers() {
     );
 
     // Both must be in the neighbor cache immediately after the RAs (before poll).
-    // Note: poll flushes the neighbor cache via update_ip_addrs during SLAAC sync,
-    // so this must be verified before calling poll.
+    // Note: poll calls sync_slaac_state which calls update_ip_addrs; if the address list
+    // changes (e.g. a SLAAC prefix address is added) the neighbor cache will be flushed.
+    // Checking here before poll avoids that race in this test which sends no prefix.
     assert!(iface
         .inner
         .neighbor_cache_has(IpAddress::Ipv6(router1_ip_addr.address())));

--- a/src/iface/route.rs
+++ b/src/iface/route.rs
@@ -373,4 +373,36 @@ mod test {
             Some(ADDR_2A.into())
         );
     }
+
+    #[test]
+    #[cfg(feature = "proto-ipv6")]
+    fn test_add_default_ipv6_route_upsert() {
+        let gw_a = Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
+        let gw_b = Ipv6Address::new(0xfe80, 0, 0, 0, 0, 0, 0, 2);
+
+        let mut routes = Routes::new();
+
+        // Adding two different gateways must not evict each other.
+        routes.add_default_ipv6_route(gw_a).unwrap();
+        routes.add_default_ipv6_route(gw_b).unwrap();
+        let routers: std::vec::Vec<_> = routes.default_ipv6_routers().collect();
+        assert_eq!(routers.len(), 2);
+        assert!(routers.contains(&gw_a));
+        assert!(routers.contains(&gw_b));
+
+        // Re-adding an existing gateway (upsert) must not create a duplicate.
+        routes.add_default_ipv6_route(gw_a).unwrap();
+        let routers: std::vec::Vec<_> = routes.default_ipv6_routers().collect();
+        assert_eq!(routers.len(), 2);
+
+        // remove_default_ipv6_route_via removes only the targeted gateway.
+        routes.remove_default_ipv6_route_via(gw_a);
+        let routers: std::vec::Vec<_> = routes.default_ipv6_routers().collect();
+        assert_eq!(routers.len(), 1);
+        assert_eq!(routers[0], gw_b);
+
+        // remove_default_ipv6_route still removes the first ::/0 entry.
+        routes.remove_default_ipv6_route();
+        assert_eq!(routes.default_ipv6_routers().count(), 0);
+    }
 }

--- a/src/iface/route.rs
+++ b/src/iface/route.rs
@@ -111,17 +111,53 @@ impl Routes {
 
     /// Add a default ipv6 gateway (ie. "ip -6 route add ::/0 via `gateway`").
     ///
-    /// On success, returns the previous default route, if any.
+    /// Uses upsert semantics: if a `::/0` route via this exact `gateway` already exists it is
+    /// replaced; routes via other gateways are left intact, supporting multiple default routers.
+    ///
+    /// On success, returns the previous route for this gateway, if any.
     #[cfg(feature = "proto-ipv6")]
     pub fn add_default_ipv6_route(
         &mut self,
         gateway: Ipv6Address,
     ) -> Result<Option<Route>, RouteTableFull> {
-        let old = self.remove_default_ipv6_route();
+        let old = self.remove_default_ipv6_route_via(gateway);
         self.storage
             .push(Route::new_ipv6_gateway(gateway))
             .map_err(|_| RouteTableFull)?;
         Ok(old)
+    }
+
+    /// Remove the `::/0` route via a specific gateway.
+    ///
+    /// On success, returns the removed route, if any.
+    #[cfg(feature = "proto-ipv6")]
+    pub fn remove_default_ipv6_route_via(&mut self, gateway: Ipv6Address) -> Option<Route> {
+        if let Some((i, _)) = self
+            .storage
+            .iter()
+            .enumerate()
+            .find(|(_, r)| r.is_ipv6_gateway() && r.via_router == IpAddress::Ipv6(gateway))
+        {
+            Some(self.storage.remove(i))
+        } else {
+            None
+        }
+    }
+
+    /// Returns an iterator over all IPv6 default routers (`::/0` routes).
+    #[cfg(feature = "proto-ipv6")]
+    pub fn default_ipv6_routers(&self) -> impl Iterator<Item = Ipv6Address> + '_ {
+        self.storage.iter().filter_map(|r| {
+            if r.is_ipv6_gateway() {
+                if let IpAddress::Ipv6(addr) = r.via_router {
+                    Some(addr)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
     }
 
     /// Returns the ipv4 default route if there is one in the route table.


### PR DESCRIPTION
## RFC 4861 minimum compliance: multi-router default list, SLLAO capture, neighbor cache fix

This is groundwork for RFC 6775 (6LoWPAN Neighbor Discovery), which requires a node to send unicast Neighbor Solicitations carrying an Address Registration Option (ARO) to one or more router on its Default Router List. Three things were missing that blocked that work.

### Capture SLLAO from Router Advertisements into the neighbor cache (`src/iface/interface/ipv6.rs`)

When an RA includes a Source Link-Layer Address Option, the router's link-layer address is now immediately stored in the neighbor cache. Previously `lladdr` was discarded, forcing a broadcast NS/NA exchange before any off-link packet could be sent. On IEEE 802.15.4 multicast is broadcast, so this extra round-trip is especially costly. RFC 6775 ARO dispatch needs to reach the router directly without it.                  

### Multiple default routers in the route table (`src/iface/route.rs`)
`Routes::add_default_ipv6_route` previously called `remove_default_ipv6_route()` before inserting, evicting the existing default router. It now uses upsert semantics keyed on the gateway address: two different gateways coexist, re-adding an existing gateway refreshes it in-place. Adds `remove_default_ipv6_route_via(gateway)` to remove a specific router and `default_ipv6_routers()` to iterate over all live ones.               

### Expose `Interface::default_ipv6_routers()` (`src/iface/interface/mod.rs`)
Thin delegate to `Routes::default_ipv6_routers()`. RFC 6775 ARO dispatch will iterate this to know which routers to register with.

### Conditional neighbor cache flush in `update_ip_addrs` (`src/iface/interface/mod.rs`)
update_ip_addrs previously flushed the neighbor cache unconditionally, even when no addresses changed. SLAAC sync calls update_ip_addrs on every poll cycle, which was silently discarding the SLLAO-captured entries from the fix above. The flush is now gated on the address list actually changing, which preserves neighbor entries across no-op syncs while still flushing correctly when addresses are added or removed.

Minimal IPv4 behavior changes. All new and modified IPv6 functions are `#[cfg(feature = "proto-ipv6")]`. The update_ip_addrs change is strictly narrowing, the existing `test_arp_flush_after_update_ip` test was preserved unchanged and still passes.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>