### PR TITLE
More checksum calculation optimization

### DIFF
--- a/src/wire/ip.rs
+++ b/src/wire/ip.rs
@@ -770,35 +770,37 @@ pub mod checksum {
     }
 
     /// Compute an RFC 1071 compliant checksum (without the final complement).
-    pub fn data(mut data: &[u8]) -> u16 {
-        let mut accum = 0;
+    pub fn data(data: &[u8]) -> u16 {
+        // We calculate the sum in native-endian before converting to big-endian at the end
+        // see RFC 1071 section 2.(B) for details
+        let mut accum: u32 = 0;
 
-        // For each 32-byte chunk...
-        const CHUNK_SIZE: usize = 32;
-        while data.len() >= CHUNK_SIZE {
-            let mut d = &data[..CHUNK_SIZE];
-            // ... take by 2 bytes and sum them.
-            while d.len() >= 2 {
-                accum += NetworkEndian::read_u16(d) as u32;
-                d = &d[2..];
-            }
-
-            data = &data[CHUNK_SIZE..];
+        // We manually unroll this hot loop.
+        // When optimizing for size (as is common for microcontrollers) the compiler will not unroll
+        // this. Manually unrolling allows us to do more work per loop tax (compare and branch).
+        // It does not seem to affect the auto-vectorization on bigger machines.
+        let (chunks, mut rem) = data.as_chunks::<4>();
+        for chunk in chunks {
+            let val_0 = u16::from_ne_bytes(chunk[..2].try_into().unwrap());
+            let val_1 = u16::from_ne_bytes(chunk[2..4].try_into().unwrap());
+            accum += val_0 as u32;
+            accum += val_1 as u32;
         }
 
-        // Sum the rest that does not fit the last 32-byte chunk,
-        // taking by 2 bytes.
-        while data.len() >= 2 {
-            accum += NetworkEndian::read_u16(data) as u32;
-            data = &data[2..];
+        // Handle 2 bytes of tail, if present.
+        if rem.len() >= 2 {
+            let val = u16::from_ne_bytes(rem[..2].try_into().unwrap());
+            accum += val as u32;
+            rem = &rem[2..];
         }
 
         // Add the last remaining odd byte, if any.
-        if let Some(&value) = data.first() {
-            accum += (value as u32) << 8;
+        if let Some(&value) = rem.first() {
+            accum += u16::from_ne_bytes([value, 0]) as u32;
         }
 
-        propagate_carries(accum)
+        let collapsed = propagate_carries(accum);
+        u16::to_be(collapsed)
     }
 
     /// Combine several RFC 1071 compliant checksums.


### PR DESCRIPTION
This attempts to continue the work in #1065.

I benchmarked various implementations for the checksum [here](https://github.com/KingCol13/smoltcp-checksum-bench) on as many CPUs as I could. Here are some of my results in relative speedup over current implementation for 1024 bytes, I propose the `into_chunks_unroll` implementation as it generally gives a good performance improvement and I didn't see a regression on any hardware I tested on:

| CPU                     | exact_no_bigchunk    | into_chunk_unroll |
| ----------------------- | -------------------- | ----------------- |
| rp2350 arm (cortex-m33) | 1.19                 | 1.92              |
| rp2350 riscv32imac      | 1.10                 | 2.00              |
| rp2040 (cortex-m0+)     | 1.13                 | 1.62              |
| cortex-a53 (pi zero 2)  | 1.28                 | 2.25              |
| ARM1176JZF-S (pi zero)  | 0.56                 | 1.00              |
| Ryzen 7950x (desktop)   | 3.02                 | 3.88              |

I used `opt-mode = "s"` and `"-C", "llvm-args=--inline-threshold=275"` for the microcontrollers and `opt-mode = 3` for the rest. `chunks_exact_no_bigchunk` had a regression on the Pi Zero. It seemed LLVM optimises quite badly for this CPU compared to GCC when I benchmarked a C++ implementation - it is a 22 year old CPU so perhaps less of a priority.

In an upload bandwidth benchmark sending 1464 byte UDP payload packets on my W6300-EVB-Pico2 I get these results:

| implementation     | bandwidth (kB/s)|
| ------------------ | --------------- |
| original           | 7370            |
| exact_no_bigchunk  | 7572            |
| into_chunks_unroll | 7637            |

My TCP benchmarks also showed around a 5% bandwidth improvement.