### PR TITLE
feat: MaybeUnint sockets to save space by putting sockets in .bss

### DIFF
--- a/src/iface/socket_set.rs
+++ b/src/iface/socket_set.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use core::mem::MaybeUninit;
 use managed::ManagedSlice;
 
 use super::socket_meta::Meta;
@@ -15,6 +16,16 @@ pub struct SocketStorage<'a> {
 
 impl<'a> SocketStorage<'a> {
     pub const EMPTY: Self = Self { inner: None };
+
+    #[allow(unsafe_code)]
+    pub fn init_slice<'s>(storage: &'s mut [MaybeUninit<Self>]) -> &'s mut [Self] {
+        for slot in storage.iter_mut() {
+            slot.write(Self::EMPTY);
+        }
+        // every element of `storage` was initialised by the loop above,
+        // and `MaybeUninit<T>` is guaranteed to have the same layout as `T`.
+        unsafe { &mut *(storage as *mut [MaybeUninit<Self>] as *mut [Self]) }
+    }
 }
 
 /// An item of a socket set.
@@ -53,6 +64,11 @@ impl<'a> SocketSet<'a> {
     {
         let sockets = sockets.into();
         SocketSet { sockets }
+    }
+
+    /// Create a socket set from uninitialised storage, initialising it in place.
+    pub fn new_uninit(storage: &'a mut [MaybeUninit<SocketStorage<'a>>]) -> SocketSet<'a> {
+        SocketSet::new(SocketStorage::init_slice(storage))
     }
 
     /// Add a socket to the set, and return its handle.
@@ -147,5 +163,25 @@ impl<'a> SocketSet<'a> {
     /// Iterate every socket in this set.
     pub(crate) fn items_mut(&mut self) -> impl Iterator<Item = &mut Item<'a>> + '_ {
         self.sockets.iter_mut().filter_map(|x| x.inner.as_mut())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn init_slice_initialises_every_slot() {
+        let mut storage: [MaybeUninit<SocketStorage>; 4] = [const { MaybeUninit::uninit() }; 4];
+        let slice = SocketStorage::init_slice(&mut storage);
+        assert_eq!(slice.len(), 4);
+        assert!(slice.iter().all(|s| s.inner.is_none()));
+    }
+
+    #[test]
+    fn new_uninit_yields_an_empty_set() {
+        let mut storage: [MaybeUninit<SocketStorage>; 2] = [const { MaybeUninit::uninit() }; 2];
+        let set = SocketSet::new_uninit(&mut storage);
+        assert_eq!(set.iter().count(), 0);
     }
 }


### PR DESCRIPTION
### Proposal

So this may be a bit more controversial but sockets currently don't get the `00` bit patteren meaning they can't be in `.bss`  on embedded targets. Maybe there is a better way of not initializing them but this is the solution I found. Feel free to deny or come with feed back on it. This also adds `unsafe` to the code which may not be wanted.

## Commit message: 

Initialise a slice of uninitialised socket storage in place, returning the initialised slice.

This exists to keep socket storage out of `.data` on bare-metal targets.

`SocketStorage` is a niche-filled `Option<Item>`: `None` occupies zero bytes of payload and its bit pattern is chosen by the compiler, so `EMPTY` is *not* all-zero. A

```rust
static mut STORAGE: [SocketStorage; N] = [SocketStorage::EMPTY; N];
```

therefore cannot live in `.bss`; it goes in `.data` and the linker emits an initialiser image of `N * size_of::<SocketStorage>()` bytes into flash, almost all of which is zeros. Declaring the storage `MaybeUninit` instead places it in `.bss`, and this function fills it at startup:

```rust
static mut STORAGE: MaybeUninit<[SocketStorage; N]> = MaybeUninit::uninit();
let sockets = SocketSet::new(SocketStorage::init_slice(unsafe {
    &mut *(core::ptr::addr_of_mut!(STORAGE) as *mut [MaybeUninit<SocketStorage>; N])
}));
```

Measured on thumbv7em-none-eabihf with 7 sockets, `opt-level="z"` and fat LTO: 3616 bytes of `.data` removed, of which 3584 were zeros, at a cost of ~380 bytes of `.rodata` and a short init loop. RAM use is unchanged.