### PR TITLE
feat: allow listen on ANY port 

### DIFF
--- a/src/iface/interface/tests/ipv4.rs
+++ b/src/iface/interface/tests/ipv4.rs
@@ -1114,6 +1114,7 @@ fn test_raw_socket_with_udp_socket(#[case] medium: Medium) {
         Ok((
             &UDP_PAYLOAD[..],
             udp::UdpMetadata {
+                local_port: Some(68),
                 local_address: Some(dst_addr.into()),
                 ..IpEndpoint::new(src_addr.into(), 67).into()
             }

--- a/src/iface/interface/tests/mod.rs
+++ b/src/iface/interface/tests/mod.rs
@@ -149,6 +149,7 @@ fn test_handle_udp_broadcast(#[case] medium: Medium) {
         Ok((
             &UDP_PAYLOAD[..],
             udp::UdpMetadata {
+                local_port: Some(68),
                 local_address: Some(dst_addr),
                 ..IpEndpoint::new(src_ip.into(), 67).into()
             }

--- a/src/iface/interface/tests/sixlowpan.rs
+++ b/src/iface/interface/tests/sixlowpan.rs
@@ -357,6 +357,7 @@ In at rhoncus tortor. Cras blandit tellus diam, varius vestibulum nibh commodo n
         Ok((
             &udp_data[..],
             udp::UdpMetadata {
+                local_port: Some(6969),
                 local_address: Some(
                     Ipv6Address::new(0xfe80, 0, 0, 0, 0x92fc, 0x48c2, 0xa441, 0xfc76).into()
                 ),

--- a/src/socket/icmp.rs
+++ b/src/socket/icmp.rs
@@ -93,8 +93,8 @@ impl Endpoint {
         match *self {
             Endpoint::Unspecified => false,
             Endpoint::Ident(_) => true,
-            Endpoint::Tcp(endpoint) => endpoint.port != 0,
-            Endpoint::Udp(endpoint) => endpoint.port != 0,
+            Endpoint::Tcp(endpoint) => matches!(endpoint.port, Some(p) if p != 0),
+            Endpoint::Udp(endpoint) => matches!(endpoint.port, Some(p) if p != 0),
         }
     }
 }
@@ -449,7 +449,7 @@ impl<'a> Socket<'a> {
                     &header.dst_addr.into(),
                     &cx.checksum_caps(),
                 ) {
-                    Ok(repr) => endpoint.port == repr.src_port,
+                    Ok(repr) => endpoint.port == Some(repr.src_port),
                     Err(_) => false,
                 }
             }
@@ -469,7 +469,7 @@ impl<'a> Socket<'a> {
                     &header.dst_addr.into(),
                     &cx.checksum_caps(),
                 ) {
-                    Ok(repr) => endpoint.port == repr.src_port,
+                    Ok(repr) => endpoint.port == Some(repr.src_port),
                     Err(_) => false,
                 }
             }
@@ -511,7 +511,7 @@ impl<'a> Socket<'a> {
                     &header.dst_addr.into(),
                     &cx.checksum_caps(),
                 ) {
-                    Ok(repr) => endpoint.port == repr.src_port,
+                    Ok(repr) => endpoint.port == Some(repr.src_port),
                     Err(_) => false,
                 }
             }
@@ -531,7 +531,7 @@ impl<'a> Socket<'a> {
                     &header.dst_addr.into(),
                     &cx.checksum_caps(),
                 ) {
-                    Ok(repr) => endpoint.port == repr.src_port,
+                    Ok(repr) => endpoint.port == Some(repr.src_port),
                     Err(_) => false,
                 }
             }

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1895,7 +1895,9 @@ impl<'a> Socket<'a> {
             // Here we need to additionally check `listen_endpoint`, because we want to make sure
             // that SYN-RECEIVED was actually converted from the LISTEN state (another possible
             // reason is TCP simultaneous open).
-            (State::SynReceived, TcpControl::Rst) if self.listen_endpoint.port != Some(0) => {
+            (State::SynReceived, TcpControl::Rst)
+                if self.listen_endpoint.port.is_some_and(|p| p != 0) =>
+            {
                 tcp_trace!("received RST");
                 self.tuple = None;
                 self.set_state(State::Listen);

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -939,12 +939,15 @@ impl<'a> Socket<'a> {
     /// This function returns `Err(Error::InvalidState)` if the socket was already open
     /// (see [is_open](#method.is_open)), and `Err(Error::Unaddressable)`
     /// if the port in the given endpoint is zero.
+    ///
+    /// A `None` port ([`IpListenEndpoint::ANY_PORT`]) may be used to listen on
+    /// any port, which is useful for VPN/proxy-like applications.
     pub fn listen<T>(&mut self, local_endpoint: T) -> Result<(), ListenError>
     where
         T: Into<IpListenEndpoint>,
     {
         let local_endpoint = local_endpoint.into();
-        if local_endpoint.port == 0 {
+        if local_endpoint.port == Some(0) {
             return Err(ListenError::Unaddressable);
         }
 
@@ -1029,9 +1032,13 @@ impl<'a> Socket<'a> {
         if remote_endpoint.port == 0 || remote_endpoint.addr.is_unspecified() {
             return Err(ConnectError::Unaddressable);
         }
-        if local_endpoint.port == 0 {
-            return Err(ConnectError::Unaddressable);
-        }
+
+        // The local port must be specified (a `None` port means "any port" and is
+        // only valid for listening) and nonzero.
+        let local_port = match local_endpoint.port {
+            Some(port) if port != 0 => port,
+            _ => return Err(ConnectError::Unaddressable),
+        };
 
         // If local address is not provided, choose it automatically.
         let local_endpoint = IpEndpoint {
@@ -1046,7 +1053,7 @@ impl<'a> Socket<'a> {
                     .get_source_address(&remote_endpoint.addr)
                     .ok_or(ConnectError::Unaddressable)?,
             },
-            port: local_endpoint.port,
+            port: local_port,
         };
 
         if local_endpoint.addr.version() != remote_endpoint.addr.version() {
@@ -1578,7 +1585,11 @@ impl<'a> Socket<'a> {
                 Some(addr) => ip_repr.dst_addr() == addr,
                 None => true,
             };
-            addr_ok && repr.dst_port != 0 && repr.dst_port == self.listen_endpoint.port
+            let port_ok = match self.listen_endpoint.port {
+                Some(port) => repr.dst_port == port,
+                None => true,
+            };
+            addr_ok && port_ok && repr.dst_port != 0
         }
     }
 
@@ -1884,7 +1895,7 @@ impl<'a> Socket<'a> {
             // Here we need to additionally check `listen_endpoint`, because we want to make sure
             // that SYN-RECEIVED was actually converted from the LISTEN state (another possible
             // reason is TCP simultaneous open).
-            (State::SynReceived, TcpControl::Rst) if self.listen_endpoint.port != 0 => {
+            (State::SynReceived, TcpControl::Rst) if self.listen_endpoint.port != Some(0) => {
                 tcp_trace!("received RST");
                 self.tuple = None;
                 self.set_state(State::Listen);
@@ -2931,7 +2942,7 @@ mod test {
     const REMOTE_PORT: u16 = 49500;
     const LISTEN_END: IpListenEndpoint = IpListenEndpoint {
         addr: None,
-        port: LOCAL_PORT,
+        port: Some(LOCAL_PORT),
     };
     const TUPLE: Tuple = Tuple {
         local: LOCAL_END,
@@ -3496,6 +3507,20 @@ mod test {
     fn test_listen_validation() {
         let mut s = socket();
         assert_eq!(s.listen(0), Err(ListenError::Unaddressable));
+    }
+
+    #[test]
+    fn test_listen_any_port() {
+        let mut s = socket();
+        assert_eq!(s.listen(IpListenEndpoint::ANY_PORT), Ok(()));
+        // A socket listening on any port accepts SYN packets to arbitrary ports.
+        let tcp_repr = TcpRepr {
+            dst_port: 12345,
+            control: TcpControl::Syn,
+            ack_number: None,
+            ..SEND_TEMPL
+        };
+        assert!(s.socket.accepts(&mut s.cx, &SEND_IP_TEMPL, &tcp_repr));
     }
 
     #[test]

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -3526,6 +3526,70 @@ mod test {
     }
 
     #[test]
+    fn test_any_port_handshake_and_data() {
+        for port in [80, 443] {
+            let mut s = socket();
+            s.listen(IpListenEndpoint::ANY_PORT).unwrap();
+            send!(
+                s,
+                TcpRepr {
+                    dst_port: port,
+                    control: TcpControl::Syn,
+                    seq_number: REMOTE_SEQ,
+                    ack_number: None,
+                    ..SEND_TEMPL
+                }
+            );
+            assert_eq!(s.local_endpoint().unwrap().port, port);
+            recv!(
+                s,
+                [TcpRepr {
+                    src_port: port,
+                    control: TcpControl::Syn,
+                    seq_number: LOCAL_SEQ,
+                    ack_number: Some(REMOTE_SEQ + 1),
+                    max_seg_size: Some(BASE_MSS),
+                    ..RECV_TEMPL
+                }]
+            );
+            send!(
+                s,
+                TcpRepr {
+                    dst_port: port,
+                    seq_number: REMOTE_SEQ + 1,
+                    ack_number: Some(LOCAL_SEQ + 1),
+                    ..SEND_TEMPL
+                }
+            );
+            assert_eq!(s.state(), State::Established);
+            send!(
+                s,
+                TcpRepr {
+                    dst_port: port,
+                    seq_number: REMOTE_SEQ + 1,
+                    ack_number: Some(LOCAL_SEQ + 1),
+                    payload: b"hello",
+                    ..SEND_TEMPL
+                }
+            );
+            let mut data = [0; 5];
+            assert_eq!(s.recv_slice(&mut data), Ok(5));
+            assert_eq!(&data, b"hello");
+            assert_eq!(s.send_slice(b"world"), Ok(5));
+            recv!(
+                s,
+                [TcpRepr {
+                    src_port: port,
+                    seq_number: LOCAL_SEQ + 1,
+                    ack_number: Some(REMOTE_SEQ + 6),
+                    payload: b"world",
+                    ..RECV_TEMPL
+                }]
+            );
+        }
+    }
+
+    #[test]
     fn test_listen_twice() {
         let mut s = socket();
         assert_eq!(s.listen(80), Ok(()));

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -23,6 +23,10 @@ pub struct UdpMetadata {
     /// determined using the algorithms of RFC 6724 (candidate source address selection) or some
     /// heuristic (for IPv4).
     pub local_address: Option<IpAddress>,
+    /// Destination port on receive (always set), or source port on send.
+    /// Required when bound to any port. For a fixed-port socket, this must be
+    /// absent or equal to the bound port.
+    pub local_port: Option<u16>,
     pub meta: PacketMeta,
 }
 
@@ -31,6 +35,7 @@ impl<T: Into<IpEndpoint>> From<T> for UdpMetadata {
         Self {
             endpoint: value.into(),
             local_address: None,
+            local_port: None,
             meta: PacketMeta::default(),
         }
     }
@@ -214,9 +219,13 @@ impl<'a> Socket<'a> {
     /// This function returns `Err(Error::Illegal)` if the socket was open
     /// (see [is_open](#method.is_open)), and `Err(Error::Unaddressable)`
     /// if the port in the given endpoint is zero.
+    ///
+    /// Use [IpListenEndpoint::ANY_PORT] to receive datagrams on all ports.
+    /// Received metadata preserves the destination address and port; use these
+    /// as the local address and port when sending a proxy reply.
     pub fn bind<T: Into<IpListenEndpoint>>(&mut self, endpoint: T) -> Result<(), BindError> {
         let endpoint = endpoint.into();
-        if endpoint.port == 0 {
+        if endpoint.port == Some(0) {
             return Err(BindError::Unaddressable);
         }
 
@@ -254,7 +263,7 @@ impl<'a> Socket<'a> {
     /// Check whether the socket is open.
     #[inline]
     pub fn is_open(&self) -> bool {
-        self.endpoint.port != 0
+        self.endpoint.port != Some(0)
     }
 
     /// Check whether the transmit buffer is full.
@@ -305,10 +314,22 @@ impl<'a> Socket<'a> {
         size: usize,
         meta: impl Into<UdpMetadata>,
     ) -> Result<&mut [u8], SendError> {
-        let meta = meta.into();
-        if self.endpoint.port == 0 {
+        if !self.is_open() {
             return Err(SendError::Unaddressable);
         }
+
+        let meta = meta.into();
+        let local_port = match meta.local_port.or(self.endpoint.port) {
+            Some(port) if port != 0 => port,
+            _ => return Err(SendError::Unaddressable),
+        };
+
+        if let Some(bound_port) = self.endpoint.port {
+            if local_port != bound_port {
+                return Err(SendError::Unaddressable);
+            }
+        }
+
         if meta.endpoint.addr.is_unspecified() {
             return Err(SendError::Unaddressable);
         }
@@ -344,10 +365,22 @@ impl<'a> Socket<'a> {
     where
         F: FnOnce(&mut [u8]) -> usize,
     {
-        let meta = meta.into();
-        if self.endpoint.port == 0 {
+        if !self.is_open() {
             return Err(SendError::Unaddressable);
         }
+
+        let meta = meta.into();
+        let local_port = match meta.local_port.or(self.endpoint.port) {
+            Some(port) if port != 0 => port,
+            _ => return Err(SendError::Unaddressable),
+        };
+
+        if let Some(bound_port) = self.endpoint.port {
+            if local_port != bound_port {
+                return Err(SendError::Unaddressable);
+            }
+        }
+
         if meta.endpoint.addr.is_unspecified() {
             return Err(SendError::Unaddressable);
         }
@@ -475,8 +508,13 @@ impl<'a> Socket<'a> {
     }
 
     pub(crate) fn accepts(&self, cx: &mut Context, ip_repr: &IpRepr, repr: &UdpRepr) -> bool {
-        if self.endpoint.port != repr.dst_port {
+        if !self.is_open() || repr.dst_port == 0 {
             return false;
+        }
+        if let Some(endpoint_port) = self.endpoint.port {
+            if endpoint_port != repr.dst_port {
+                return false;
+            }
         }
         if self.endpoint.addr.is_some()
             && self.endpoint.addr != Some(ip_repr.dst_addr())
@@ -516,6 +554,7 @@ impl<'a> Socket<'a> {
         let metadata = UdpMetadata {
             endpoint: remote_endpoint,
             local_address: Some(ip_repr.dst_addr()),
+            local_port: Some(repr.dst_port),
             meta,
         };
 
@@ -540,6 +579,17 @@ impl<'a> Socket<'a> {
         let hop_limit = self.hop_limit.unwrap_or(64);
 
         let res = self.tx_buffer.dequeue_with(|packet_meta, payload_buf| {
+            let endpoint_port = match packet_meta.local_port.or(endpoint.port) {
+                Some(port) if port != 0 => port,
+                _ => {
+                    net_trace!(
+                        "udp:{}:{}: invalid local port, dropping.",
+                        endpoint,
+                        packet_meta.endpoint
+                    );
+                    return Ok(());
+                }
+            };
             let src_addr = if let Some(s) = packet_meta.local_address {
                 s
             } else {
@@ -567,7 +617,7 @@ impl<'a> Socket<'a> {
             );
 
             let repr = UdpRepr {
-                src_port: endpoint.port,
+                src_port: endpoint_port,
                 dst_port: packet_meta.endpoint.port,
             };
             let ip_repr = IpRepr::new(
@@ -670,6 +720,7 @@ mod test {
         // Would be great as a const once we have const `.into()`.
         UdpMetadata {
             local_address: Some(LOCAL_ADDR.into()),
+            local_port: Some(LOCAL_PORT),
             ..REMOTE_END.into()
         }
     }
@@ -709,6 +760,74 @@ mod test {
     };
 
     const PAYLOAD: &[u8] = b"abcdef";
+
+    #[test]
+    #[cfg(feature = "medium-ip")]
+    fn test_any_port_roundtrip() {
+        let (mut iface, _, _) = setup(Medium::Ip);
+        let cx = iface.context();
+        let mut socket = socket(buffer(2), buffer(2));
+        assert!(!socket.is_open());
+        assert!(!socket.accepts(cx, &REMOTE_IP_REPR, &REMOTE_UDP_REPR));
+        socket.bind(IpListenEndpoint::ANY_PORT).unwrap();
+        assert!(socket.is_open());
+        assert_eq!(socket.bind(1234), Err(BindError::InvalidState));
+        for port in [53, 443] {
+            let repr = UdpRepr {
+                dst_port: port,
+                ..REMOTE_UDP_REPR
+            };
+            assert!(socket.accepts(cx, &REMOTE_IP_REPR, &repr));
+            socket.process(cx, PacketMeta::default(), &REMOTE_IP_REPR, &repr, PAYLOAD);
+        }
+        for port in [53, 443] {
+            let (payload, meta) = socket.recv().unwrap();
+            assert_eq!(payload, PAYLOAD);
+            assert_eq!(meta.endpoint, REMOTE_END);
+            assert_eq!(meta.local_address, Some(LOCAL_ADDR.into()));
+            assert_eq!(meta.local_port, Some(port));
+            socket.send_slice(PAYLOAD, meta).unwrap();
+        }
+        for port in [53, 443] {
+            socket
+                .dispatch(cx, |_, _, (ip, udp, payload)| {
+                    assert_eq!(ip, LOCAL_IP_REPR);
+                    assert_eq!(udp.src_port, port);
+                    assert_eq!(udp.dst_port, REMOTE_PORT);
+                    assert_eq!(payload, PAYLOAD);
+                    Ok::<_, ()>(())
+                })
+                .unwrap();
+        }
+        assert_eq!(
+            socket.send_slice(PAYLOAD, REMOTE_END),
+            Err(SendError::Unaddressable)
+        );
+        assert_eq!(
+            socket.send_with(6, REMOTE_END, |_| panic!("invalid send")),
+            Err(SendError::Unaddressable)
+        );
+        let zero = UdpMetadata {
+            local_port: Some(0),
+            ..REMOTE_END.into()
+        };
+        assert_eq!(
+            socket.send_slice(PAYLOAD, zero),
+            Err(SendError::Unaddressable)
+        );
+        socket.close();
+        assert!(!socket.is_open());
+        assert!(!socket.accepts(cx, &REMOTE_IP_REPR, &REMOTE_UDP_REPR));
+        socket.bind(LOCAL_PORT).unwrap();
+        let wrong = UdpMetadata {
+            local_port: Some(LOCAL_PORT + 1),
+            ..REMOTE_END.into()
+        };
+        assert_eq!(
+            socket.send_slice(PAYLOAD, wrong),
+            Err(SendError::Unaddressable)
+        );
+    }
 
     #[test]
     fn test_bind_unaddressable() {

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -23,9 +23,8 @@ pub struct UdpMetadata {
     /// determined using the algorithms of RFC 6724 (candidate source address selection) or some
     /// heuristic (for IPv4).
     pub local_address: Option<IpAddress>,
-    /// Destination port on receive (always set), or source port on send.
-    /// Required when bound to any port. For a fixed-port socket, this must be
-    /// absent or equal to the bound port.
+    /// Destination port on receive (always set); source port on send.
+    /// On send, defaults to the bound port and must match it if fixed.
     pub local_port: Option<u16>,
     pub meta: PacketMeta,
 }

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -323,10 +323,10 @@ impl<'a> Socket<'a> {
             _ => return Err(SendError::Unaddressable),
         };
 
-        if let Some(bound_port) = self.endpoint.port {
-            if local_port != bound_port {
-                return Err(SendError::Unaddressable);
-            }
+        if let Some(bound_port) = self.endpoint.port
+            && local_port != bound_port
+        {
+            return Err(SendError::Unaddressable);
         }
 
         if meta.endpoint.addr.is_unspecified() {
@@ -374,10 +374,10 @@ impl<'a> Socket<'a> {
             _ => return Err(SendError::Unaddressable),
         };
 
-        if let Some(bound_port) = self.endpoint.port {
-            if local_port != bound_port {
-                return Err(SendError::Unaddressable);
-            }
+        if let Some(bound_port) = self.endpoint.port
+            && local_port != bound_port
+        {
+            return Err(SendError::Unaddressable);
         }
 
         if meta.endpoint.addr.is_unspecified() {
@@ -510,10 +510,10 @@ impl<'a> Socket<'a> {
         if !self.is_open() || repr.dst_port == 0 {
             return false;
         }
-        if let Some(endpoint_port) = self.endpoint.port {
-            if endpoint_port != repr.dst_port {
-                return false;
-            }
+        if let Some(endpoint_port) = self.endpoint.port
+            && endpoint_port != repr.dst_port
+        {
+            return false;
         }
         if self.endpoint.addr.is_some()
             && self.endpoint.addr != Some(ip_repr.dst_addr())

--- a/src/wire/ieee802154.rs
+++ b/src/wire/ieee802154.rs
@@ -988,8 +988,10 @@ impl Repr {
             frame.set_dst_addr(dst_addr);
         }
 
-        if !self.pan_id_compression && self.src_pan_id.is_some() {
-            frame.set_src_pan_id(self.src_pan_id.unwrap());
+        if !self.pan_id_compression
+            && let Some(src_pan_id) = self.src_pan_id
+        {
+            frame.set_src_pan_id(src_pan_id);
         }
 
         if let Some(src_addr) = self.src_addr {

--- a/src/wire/ip.rs
+++ b/src/wire/ip.rs
@@ -425,19 +425,32 @@ impl<T: Into<Address>> From<(T, u16)> for Endpoint {
 /// An internet endpoint address for listening.
 ///
 /// In contrast with [`Endpoint`], `ListenEndpoint` allows not specifying the address,
-/// in order to listen on a given port at all our addresses.
+/// in order to listen on a given port at all our addresses, and/or not specifying the
+/// port, in order to listen on all ports at a given address.
+///
+/// A `None` address means "any address", and a `None` port means "any port".
 ///
 /// An endpoint can be constructed from a port, in which case the address is unspecified.
 #[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default)]
 pub struct ListenEndpoint {
     pub addr: Option<Address>,
-    pub port: u16,
+    pub port: Option<u16>,
 }
 
 impl ListenEndpoint {
+    /// A listen endpoint that matches any address and any port.
+    pub const ANY_PORT: Self = Self {
+        addr: None,
+        port: None,
+    };
+
     /// Query whether the endpoint has a specified address and port.
     pub const fn is_specified(&self) -> bool {
-        self.addr.is_some() && self.port != 0
+        self.addr.is_some()
+            && match self.port {
+                Some(port) => port != 0,
+                None => false,
+            }
     }
 }
 
@@ -446,7 +459,7 @@ impl From<::core::net::SocketAddr> for ListenEndpoint {
     fn from(x: ::core::net::SocketAddr) -> ListenEndpoint {
         ListenEndpoint {
             addr: Some(x.ip().into()),
-            port: x.port(),
+            port: Some(x.port()),
         }
     }
 }
@@ -456,7 +469,7 @@ impl From<::core::net::SocketAddrV4> for ListenEndpoint {
     fn from(x: ::core::net::SocketAddrV4) -> ListenEndpoint {
         ListenEndpoint {
             addr: Some((*x.ip()).into()),
-            port: x.port(),
+            port: Some(x.port()),
         }
     }
 }
@@ -466,17 +479,18 @@ impl From<::core::net::SocketAddrV6> for ListenEndpoint {
     fn from(x: ::core::net::SocketAddrV6) -> ListenEndpoint {
         ListenEndpoint {
             addr: Some((*x.ip()).into()),
-            port: x.port(),
+            port: Some(x.port()),
         }
     }
 }
 
 impl fmt::Display for ListenEndpoint {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(addr) = self.addr {
-            write!(f, "{}:{}", addr, self.port)
-        } else {
-            write!(f, "*:{}", self.port)
+        match (self.addr, self.port) {
+            (Some(addr), Some(port)) => write!(f, "{}:{}", addr, port),
+            (Some(addr), None) => write!(f, "{}:*", addr),
+            (None, Some(port)) => write!(f, "*:{}", port),
+            (None, None) => write!(f, "*:*"),
         }
     }
 }
@@ -484,13 +498,16 @@ impl fmt::Display for ListenEndpoint {
 #[cfg(feature = "defmt")]
 impl defmt::Format for ListenEndpoint {
     fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{:?}:{=u16}", self.addr, self.port);
+        defmt::write!(f, "{:?}:{:?}", self.addr, self.port);
     }
 }
 
 impl From<u16> for ListenEndpoint {
     fn from(port: u16) -> ListenEndpoint {
-        ListenEndpoint { addr: None, port }
+        ListenEndpoint {
+            addr: None,
+            port: Some(port),
+        }
     }
 }
 
@@ -498,7 +515,7 @@ impl From<Endpoint> for ListenEndpoint {
     fn from(endpoint: Endpoint) -> ListenEndpoint {
         ListenEndpoint {
             addr: Some(endpoint.addr),
-            port: endpoint.port,
+            port: Some(endpoint.port),
         }
     }
 }
@@ -507,7 +524,7 @@ impl<T: Into<Address>> From<(T, u16)> for ListenEndpoint {
     fn from((addr, port): (T, u16)) -> ListenEndpoint {
         ListenEndpoint {
             addr: Some(addr.into()),
-            port,
+            port: Some(port),
         }
     }
 }

--- a/src/wire/ip.rs
+++ b/src/wire/ip.rs
@@ -431,10 +431,20 @@ impl<T: Into<Address>> From<(T, u16)> for Endpoint {
 /// A `None` address means "any address", and a `None` port means "any port".
 ///
 /// An endpoint can be constructed from a port, in which case the address is unspecified.
-#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default)]
+#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub struct ListenEndpoint {
     pub addr: Option<Address>,
     pub port: Option<u16>,
+}
+
+impl Default for ListenEndpoint {
+    /// Return an unspecified endpoint, which cannot be bound or listened on.
+    fn default() -> Self {
+        Self {
+            addr: None,
+            port: Some(0),
+        }
+    }
 }
 
 impl ListenEndpoint {

--- a/src/wire/ip.rs
+++ b/src/wire/ip.rs
@@ -508,7 +508,12 @@ impl fmt::Display for ListenEndpoint {
 #[cfg(feature = "defmt")]
 impl defmt::Format for ListenEndpoint {
     fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{:?}:{:?}", self.addr, self.port);
+        match (self.addr, self.port) {
+            (Some(addr), Some(port)) => defmt::write!(f, "{}:{=u16}", addr, port),
+            (Some(addr), None) => defmt::write!(f, "{}:*", addr),
+            (None, Some(port)) => defmt::write!(f, "*:{=u16}", port),
+            (None, None) => defmt::write!(f, "*:*"),
+        }
     }
 }
 


### PR DESCRIPTION
I've been trying to build something like [tun2socks](https://github.com/xjasonlyu/tun2socks) (which based on gVisor's network stack) in Rust using smoltcp to route TUN traffic through a SOCKS proxy. 

However, I've run into a limitation: smoltcp does not yet support listening on any ports. In the context of a TUN device, we really need to be able to catch traffic on any port to forward it to the proxy.

I found @chayleaf's [PR #814](https://github.com/smoltcp-rs/smoltcp/pull/814) which was tackling this, but it hasn't been merged yet. I decide to build on top of the code from PR #814 and incorporated the comment from @raftario.

I think this functionality would be super useful for anyone building VPN-like tools. I've passed the tests in my tun2socks impl with this branch here: https://github.com/flaneur2020/smoltcp-socks/blob/master/src/netstack/actor.rs#L288

Any feedback would be appreciated!