### PR TITLE
wire: expose the checksum module publicly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No unreleased changes yet. Please send PRs!
+- wire: Expose the `checksum` module publicly, so downstream crates can compute RFC 1071 Internet checksums over discontiguous buffers. ([#1172](https://github.com/smoltcp-rs/smoltcp/pull/1172))
 
 ## [0.13.1] - 2026-05-01
 

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -178,6 +178,7 @@ pub use self::ieee802154::{
     FrameVersion as Ieee802154FrameVersion, Pan as Ieee802154Pan, Repr as Ieee802154Repr,
 };
 
+pub use self::ip::checksum;
 pub use self::ip::{
     Address as IpAddress, Cidr as IpCidr, Endpoint as IpEndpoint,
     ListenEndpoint as IpListenEndpoint, Protocol as IpProtocol, Repr as IpRepr,


### PR DESCRIPTION
The `checksum` module in `wire::ip` contains the RFC 1071 Internet-checksum helpers (`data`, `combine`, `pseudo_header`, `pseudo_header_v4`/`v6`). The functions are `pub`, but the module lives inside `pub(crate) mod ip`, so they are effectively crate-private and cannot be reused by downstream crates.

This re-exports the module as `smoltcp::wire::checksum`, so callers that build packets out of discontiguous buffers can compute checksums using smoltcp's own arithmetic instead of reimplementing the one's-complement summation.

No functional change; purely a visibility/re-export change.
