### PR TITLE
Implement core::error::Error for errors

### DIFF
--- a/src/iface/fragmentation.rs
+++ b/src/iface/fragmentation.rs
@@ -27,8 +27,7 @@ impl fmt::Display for AssemblerError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for AssemblerError {}
+impl core::error::Error for AssemblerError {}
 
 /// Packet assembler is full
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -41,8 +40,7 @@ impl fmt::Display for AssemblerFullError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for AssemblerFullError {}
+impl core::error::Error for AssemblerFullError {}
 
 /// Holds different fragments of one packet, used for assembling fragmented packets.
 ///

--- a/src/iface/interface/multicast.rs
+++ b/src/iface/interface/multicast.rs
@@ -97,8 +97,7 @@ impl core::fmt::Display for MulticastError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for MulticastError {}
+impl core::error::Error for MulticastError {}
 
 impl Interface {
     /// Add an address to a list of subscribed multicast IP addresses.

--- a/src/iface/route.rs
+++ b/src/iface/route.rs
@@ -18,8 +18,7 @@ impl core::fmt::Display for RouteTableFull {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for RouteTableFull {}
+impl core::error::Error for RouteTableFull {}
 
 /// A prefix of addresses that should be routed via a router
 #[derive(Debug, Clone, Copy)]

--- a/src/socket/dns.rs
+++ b/src/socket/dns.rs
@@ -49,8 +49,7 @@ impl core::fmt::Display for StartQueryError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for StartQueryError {}
+impl core::error::Error for StartQueryError {}
 
 /// Error returned by [`Socket::get_query_result`]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -71,8 +70,7 @@ impl core::fmt::Display for GetQueryResultError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for GetQueryResultError {}
+impl core::error::Error for GetQueryResultError {}
 
 /// State for an in-progress DNS query.
 ///

--- a/src/socket/icmp.rs
+++ b/src/socket/icmp.rs
@@ -34,8 +34,7 @@ impl core::fmt::Display for BindError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for BindError {}
+impl core::error::Error for BindError {}
 
 /// Error returned by [`Socket::send`]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -54,8 +53,7 @@ impl core::fmt::Display for SendError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for SendError {}
+impl core::error::Error for SendError {}
 
 /// Error returned by [`Socket::recv`]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -74,8 +72,7 @@ impl core::fmt::Display for RecvError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for RecvError {}
+impl core::error::Error for RecvError {}
 
 /// Type of endpoint to bind the ICMP socket to. See [IcmpSocket::bind] for
 /// more details.

--- a/src/socket/raw.rs
+++ b/src/socket/raw.rs
@@ -31,8 +31,7 @@ impl core::fmt::Display for BindError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for BindError {}
+impl core::error::Error for BindError {}
 
 /// Error returned by [`Socket::send`]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -49,8 +48,7 @@ impl core::fmt::Display for SendError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for SendError {}
+impl core::error::Error for SendError {}
 
 /// Error returned by [`Socket::recv`]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -69,8 +67,7 @@ impl core::fmt::Display for RecvError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for RecvError {}
+impl core::error::Error for RecvError {}
 
 /// A UDP packet metadata.
 pub type PacketMetadata = crate::storage::PacketMetadata<()>;

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -40,8 +40,7 @@ impl Display for ListenError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ListenError {}
+impl core::error::Error for ListenError {}
 
 /// Error returned by [`Socket::connect`]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -60,8 +59,7 @@ impl Display for ConnectError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ConnectError {}
+impl core::error::Error for ConnectError {}
 
 /// Error returned by [`Socket::send`]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -78,8 +76,7 @@ impl Display for SendError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for SendError {}
+impl core::error::Error for SendError {}
 
 /// Error returned by [`Socket::recv`]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -98,8 +95,7 @@ impl Display for RecvError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for RecvError {}
+impl core::error::Error for RecvError {}
 
 /// A TCP socket ring buffer.
 pub type SocketBuffer<'a> = RingBuffer<'a, u8>;

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -69,8 +69,7 @@ impl core::fmt::Display for BindError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for BindError {}
+impl core::error::Error for BindError {}
 
 /// Error returned by [`Socket::send`]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -89,8 +88,7 @@ impl core::fmt::Display for SendError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for SendError {}
+impl core::error::Error for SendError {}
 
 /// Error returned by [`Socket::recv`]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -109,8 +107,7 @@ impl core::fmt::Display for RecvError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for RecvError {}
+impl core::error::Error for RecvError {}
 
 /// A User Datagram Protocol socket.
 ///

--- a/src/storage/assembler.rs
+++ b/src/storage/assembler.rs
@@ -11,8 +11,7 @@ impl fmt::Display for TooManyHolesError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for TooManyHolesError {}
+impl core::error::Error for TooManyHolesError {}
 
 /// A contiguous chunk of absent data, followed by a contiguous chunk of present data.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -304,8 +304,7 @@ pub use self::ipsec_esp::{Packet as IpSecEspPacket, Repr as IpSecEspRepr};
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Error;
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
The `Error` trait is now available in the `core` and doesn't require `std`: [core::error::Error](https://doc.rust-lang.org/beta/core/error/trait.Error.html)