### PR TITLE
Fixing warnings when buidling under a minimal features set.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,8 @@ name: Test
 jobs:
   tests:
     runs-on: ubuntu-22.04
-    needs: [check-msrv, test-msrv, test-stable, clippy, test-netsim]
+    needs:
+      [check-msrv, test-msrv, test-stable, clippy, check-unused, test-netsim]
     steps:
       - name: Done
         run: exit 0
@@ -32,6 +33,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run Clippy
         run: ./ci.sh clippy
+
+  check-unused:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for unused code
+        run: ./ci.sh check_unused
 
   test-stable:
     runs-on: ubuntu-22.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license = "0BSD"
 autoexamples = false
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)', 'cfg(ci_forbid_unused)'] }
 
 [dependencies]
 managed = { version = "0.8", default-features = false, features = ["map"] }

--- a/ci.sh
+++ b/ci.sh
@@ -81,6 +81,11 @@ clippy() {
     cargo +$MSRV clippy --tests --examples -- -D warnings
 }
 
+check_unused() {
+    export RUSTFLAGS="--cfg ci_forbid_unused --deny unused --deny irrefutable_let_patterns"
+    cargo check --tests --examples
+}
+
 build_16bit() {
     rustup toolchain install nightly
     rustup +nightly component add rust-src
@@ -128,6 +133,10 @@ fi
 
 if [[ $1 == "clippy" || $1 == "all" ]]; then
     clippy
+fi
+
+if [[ $1 == "check_unused" || $1 == "all" ]]; then
+    check_unused
 fi
 
 if [[ $1 == "build_16bit" || $1 == "all" ]]; then

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![deny(unsafe_code)]
+// Since we have many different flags that can come on and off, we expect some variables to
+// be unused sometimes, and we allow that.
+#![cfg_attr(not(ci_forbid_unused), allow(unused, irrefutable_let_patterns))]
 
 //! The _smoltcp_ library is built in a layered structure, with the layers corresponding
 //! to the levels of API abstraction. Only the highest layers would be used by a typical


### PR DESCRIPTION
This change is a noop. It only fixes warnings that get generated under a minimal features set, because for example a variable is declared or imported always, but only used under some feature sets.

The warnings can be reproduced on the main branch with this command:

`cargo check --no-default-features --features std,medium-ethernet,proto-ipv4,socket-tcp,socket-dhcpv4`

It also  explicitly declares when imports/variables are only used under certain features.

These are the warnings it fixes:
warning: unused import: `super::fragmentation::PacketAssemblerSet`
  --> smoltcp\src\iface\interface\mod.rs:35:5
   |
35 | use super::fragmentation::PacketAssemblerSet;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

warning: unused imports: `IFACE_MAX_PREFIX_COUNT` and `IFACE_MAX_SIXLOWPAN_ADDRESS_CONTEXT_COUNT`
  --> smoltcp\src\iface\interface\mod.rs:42:27
   |
42 |     IFACE_MAX_ADDR_COUNT, IFACE_MAX_PREFIX_COUNT, IFACE_MAX_SIXLOWPAN_ADDRESS_CONTEXT_COUNT,
   |                           ^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: variable does not need to be mutable
   --> smoltcp\src\iface\interface\ipv4.rs:103:13
    |
103 |         let mut ipv4_repr = check!(Ipv4Repr::parse(ipv4_packet, &self.caps.checksum));
    |             ----^^^^^^^^^
    |             |
    |             help: remove this `mut`
    |
    = note: `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default

warning: unused variable: `meta`
  --> smoltcp\src\iface\interface\ipv4.rs:98:9
   |
98 |         meta: PacketMeta,
   |         ^^^^ help: if this is intentional, prefix it with an underscore: `_meta`
   |
   = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default

warning: unused variable: `frag`
   --> smoltcp\src\iface\interface\ipv4.rs:101:9
    |
101 |         frag: &'a mut FragmentsBuffer,
    |         ^^^^ help: if this is intentional, prefix it with an underscore: `_frag`

warning: unused variable: `ip_repr`
   --> smoltcp\src\iface\interface\ipv4.rs:323:9
    |
323 |         ip_repr: Ipv4Repr,
    |         ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_ip_repr`

warning: unused variable: `fragmenter`
    --> smoltcp\src\iface\interface\mod.rs:1127:9
     |
1127 |         fragmenter: &mut Fragmenter,
     |         ^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_fragmenter`

warning: unreachable pattern
    --> smoltcp\src\iface\interface\mod.rs:1324:13
     |
1318 |             Medium::Ethernet => {
     |             ---------------- matches all the relevant values
...
1324 |             _ => (EthernetAddress([0; 6]), tx_token),
     |             ^ no value can reach this
     |
     = note: `#[warn(unreachable_patterns)]` (part of `#[warn(unused)]`) on by default

warning: unreachable pattern
    --> smoltcp\src\iface\interface\mod.rs:1321:21
     |
1320 |                     (HardwareAddress::Ethernet(addr), tx_token) => (addr, tx_token),
     |                     ------------------------------------------- matches all the relevant values
1321 |                     (_, _) => unreachable!(),
     |                     ^^^^^^ no value can reach this

warning: unused variable: `repr`
    --> smoltcp\src\iface\interface\mod.rs:1356:26
     |
1356 |             IpRepr::Ipv4(repr) => {
     |                          ^^^^ help: if this is intentional, prefix it with an underscore: `_repr`

warning: unreachable `else` clause
   --> smoltcp\src\socket\dhcpv4.rs:332:75
    |
332 |         let HardwareAddress::Ethernet(ethernet_addr) = cx.hardware_addr() else {
    |         ----------------------------------------------------------------- ^^^^
    |         |
    |         assigning to binding pattern will always succeed
    |
    = note: this pattern always matches, so the else clause is unreachable
    = note: `#[warn(irrefutable_let_patterns)]` on by default

warning: unreachable `else` clause
   --> smoltcp\src\socket\dhcpv4.rs:569:75
    |
569 |         let HardwareAddress::Ethernet(ethernet_addr) = cx.hardware_addr() else {
    |         ----------------------------------------------------------------- ^^^^
    |         |
    |         assigning to binding pattern will always succeed
    |
    = note: this pattern always matches, so the else clause is unreachable

warning: method `emit_header` is never used
   --> smoltcp\src\wire\udp.rs:275:19
    |
232 | impl Repr {
    | --------- method in this implementation
...
275 |     pub(crate) fn emit_header<T>(&self, packet: &mut Packet<&mut T>, payload_len: usize)
    |                   ^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default

warning: `smoltcp` (lib) generated 13 warnings (run `cargo fix --lib -p smoltcp` to apply 8 suggestions)