### PR TITLE
Upgrade `defmt` to version 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ byteorder = { version = "1.0", default-features = false }
 log = { version = "0.4.4", default-features = false, optional = true }
 libc = { version = "0.2.18", optional = true }
 bitflags = { version = "1.0", default-features = false }
-defmt = { version = "0.3.8", optional = true, features = ["ip_in_core"] }
+defmt = { version = "1", optional = true, features = ["ip_in_core"] }
 cfg-if = "1.0.0"
 heapless = "0.9"
 


### PR DESCRIPTION
I noticed that we have two versions of `defmt` in Hermit, even though we don't use `defmt` at all. Both versions come from smoltcp, since `defmt` 0.3.100 depends on `defmt` 1 for [compatibility](https://docs.rs/defmt/0.3.100/defmt/#compatibility).

Before:

```console
$ cargo tree --no-default-features --features defmt
smoltcp v0.13.1 (/Users/mkroening/devel/smoltcp)
├── ...
└── defmt v0.3.100
    └── defmt v1.1.1
        └── ...
```

After:

```console
$ cargo tree --no-default-features --features defmt
smoltcp v0.13.1 (/Users/mkroening/devel/smoltcp)
├── ...
└── defmt v1.1.1
    └── ...
```