### PR TITLE
fix: incorrect conversion from `std::time::Instant` to `Instant`

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -105,8 +105,11 @@ impl Instant {
 #[cfg(feature = "std")]
 impl From<::std::time::Instant> for Instant {
     fn from(other: ::std::time::Instant) -> Instant {
-        let elapsed = other.elapsed();
-        Instant::from_micros((elapsed.as_secs() * 1_000000) as i64 + elapsed.subsec_micros() as i64)
+        static REFERENTIAL: ::std::sync::LazyLock<::std::time::Instant> =
+            ::std::sync::LazyLock::new(::std::time::Instant::now);
+
+        let n = other.saturating_duration_since(*REFERENTIAL);
+        Self::from_micros(n.as_secs() as i64 * 1000000 + n.subsec_micros() as i64)
     }
 }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -397,6 +397,21 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "std")]
+    fn test_instant_conversions_from_std_instant() {
+        let std_now = ::std::time::Instant::now();
+
+        let before = Instant::from(std_now);
+        ::std::thread::sleep(::std::time::Duration::from_millis(5));
+        let after = Instant::from(std_now);
+
+        assert_eq!(
+            before, after,
+            "converting the same std Instant twice should yield the same result"
+        );
+    }
+
+    #[test]
     fn test_duration_ops() {
         // std::ops::Add
         assert_eq!(


### PR DESCRIPTION
Fixes #347.

Converting the same `std::time::Instant` twice produced two different values because the `From` implementation was incorrect.

This PR fixes it by comparing against a single lazily-initialized reference `std::time::Instant`. All conversions are now measured relative to that fixed point instead of "now" and converting the same `std::time::Instant` yields the same result. I've also added a test that fails with the previous implementation and works with the fixed one.

## Notes

- I'm using [`std::sync::LazyLock`](https://doc.rust-lang.org/std/sync/struct.LazyLock.html) which is available since Rust 1.80.0 and fits within the MSRV.
- Since the reference `std::time::Instant` gets lazily initialized, it is possible that on the first use, the `std::time::Instant` from which we try to converts happens to be earlier than the reference. In this case, the conversion will be saturated to 0.
- The saturating behavior is the default for [`std::time::Instant::duration_since`](https://doc.rust-lang.org/std/time/struct.Instant.html#method.duration_since) but not a guarantee, so I've used [`std::time::Instant::saturating_duration_since`](https://doc.rust-lang.org/std/time/struct.Instant.html#method.saturating_duration_since) instead.