### PR TITLE
Fix broken doc links

### DIFF
--- a/src/iface/interface/mod.rs
+++ b/src/iface/interface/mod.rs
@@ -202,7 +202,7 @@ impl Interface {
     /// Create a network interface using the previously provided configuration.
     ///
     /// # Panics
-    /// This function panics if the [`Config::hardware_address`] does not match
+    /// This function panics if the [`Config::hardware_addr`] does not match
     /// the medium of the device.
     pub fn new(config: Config, device: &mut (impl Device + ?Sized), now: Instant) -> Self {
         let caps = device.capabilities();
@@ -414,7 +414,7 @@ impl Interface {
     /// Enable or disable the AnyIP capability.
     ///
     /// AnyIP allowins packets to be received
-    /// locally on IP addresses other than the interface's configured [ip_addrs].
+    /// locally on IP addresses other than the interface's configured [`ip_addrs`](Self::ip_addrs).
     /// When AnyIP is enabled and a route prefix in [`routes`](Self::routes) specifies one of
     /// the interface's [`ip_addrs`](Self::ip_addrs) as its gateway, the interface will accept
     /// packets addressed to that prefix.

--- a/src/socket/dns.rs
+++ b/src/socket/dns.rs
@@ -283,7 +283,7 @@ impl<'a> Socket<'a> {
     /// Start a query with a raw (wire-format) DNS name.
     /// `b"\x09rust-lang\x03org\x00"`
     ///
-    /// You probably want to use [`start_query`] instead.
+    /// You probably want to use [`start_query`](Self::start_query) instead.
     pub fn start_query_raw(
         &mut self,
         cx: &mut Context,

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -54,7 +54,7 @@ pub(crate) enum PollAt {
 /// It is usually more convenient to use [SocketSet::get] instead.
 ///
 /// [AnySocket]: trait.AnySocket.html
-/// [SocketSet::get]: struct.SocketSet.html#method.get
+/// [SocketSet::get]: ../iface/struct.SocketSet.html#method.get
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum Socket<'a> {

--- a/src/wire/ip.rs
+++ b/src/wire/ip.rs
@@ -628,7 +628,7 @@ impl Repr {
         }
     }
 
-    /// Parse an Internet Protocol packet and return an [IpRepr] containing either an Internet
+    /// Parse an Internet Protocol packet and return an [`IpRepr`](Repr) containing either an Internet
     /// Protocol version 4 or Internet Protocol version 6 packet. Delegates the parsing to the
     /// specific Internet Protocol parsing function. Includes [ChecksumCapabilities] to handle
     /// Internet Protocol version 4 parsing.


### PR DESCRIPTION
A few of the doc links were broken likely due to reorganization.
This commit fixes them