### PR TITLE
meta: add extra field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ defmt = ["dep:defmt", "heapless/defmt"]
 "socket-tcp-reno" = []
 
 "packetmeta-id" = []
+"packetmeta-extra" = []
 
 "async" = []
 

--- a/src/phy/mod.rs
+++ b/src/phy/mod.rs
@@ -168,6 +168,8 @@ pub const IPV4_FRAGMENT_PAYLOAD_ALIGNMENT: usize = 8;
 pub struct PacketMeta {
     #[cfg(feature = "packetmeta-id")]
     pub id: u32,
+    #[cfg(feature = "packetmeta-extra")]
+    pub extra: u32,
 }
 
 /// A description of checksum behavior for a particular protocol.


### PR DESCRIPTION
Adding this field will allow me to store a timestamp in packetmeta for rx packets, avoiding extra complexity in embassy-net. The complexity added to smoltcp is virtually zero.